### PR TITLE
fix: make claude-trace the default when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,21 @@ That's it! The command automatically:
 
 - Downloads the latest framework
 - Sets up the environment
+- **Detects and uses claude-trace for enhanced debugging** (if available)
+- **Attempts to install claude-trace if not found** (requires npm)
 - Launches Claude Code with all agents configured
 - No local installation required
+
+#### Claude-Trace Enhanced Debugging
+
+The framework automatically uses
+[claude-trace](https://github.com/mariozechner/claude-trace) for better
+debugging:
+
+- **Default behavior**: Claude-trace is used automatically when available
+- **Auto-installation**: Attempts to install via npm if not found
+- **Opt-out**: Set `AMPLIHACK_USE_TRACE=0` to use standard claude
+- **Fallback**: Uses regular claude if claude-trace can't be installed
 
 ### Advanced Usage
 

--- a/src/amplihack/utils/claude_trace.py
+++ b/src/amplihack/utils/claude_trace.py
@@ -6,8 +6,17 @@ import subprocess
 
 
 def should_use_trace() -> bool:
-    """Check if claude-trace should be used instead of claude."""
-    return os.getenv("AMPLIHACK_USE_TRACE", "").lower() in ("1", "true", "yes")
+    """Check if claude-trace should be used instead of claude.
+
+    Default behavior: Always prefer claude-trace unless explicitly disabled.
+    """
+    # Check if explicitly disabled
+    use_trace_env = os.getenv("AMPLIHACK_USE_TRACE", "").lower()
+    if use_trace_env in ("0", "false", "no"):
+        return False
+
+    # Default to using claude-trace
+    return True
 
 
 def get_claude_command() -> str:
@@ -17,20 +26,25 @@ def get_claude_command() -> str:
         Command name to use ('claude' or 'claude-trace')
 
     Side Effects:
-        May attempt to install claude-trace via npm if requested but not found
+        May attempt to install claude-trace via npm if not found
     """
     if not should_use_trace():
+        print("Claude-trace explicitly disabled via AMPLIHACK_USE_TRACE=0")
         return "claude"
 
     # Check if claude-trace is available
     if shutil.which("claude-trace"):
+        print("Using claude-trace for enhanced debugging")
         return "claude-trace"
 
     # Try to install claude-trace
+    print("Claude-trace not found, attempting to install...")
     if _install_claude_trace():
+        print("Claude-trace installed successfully")
         return "claude-trace"
 
     # Fall back to claude
+    print("Could not install claude-trace, falling back to standard claude")
     return "claude"
 
 

--- a/tests/test_claude_trace_default.py
+++ b/tests/test_claude_trace_default.py
@@ -1,0 +1,191 @@
+"""Test claude-trace default behavior."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from amplihack.utils.claude_trace import _install_claude_trace, get_claude_command, should_use_trace
+
+
+def test_should_use_trace_default():
+    """Test that claude-trace is preferred by default."""
+    with patch.dict(os.environ, {}, clear=True):
+        assert should_use_trace() is True, "Should default to using claude-trace"
+
+
+def test_should_use_trace_explicit_disable():
+    """Test that claude-trace can be explicitly disabled."""
+    test_cases = ["0", "false", "no", "False", "NO", "FALSE"]
+
+    for value in test_cases:
+        with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": value}):
+            assert should_use_trace() is False, (
+                f"Should be disabled with AMPLIHACK_USE_TRACE={value}"
+            )
+
+
+def test_should_use_trace_explicit_enable():
+    """Test that explicit enable still works (backward compatibility)."""
+    test_cases = ["1", "true", "yes", "True", "YES", "TRUE"]
+
+    for value in test_cases:
+        with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": value}):
+            assert should_use_trace() is True, f"Should be enabled with AMPLIHACK_USE_TRACE={value}"
+
+
+def test_get_claude_command_when_disabled():
+    """Test that regular claude is used when explicitly disabled."""
+    with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": "0"}):
+        with patch("builtins.print") as mock_print:
+            cmd = get_claude_command()
+            assert cmd == "claude"
+            mock_print.assert_called_with(
+                "Claude-trace explicitly disabled via AMPLIHACK_USE_TRACE=0"
+            )
+
+
+def test_get_claude_command_when_trace_available():
+    """Test that claude-trace is used when available."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("shutil.which") as mock_which:
+            with patch("builtins.print") as mock_print:
+                mock_which.return_value = "/usr/local/bin/claude-trace"
+
+                cmd = get_claude_command()
+                assert cmd == "claude-trace"
+                mock_print.assert_called_with("Using claude-trace for enhanced debugging")
+
+
+def test_get_claude_command_install_success():
+    """Test that claude-trace is installed and used when not found."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("shutil.which") as mock_which:
+            with patch("amplihack.utils.claude_trace._install_claude_trace") as mock_install:
+                with patch("builtins.print") as mock_print:
+                    # First check returns None (not found), second would return path after install
+                    mock_which.return_value = None
+                    mock_install.return_value = True
+
+                    cmd = get_claude_command()
+                    assert cmd == "claude-trace"
+
+                    # Verify installation was attempted
+                    mock_install.assert_called_once()
+
+                    # Check print messages
+                    assert mock_print.call_count == 2
+                    mock_print.assert_any_call("Claude-trace not found, attempting to install...")
+                    mock_print.assert_any_call("Claude-trace installed successfully")
+
+
+def test_get_claude_command_install_failure():
+    """Test fallback to claude when installation fails."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("shutil.which") as mock_which:
+            with patch("amplihack.utils.claude_trace._install_claude_trace") as mock_install:
+                with patch("builtins.print") as mock_print:
+                    mock_which.return_value = None
+                    mock_install.return_value = False
+
+                    cmd = get_claude_command()
+                    assert cmd == "claude"
+
+                    # Check print messages
+                    assert mock_print.call_count == 2
+                    mock_print.assert_any_call("Claude-trace not found, attempting to install...")
+                    mock_print.assert_any_call(
+                        "Could not install claude-trace, falling back to standard claude"
+                    )
+
+
+def test_install_claude_trace_no_npm():
+    """Test that installation fails gracefully when npm is not available."""
+    with patch("shutil.which") as mock_which:
+        mock_which.return_value = None  # npm not found
+
+        result = _install_claude_trace()
+        assert result is False
+
+
+def test_install_claude_trace_success():
+    """Test successful installation of claude-trace."""
+    with patch("shutil.which") as mock_which:
+        with patch("subprocess.run") as mock_run:
+            mock_which.return_value = "/usr/local/bin/npm"
+            mock_run.return_value = MagicMock(returncode=0)
+
+            result = _install_claude_trace()
+            assert result is True
+
+            # Verify correct npm command was called
+            mock_run.assert_called_once_with(
+                ["npm", "install", "-g", "@mariozechner/claude-trace"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+
+def test_install_claude_trace_failure():
+    """Test handling of installation failure."""
+    with patch("shutil.which") as mock_which:
+        with patch("subprocess.run") as mock_run:
+            mock_which.return_value = "/usr/local/bin/npm"
+            mock_run.return_value = MagicMock(returncode=1)
+
+            result = _install_claude_trace()
+            assert result is False
+
+
+def test_install_claude_trace_timeout():
+    """Test handling of installation timeout."""
+    with patch("shutil.which") as mock_which:
+        with patch("subprocess.run") as mock_run:
+            mock_which.return_value = "/usr/local/bin/npm"
+            mock_run.side_effect = subprocess.TimeoutExpired("npm", 60)
+
+            result = _install_claude_trace()
+            assert result is False
+
+
+if __name__ == "__main__":
+    # Run all tests
+    test_functions = [
+        test_should_use_trace_default,
+        test_should_use_trace_explicit_disable,
+        test_should_use_trace_explicit_enable,
+        test_get_claude_command_when_disabled,
+        test_get_claude_command_when_trace_available,
+        test_get_claude_command_install_success,
+        test_get_claude_command_install_failure,
+        test_install_claude_trace_no_npm,
+        test_install_claude_trace_success,
+        test_install_claude_trace_failure,
+        test_install_claude_trace_timeout,
+    ]
+
+    print("Running claude-trace default behavior tests...")
+    passed = 0
+    failed = 0
+
+    for test_func in test_functions:
+        try:
+            test_func()
+            print(f"✓ {test_func.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"✗ {test_func.__name__}: {e}")
+            failed += 1
+
+    print(f"\n{'=' * 50}")
+    print(f"Tests: {passed} passed, {failed} failed")
+    if failed == 0:
+        print("✅ All tests passed!")
+    else:
+        print("❌ Some tests failed")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

This PR fixes the issue where claude-trace was not being used by default when launching via uvx. Now claude-trace provides enhanced debugging automatically when available.

Closes #131

## Problem

When running the uvx command from the README:
```bash
uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding amplihack launch
```

Claude-trace was NOT being used even though PR #126 had added support. Users had to explicitly set `AMPLIHACK_USE_TRACE=1` which most didn't know about.

## Solution

Changed the default behavior to:
1. **Always prefer claude-trace** when available (no environment variable needed)
2. **Attempt auto-installation** via npm if claude-trace not found
3. **Clear opt-out** with `AMPLIHACK_USE_TRACE=0` for users who prefer standard claude
4. **Informative messages** so users know what's happening
5. **Graceful fallback** to standard claude if installation fails

## Key Changes

### `src/amplihack/utils/claude_trace.py`
- Modified `should_use_trace()` to return `True` by default
- Check for explicit opt-out via `AMPLIHACK_USE_TRACE=0`
- Added print statements for user feedback
- Auto-installation attempt when claude-trace not found

### `README.md`
- Added claude-trace documentation in Quick Start section
- Explained automatic detection and installation
- Documented opt-out mechanism
- Link to claude-trace project

### `tests/test_claude_trace_default.py`
- Comprehensive test suite for all scenarios
- Tests default behavior, opt-out, auto-installation
- Mock-based testing for external dependencies
- All tests passing

## Testing

```bash
# Run test suite
cd ../MicrosoftHackathon2025-AgenticCoding-trace-fix
python tests/test_claude_trace_default.py

# Output:
✅ All tests passed!
Tests: 11 passed, 0 failed

# Verify real detection
python -c "from src.amplihack.utils.claude_trace import get_claude_command; cmd = get_claude_command(); print(f'Command: {cmd}')"

# Output:
Using claude-trace for enhanced debugging
Command: claude-trace
```

## User Experience

**Before (PR #126):**
```bash
# Claude-trace not used unless explicitly requested
export AMPLIHACK_USE_TRACE=1  # Most users didn't know about this
uvx --from git+... amplihack launch
```

**After (This PR):**
```bash
# Claude-trace used automatically!
uvx --from git+... amplihack launch
# Output: "Using claude-trace for enhanced debugging"

# Or opt-out if preferred
export AMPLIHACK_USE_TRACE=0
uvx --from git+... amplihack launch
# Output: "Claude-trace explicitly disabled via AMPLIHACK_USE_TRACE=0"
```

## Benefits

✅ **Better debugging by default** - Users get claude-trace benefits automatically
✅ **Zero configuration** - Works out of the box
✅ **Automatic setup** - Attempts to install if not found
✅ **User-friendly** - Clear messages about what's happening
✅ **Backward compatible** - Old `AMPLIHACK_USE_TRACE=1` still works
✅ **Opt-out available** - Users can disable if they prefer

## Related Issues

- Fixes #131: Claude-trace should be used by default when available
- Enhances PR #126: Original claude-trace integration

🤖 Generated with [Claude Code](https://claude.ai/code)