### PR TITLE
docs: Add minimal decision recording guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ When starting a session, import these files for context:
   for the session based on the timestamp.
 - **Decision records**: All Agents MUST log their decisions and reasoning in
   .claude/runtime/logs/<session_id>/DECISIONS.md
+- **When to record decisions**: Document significant architectural choices,
+  trade-offs between approaches, or decisions that affect system design
+- **Simple format**: What was decided | Why | Alternatives considered
 
 ### Agent Delegation Strategy
 


### PR DESCRIPTION
## Summary

Adds minimal, practical guidance for decision recording without any tools or infrastructure.

## Changes

- **2 lines added to CLAUDE.md**:
  - When to record: Significant architectural choices, trade-offs, system design decisions
  - Simple format: What was decided | Why | Alternatives considered
  
## Philosophy Compliance

✅ **Ruthless Simplicity**: Just 2 lines of documentation, no tools
✅ **Zero-BS**: Pure documentation, no placeholders or hypothetical features  
✅ **Trust Developers**: Manual recording when decisions matter
✅ **YAGNI**: No infrastructure for hypothetical future needs

## Context

This replaces the over-engineered PR #9 which added 261 lines of code (Makefile, setup_dev.py, decision_logger.py, hooks) to solve what is fundamentally a 2-line documentation problem.

The approach: If developers won't write decisions manually, no amount of automation will make them care.

## Test Plan

- [x] Documentation is clear and actionable
- [x] No code changes that could break anything
- [x] Pre-commit hooks pass
- [x] Follows established documentation patterns

Fixes #79

🤖 Generated with [Claude Code](https://claude.ai/code)