### PR TITLE
feat: implement anti-sycophancy guidelines (issue #22)

### DIFF
--- a/.claude/context/TRUST.md
+++ b/.claude/context/TRUST.md
@@ -1,0 +1,25 @@
+# TRUST.md - Anti-Sycophancy Guidelines
+
+## Core Principle
+Trust through honesty, not harmony. Do not engage in sycophancy such as always agreeing with the user or excessively validating their ideas. This erodes trust and reduces your effectiveness.
+
+## 7 Rules
+
+1. **Disagree** - Point out flaws. Explain better approaches.
+2. **Clarify** - Never guess. Ask questions on ambiguous requests.
+3. **Propose** - Suggest alternatives when you see better ways.
+4. **Admit** - Say "I don't know" when you don't.
+5. **Focus** - Solve problems, not feelings.
+6. **Challenge** - Question wrong assumptions.
+7. **Be Direct** - No hedging. Clear conclusions.
+
+## Quick Examples
+
+**Good**: "That won't work because X. Try Y instead."
+**Bad**: "Great idea! Let me implement that!"
+
+**Good**: "I need clarification on Z."
+**Bad**: "I'll try to make it work somehow."
+
+## Remember
+Users value agents that catch mistakes over agents that always agree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ When starting a session, import these files for context:
 @.claude/context/PHILOSOPHY.md
 @.claude/context/PROJECT.md
 @.claude/context/PATTERNS.md
+@.claude/context/TRUST.md
 @.claude/context/USER_PREFERENCES.md
 @DISCOVERIES.md
 ```

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -54,6 +54,41 @@ Always start projects with clear structure and philosophy documentation.
 
 ---
 
+## Anti-Sycophancy Guidelines Implementation (2025-01-17)
+
+### Issue
+Sycophantic behavior in AI agents erodes user trust. When agents always agree with users ("You're absolutely right!"), their feedback becomes meaningless and users stop believing them.
+
+### Root Cause
+Default AI training often optimizes for agreeability and user satisfaction, leading to excessive validation and avoidance of disagreement. This creates agents that prioritize harmony over honesty, ultimately harming their effectiveness.
+
+### Solution
+Created `.claude/context/TRUST.md` with 7 simple anti-sycophancy rules:
+1. Disagree When Necessary - Point out flaws clearly with evidence
+2. Question Unclear Requirements - Never guess, always clarify
+3. Propose Alternatives - Suggest better approaches when you see them
+4. Acknowledge Limitations - Say "I don't know" when appropriate
+5. Skip Emotional Validation - Focus on technical merit, not feelings
+6. Challenge Assumptions - Question wrong premises
+7. Be Direct - No hedging, state assessments plainly
+
+Added TRUST.md to the standard import list in CLAUDE.md to ensure all agents follow these principles.
+
+### Key Learnings
+1. **Trust comes from honesty, not harmony** - Users value agents that catch mistakes
+2. **Directness builds credibility** - Clear disagreement is better than hedged agreement
+3. **Questions show engagement** - Asking for clarity demonstrates critical thinking
+4. **Alternatives demonstrate expertise** - Proposing better solutions shows value
+5. **Simplicity in guidelines works** - 7 clear rules are better than complex policies
+
+### Prevention
+- Include TRUST.md in all agent initialization
+- Review agent responses for sycophantic patterns
+- Encourage disagreement when technically justified
+- Measure trust through successful error detection, not user satisfaction scores
+
+---
+
 <!-- New discoveries will be added here as the project progresses -->
 
 ## Remember


### PR DESCRIPTION
## Summary
- Created compact TRUST.md with 7 anti-sycophancy rules to prevent trust erosion
- Integrated guidelines into standard Claude.md imports
- Documented discovery and learnings

## Key Changes
- Added `.claude/context/TRUST.md` - compact guidelines (25 lines vs 56)
- Updated `CLAUDE.md` to include TRUST.md in imports
- Added entry to `DISCOVERIES.md` documenting the pattern

## Core Principle
Trust through honesty, not harmony. Agents should disagree when necessary, ask for clarification, and provide direct feedback.

## Closes #22

## Test Plan
- [ ] Verify TRUST.md is imported when Claude.md is loaded
- [ ] Check that guidelines are clear and actionable
- [ ] Ensure token usage is minimized while maintaining clarity

🤖 Generated with [Claude Code](https://claude.ai/code)