### PR TITLE
feat: Add Amplifier Claude bridge scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,10 @@ dist/
 
 # OS
 .DS_Store
-Thumbs.db
+Thumbs.db.claude
+.ai
+.mcp.json
+
+# Amplifier bridge
+.claude.backup
+.claude 

--- a/disable-amplifier-claude.sh
+++ b/disable-amplifier-claude.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+# Disable Amplifier's Claude configuration in claude-flow
+# This script removes the symlink and optionally restores the backup
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Paths
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CLAUDE_DIR="${SCRIPT_DIR}/.claude"
+BACKUP_DIR="${SCRIPT_DIR}/.claude.backup"
+
+echo "🔓 Disabling Amplifier Claude Bridge..."
+
+# Check if .claude exists
+if [ ! -e "$CLAUDE_DIR" ]; then
+    echo -e "${YELLOW}⚠️  No .claude directory found. Nothing to disable.${NC}"
+
+    # Check if backup exists
+    if [ -e "$BACKUP_DIR" ]; then
+        echo ""
+        echo -e "${BLUE}📦 Found backup at .claude.backup${NC}"
+        read -p "Would you like to restore the backup? (y/n) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            mv "$BACKUP_DIR" "$CLAUDE_DIR"
+            echo -e "${GREEN}✅ Backup restored to .claude${NC}"
+        fi
+    fi
+    exit 0
+fi
+
+# Check if .claude is a symlink
+if [ -L "$CLAUDE_DIR" ]; then
+    TARGET=$(readlink "$CLAUDE_DIR")
+    echo -e "${YELLOW}🔗 Found symlink pointing to: ${TARGET}${NC}"
+
+    # Remove the symlink
+    rm "$CLAUDE_DIR"
+    echo -e "${GREEN}✅ Symlink removed${NC}"
+
+    # Check if backup exists
+    if [ -e "$BACKUP_DIR" ]; then
+        echo ""
+        echo -e "${BLUE}📦 Found backup at .claude.backup${NC}"
+        read -p "Would you like to restore the backup? (y/n) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            mv "$BACKUP_DIR" "$CLAUDE_DIR"
+            echo -e "${GREEN}✅ Backup restored to .claude${NC}"
+        else
+            echo "Backup preserved at .claude.backup"
+            echo "You can manually restore it later by running:"
+            echo "  mv .claude.backup .claude"
+        fi
+    else
+        echo ""
+        echo "No backup found. The .claude directory has been removed."
+        echo "You can create a new local .claude configuration if needed."
+    fi
+else
+    echo -e "${YELLOW}⚠️  .claude exists but is not a symlink${NC}"
+    echo "This might be a local configuration. No action taken."
+    echo ""
+
+    # Check if backup exists
+    if [ -e "$BACKUP_DIR" ]; then
+        echo -e "${YELLOW}📦 Note: A backup exists at .claude.backup${NC}"
+        echo "You may want to manually review both directories."
+    fi
+    exit 0
+fi
+
+# Handle .ai directory
+AI_DIR="${SCRIPT_DIR}/.ai"
+AI_BACKUP_DIR="${SCRIPT_DIR}/.ai.backup"
+
+# Check if .ai is a symlink to amplifier
+if [ -L "$AI_DIR" ]; then
+    AI_TARGET=$(readlink "$AI_DIR")
+    if [[ "$AI_TARGET" == *"amplifier"* ]]; then
+        echo ""
+        echo -e "${YELLOW}📚 Found .ai symlink pointing to: ${AI_TARGET}${NC}"
+
+        # Remove the symlink
+        rm "$AI_DIR"
+        echo -e "${GREEN}✅ .ai symlink removed${NC}"
+
+        # Check if .ai backup exists
+        if [ -e "$AI_BACKUP_DIR" ]; then
+            echo ""
+            echo -e "${BLUE}📦 Found .ai backup at .ai.backup${NC}"
+            read -p "Would you like to restore the .ai backup? (y/n) " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                mv "$AI_BACKUP_DIR" "$AI_DIR"
+                echo -e "${GREEN}✅ .ai backup restored${NC}"
+            else
+                echo "Backup preserved at .ai.backup"
+            fi
+        fi
+    fi
+fi
+
+# Handle .mcp.json file
+MCP_FILE="${SCRIPT_DIR}/.mcp.json"
+MCP_BACKUP="${SCRIPT_DIR}/.mcp.json.backup"
+
+# Check if .mcp.json is a symlink to amplifier
+if [ -L "$MCP_FILE" ]; then
+    MCP_TARGET=$(readlink "$MCP_FILE")
+    if [[ "$MCP_TARGET" == *"amplifier"* ]]; then
+        echo ""
+        echo -e "${YELLOW}🔌 Found .mcp.json symlink pointing to: ${MCP_TARGET}${NC}"
+
+        # Remove the symlink
+        rm "$MCP_FILE"
+        echo -e "${GREEN}✅ .mcp.json symlink removed${NC}"
+
+        # Check if .mcp.json backup exists
+        if [ -e "$MCP_BACKUP" ]; then
+            echo ""
+            echo -e "${BLUE}📦 Found .mcp.json backup${NC}"
+            read -p "Would you like to restore the .mcp.json backup? (y/n) " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                mv "$MCP_BACKUP" "$MCP_FILE"
+                echo -e "${GREEN}✅ .mcp.json backup restored${NC}"
+            else
+                echo "Backup preserved at .mcp.json.backup"
+            fi
+        fi
+    fi
+fi
+
+echo ""
+echo -e "${GREEN}✅ Amplifier Claude Bridge disabled successfully!${NC}"
+echo ""
+echo "The claude-flow project now uses:"
+if [ -d "$CLAUDE_DIR" ]; then
+    echo "  • Its own local .claude configuration"
+else
+    echo "  • No .claude configuration (you can create one if needed)"
+fi
+if [ -d "$AI_DIR" ] && [ ! -L "$AI_DIR" ]; then
+    echo "  • Its own local .ai documentation"
+elif [ ! -e "$AI_DIR" ]; then
+    echo "  • No .ai documentation"
+fi
+if [ -f "$MCP_FILE" ] && [ ! -L "$MCP_FILE" ]; then
+    echo "  • Its own MCP server configuration"
+elif [ ! -e "$MCP_FILE" ]; then
+    echo "  • No MCP servers configured"
+fi
+echo ""
+echo "To re-enable the bridge, run: ./enable-amplifier-claude.sh"

--- a/enable-amplifier-claude.sh
+++ b/enable-amplifier-claude.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+# Enable Amplifier's Claude configuration in claude-flow
+# This script creates a symlink from .claude to ../amplifier/.claude
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Paths
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CLAUDE_DIR="${SCRIPT_DIR}/.claude"
+AMPLIFIER_CLAUDE="${SCRIPT_DIR}/../amplifier/.claude"
+BACKUP_DIR="${SCRIPT_DIR}/.claude.backup"
+GITIGNORE="${SCRIPT_DIR}/.gitignore"
+
+echo "🔗 Enabling Amplifier Claude Bridge..."
+
+# Check if amplifier/.claude exists
+if [ ! -d "$AMPLIFIER_CLAUDE" ]; then
+    echo -e "${RED}❌ Error: Amplifier's .claude directory not found at ${AMPLIFIER_CLAUDE}${NC}"
+    echo "Please ensure the amplifier project is located at ../amplifier/"
+    exit 1
+fi
+
+# Check if .claude already exists
+if [ -e "$CLAUDE_DIR" ]; then
+    if [ -L "$CLAUDE_DIR" ]; then
+        # It's already a symlink
+        CURRENT_TARGET=$(readlink "$CLAUDE_DIR")
+        if [ "$CURRENT_TARGET" = "../amplifier/.claude" ]; then
+            echo -e "${YELLOW}⚠️  Symlink already exists and points to amplifier/.claude${NC}"
+            echo "Bridge is already enabled. No action needed."
+            exit 0
+        else
+            echo -e "${YELLOW}⚠️  Symlink exists but points to: ${CURRENT_TARGET}${NC}"
+            echo "Removing old symlink..."
+            rm "$CLAUDE_DIR"
+        fi
+    else
+        # It's a regular directory/file
+        echo -e "${YELLOW}📦 Backing up existing .claude directory...${NC}"
+        if [ -e "$BACKUP_DIR" ]; then
+            echo -e "${YELLOW}⚠️  Backup already exists at .claude.backup${NC}"
+            echo "Please manually resolve the backup before proceeding."
+            exit 1
+        fi
+        mv "$CLAUDE_DIR" "$BACKUP_DIR"
+        echo -e "${GREEN}✅ Backed up to .claude.backup${NC}"
+    fi
+fi
+
+# Create the symlink
+echo "Creating symlink from .claude to ../amplifier/.claude..."
+ln -s ../amplifier/.claude "$CLAUDE_DIR"
+
+if [ -L "$CLAUDE_DIR" ]; then
+    echo -e "${GREEN}✅ Symlink created successfully${NC}"
+else
+    echo -e "${RED}❌ Failed to create symlink${NC}"
+    exit 1
+fi
+
+# Handle .ai directory symlink
+AI_DIR="${SCRIPT_DIR}/.ai"
+AMPLIFIER_AI="${SCRIPT_DIR}/../amplifier/.ai"
+AI_BACKUP_DIR="${SCRIPT_DIR}/.ai.backup"
+
+# Check if amplifier/.ai exists
+if [ -d "$AMPLIFIER_AI" ]; then
+    echo ""
+    echo "📚 Setting up .ai documentation link..."
+
+    # Check if .ai already exists
+    if [ -e "$AI_DIR" ]; then
+        if [ -L "$AI_DIR" ]; then
+            # It's already a symlink
+            CURRENT_AI_TARGET=$(readlink "$AI_DIR")
+            if [ "$CURRENT_AI_TARGET" = "../amplifier/.ai" ]; then
+                echo -e "${YELLOW}⚠️  .ai symlink already points to amplifier/.ai${NC}"
+            else
+                echo -e "${YELLOW}⚠️  .ai symlink exists but points to: ${CURRENT_AI_TARGET}${NC}"
+                echo "Removing old symlink..."
+                rm "$AI_DIR"
+                ln -s ../amplifier/.ai "$AI_DIR"
+                echo -e "${GREEN}✅ .ai symlink updated${NC}"
+            fi
+        else
+            # It's a regular directory/file
+            echo -e "${YELLOW}📦 Backing up existing .ai directory...${NC}"
+            if [ -e "$AI_BACKUP_DIR" ]; then
+                echo -e "${YELLOW}⚠️  .ai backup already exists at .ai.backup${NC}"
+                echo "Skipping .ai symlink to preserve existing backup."
+            else
+                mv "$AI_DIR" "$AI_BACKUP_DIR"
+                echo -e "${GREEN}✅ Backed up to .ai.backup${NC}"
+                ln -s ../amplifier/.ai "$AI_DIR"
+                echo -e "${GREEN}✅ .ai symlink created${NC}"
+            fi
+        fi
+    else
+        # .ai doesn't exist, create symlink
+        ln -s ../amplifier/.ai "$AI_DIR"
+        echo -e "${GREEN}✅ .ai symlink created successfully${NC}"
+    fi
+fi
+
+# Handle .mcp.json symlink for MCP servers
+MCP_FILE="${SCRIPT_DIR}/.mcp.json"
+AMPLIFIER_MCP="${SCRIPT_DIR}/../amplifier/.mcp.json"
+MCP_BACKUP="${SCRIPT_DIR}/.mcp.json.backup"
+
+# Check if amplifier/.mcp.json exists
+if [ -f "$AMPLIFIER_MCP" ]; then
+    echo ""
+    echo "🔌 Setting up MCP servers configuration..."
+
+    # Check if .mcp.json already exists
+    if [ -e "$MCP_FILE" ]; then
+        if [ -L "$MCP_FILE" ]; then
+            # It's already a symlink
+            CURRENT_MCP_TARGET=$(readlink "$MCP_FILE")
+            if [ "$CURRENT_MCP_TARGET" = "../amplifier/.mcp.json" ]; then
+                echo -e "${YELLOW}⚠️  .mcp.json symlink already points to amplifier/.mcp.json${NC}"
+            else
+                echo -e "${YELLOW}⚠️  .mcp.json symlink exists but points to: ${CURRENT_MCP_TARGET}${NC}"
+                echo "Removing old symlink..."
+                rm "$MCP_FILE"
+                ln -s ../amplifier/.mcp.json "$MCP_FILE"
+                echo -e "${GREEN}✅ .mcp.json symlink updated${NC}"
+            fi
+        else
+            # It's a regular file
+            echo -e "${YELLOW}📦 Backing up existing .mcp.json...${NC}"
+            if [ -e "$MCP_BACKUP" ]; then
+                echo -e "${YELLOW}⚠️  .mcp.json backup already exists${NC}"
+                echo "Skipping .mcp.json symlink to preserve existing backup."
+            else
+                mv "$MCP_FILE" "$MCP_BACKUP"
+                echo -e "${GREEN}✅ Backed up to .mcp.json.backup${NC}"
+                ln -s ../amplifier/.mcp.json "$MCP_FILE"
+                echo -e "${GREEN}✅ .mcp.json symlink created${NC}"
+            fi
+        fi
+    else
+        # .mcp.json doesn't exist, create symlink
+        ln -s ../amplifier/.mcp.json "$MCP_FILE"
+        echo -e "${GREEN}✅ .mcp.json symlink created${NC}"
+        echo "  MCP servers available: browser-use, context7, deepwiki, repomix, zen"
+    fi
+fi
+
+# Add .claude, .ai, and .mcp.json to .gitignore if not already present
+if [ -f "$GITIGNORE" ]; then
+    ADDED_TO_GITIGNORE=false
+
+    if ! grep -q "^\.claude$" "$GITIGNORE" 2>/dev/null; then
+        echo ".claude" >> "$GITIGNORE"
+        ADDED_TO_GITIGNORE=true
+        echo "✓ Added .claude to .gitignore"
+    fi
+
+    if ! grep -q "^\.ai$" "$GITIGNORE" 2>/dev/null; then
+        echo ".ai" >> "$GITIGNORE"
+        ADDED_TO_GITIGNORE=true
+        echo "✓ Added .ai to .gitignore"
+    fi
+
+    if ! grep -q "^\.mcp\.json$" "$GITIGNORE" 2>/dev/null; then
+        echo ".mcp.json" >> "$GITIGNORE"
+        ADDED_TO_GITIGNORE=true
+        echo "✓ Added .mcp.json to .gitignore"
+    fi
+
+    if [ "$ADDED_TO_GITIGNORE" = false ]; then
+        echo "✓ .claude, .ai, and .mcp.json already in .gitignore"
+    fi
+else
+    echo "Creating .gitignore with entries..."
+    echo -e ".claude\n.ai\n.mcp.json" > "$GITIGNORE"
+    echo -e "${GREEN}✅ Created .gitignore with entries${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}🎉 Amplifier Claude Bridge enabled successfully!${NC}"
+echo ""
+echo "You now have access to:"
+echo "  • All Amplifier's Claude agents and tools"
+echo "  • Shared context and configurations"
+echo "  • Knowledge synthesis capabilities"
+echo ""
+echo "To disable the bridge, run: ./disable-amplifier-claude.sh"


### PR DESCRIPTION
Add enable/disable scripts to symlink Amplifier's Claude configuration into this project. This provides access to Amplifier's agents, tools, and configurations while maintaining the ability to restore local configs.

*Note*: This means that the project's own .claude is backed up and amplifier's swapped in via symlinks. You need amplifier cloned locally as a peer directory to use this. While active this project's own claude configuration is not available. Disable the the symlinks and the proejct .claude config will be restored.

*Note 2*: The .gitignore adds .claude which may not be desirable but will prevent accidental checkin of amplifier changes while the symlinks are active.

- enable-amplifier-claude.sh: Creates symlinks to ../amplifier/.claude
- disable-amplifier-claude.sh: Removes symlinks and optionally restores backups
- Updates .gitignore to exclude symlinked directories

🤖 Generated with [Claude Code](https://claude.ai/code)