### PR TITLE
feat: Fix proxy port binding to respect PORT environment variable

### DIFF
--- a/src/amplihack/proxy/server.py
+++ b/src/amplihack/proxy/server.py
@@ -1954,4 +1954,19 @@ def run_server(host: str = "127.0.0.1", port: int = 8082):
 
 
 if __name__ == "__main__":
-    run_server()
+    import os
+
+    # Read PORT from environment with error handling
+    port = 8082  # Default port
+    port_env = os.environ.get("PORT")
+    if port_env:
+        try:
+            port = int(port_env)
+            if not (1 <= port <= 65535):
+                print(f"Warning: PORT={port_env} is invalid (must be 1-65535), using default 8082")
+                port = 8082
+        except ValueError:
+            print(f"Warning: PORT={port_env} is not a valid number, using default 8082")
+            port = 8082
+
+    run_server(port=port)


### PR DESCRIPTION
## Summary

Successfully fixes the proxy connection error that occurred after merging PR #885. The proxy now properly respects the `PORT` environment variable when started as a module.

## Problem Solved

**Before:**
```
Proxy started successfully on port 9001  # ← Claimed to start on 9001
✓ Configured Claude to use proxy at http://localhost:9001  # ← Claude configured for 9001
API Error: Connection error.  # ← But connection failed
```

**After:**
```
Proxy started successfully on port 9001  # ← Actually starts on 9001
✓ Configured Claude to use proxy at http://localhost:9001  # ← Claude connects successfully
API Error: 404 Resource not found  # ← Now reaching Azure (different issue)
```

## Root Cause & Fix

**Root Cause**: The `run_server()` function ignored the `PORT` environment variable when started as a module via `python -m amplihack.proxy.server`.

**Fix Applied**:
```python
# Before (buggy)
if __name__ == "__main__":
    run_server()  # Always used default port 8082

# After (fixed)  
if __name__ == "__main__":
    import os
    
    port = 8082  # Default port
    port_env = os.environ.get("PORT")
    if port_env:
        try:
            port = int(port_env)
            if not (1 <= port <= 65535):
                print(f"Warning: PORT={port_env} is invalid, using default 8082")
                port = 8082
        except ValueError:
            print(f"Warning: PORT={port_env} is not a valid number, using default 8082")
            port = 8082
    
    run_server(port=port)
```

## Test Results

✅ **Connection error fixed**: Proxy now properly binds to PORT from environment

✅ **UVX feature branch testing**: 
```bash
uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding@feat/issue-886-fix-proxy-port-binding amplihack launch --with-proxy-config .azure.env -- -p "tell me your model name"
```

✅ **Progress**: Connection error → 404 error (different issue, shows proxy connectivity working)

✅ **Backward compatibility**: Default port 8082 when PORT not set

✅ **Error handling**: Invalid PORT values gracefully fallback to default

## Technical Details

- **Minimal change**: Only modified the `if __name__ == "__main__":` block
- **Follows project patterns**: Uses `os.environ.get()` pattern consistent with existing code
- **Robust error handling**: Invalid ports fall back to default with clear warnings
- **Zero breaking changes**: All existing functionality preserved

## Quality Assurance

- [x] Pre-commit hooks passed
- [x] All security and linting checks passed  
- [x] Tested with exact user UVX command syntax
- [x] Verified connection error resolved
- [x] Confirmed backward compatibility

## Related Issues

Fixes #886

**Next**: The remaining 404 error is a separate Azure endpoint configuration issue, not a proxy connectivity problem.

🤖 Generated with [Claude Code](https://claude.ai/code)