### PR TITLE
fix: Pass ANTHROPIC_BASE_URL to Claude when using proxy

### DIFF
--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -318,6 +318,21 @@ class ClaudeLauncher:
             if "CLAUDE_PROJECT_DIR" in os.environ:
                 env["CLAUDE_PROJECT_DIR"] = os.environ["CLAUDE_PROJECT_DIR"]
 
+            # Include proxy environment variables if proxy is configured
+            if self.proxy_manager and self.proxy_manager.is_running():
+                proxy_env = self.proxy_manager.env_manager.get_proxy_env(
+                    proxy_port=self.proxy_manager.proxy_port,
+                    config=self.proxy_manager.proxy_config.to_env_dict()
+                    if self.proxy_manager.proxy_config
+                    else None,
+                )
+                # Update env with proxy settings, especially ANTHROPIC_BASE_URL
+                if proxy_env.get("ANTHROPIC_BASE_URL"):
+                    env["ANTHROPIC_BASE_URL"] = proxy_env["ANTHROPIC_BASE_URL"]
+                    print(f"✓ Configured Claude to use proxy at {proxy_env['ANTHROPIC_BASE_URL']}")
+                if proxy_env.get("ANTHROPIC_API_KEY"):
+                    env["ANTHROPIC_API_KEY"] = proxy_env["ANTHROPIC_API_KEY"]
+
             # Launch Claude
             self.claude_process = subprocess.Popen(cmd, env=env)
 
@@ -375,6 +390,21 @@ class ClaudeLauncher:
             # Pass through CLAUDE_PROJECT_DIR if set (for UVX temp environments)
             if "CLAUDE_PROJECT_DIR" in os.environ:
                 env["CLAUDE_PROJECT_DIR"] = os.environ["CLAUDE_PROJECT_DIR"]
+
+            # Include proxy environment variables if proxy is configured
+            if self.proxy_manager and self.proxy_manager.is_running():
+                proxy_env = self.proxy_manager.env_manager.get_proxy_env(
+                    proxy_port=self.proxy_manager.proxy_port,
+                    config=self.proxy_manager.proxy_config.to_env_dict()
+                    if self.proxy_manager.proxy_config
+                    else None,
+                )
+                # Update env with proxy settings, especially ANTHROPIC_BASE_URL
+                if proxy_env.get("ANTHROPIC_BASE_URL"):
+                    env["ANTHROPIC_BASE_URL"] = proxy_env["ANTHROPIC_BASE_URL"]
+                    print(f"✓ Configured Claude to use proxy at {proxy_env['ANTHROPIC_BASE_URL']}")
+                if proxy_env.get("ANTHROPIC_API_KEY"):
+                    env["ANTHROPIC_API_KEY"] = proxy_env["ANTHROPIC_API_KEY"]
 
             # Launch Claude with direct I/O (interactive mode)
             print("Starting Claude...")


### PR DESCRIPTION
## Summary

Fixes the issue where Claude Code shows "Unable to connect to API" when launched with `--with-proxy-config`, even though the proxy is running correctly.

## Problem

When running:
```bash
uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding \
    amplihack launch --with-proxy-config .azure.env
```

The proxy starts correctly on port 9001, but Claude tries to connect directly to Anthropic's API instead of using the proxy, resulting in connection errors.

## Root Cause

The `ANTHROPIC_BASE_URL` environment variable was not being passed to Claude's subprocess, so Claude didn't know to use the proxy.

## Solution

Added code to `src/amplihack/launcher/core.py` that:
1. Checks if proxy is configured and running
2. Gets proxy environment variables from `ProxyEnvironment`
3. Passes `ANTHROPIC_BASE_URL=http://localhost:<port>` to Claude's subprocess
4. Shows confirmation: "✓ Configured Claude to use proxy at http://localhost:9001"

## Testing

Verified that:
- Claude now receives the `ANTHROPIC_BASE_URL` environment variable
- Claude connects through the proxy instead of directly to Anthropic
- Works with both `launch()` and `launch_interactive()` methods

## Result

Claude Code now correctly connects through the proxy to Azure OpenAI or other configured endpoints when using the `--with-proxy-config` option.

Closes: User's reported issue with proxy connectivity

🤖 Generated with [Claude Code](https://claude.ai/code)