### PR TITLE
fix: Model mapping now respects Azure configuration

### DIFF
--- a/src/amplihack/proxy/server.py
+++ b/src/amplihack/proxy/server.py
@@ -331,23 +331,25 @@ class MessagesRequest(BaseModel):
 
         # --- Mapping Logic --- START ---
         mapped = False
+        # Determine provider based on configuration
+        # Azure takes precedence if configured
+        provider_prefix = "openai/"
+        if AZURE_BASE_URL:
+            provider_prefix = "azure/"
+        elif PREFERRED_PROVIDER == "google" and (
+            BIG_MODEL in GEMINI_MODELS or SMALL_MODEL in GEMINI_MODELS
+        ):
+            provider_prefix = "gemini/"
+
         # Map Haiku to SMALL_MODEL based on provider preference
         if "haiku" in clean_v.lower():
-            if PREFERRED_PROVIDER == "google" and SMALL_MODEL in GEMINI_MODELS:
-                new_model = f"gemini/{SMALL_MODEL}"
-                mapped = True
-            else:
-                new_model = f"openai/{SMALL_MODEL}"
-                mapped = True
+            new_model = f"{provider_prefix}{SMALL_MODEL}"
+            mapped = True
 
         # Map Sonnet to BIG_MODEL based on provider preference
         elif "sonnet" in clean_v.lower():
-            if PREFERRED_PROVIDER == "google" and BIG_MODEL in GEMINI_MODELS:
-                new_model = f"gemini/{BIG_MODEL}"
-                mapped = True
-            else:
-                new_model = f"openai/{BIG_MODEL}"
-                mapped = True
+            new_model = f"{provider_prefix}{BIG_MODEL}"
+            mapped = True
 
         # Add prefixes to non-mapped models if they match known lists
         elif not mapped:
@@ -410,23 +412,25 @@ class TokenCountRequest(BaseModel):
 
         # --- Mapping Logic --- START ---
         mapped = False
+        # Determine provider based on configuration
+        # Azure takes precedence if configured
+        provider_prefix = "openai/"
+        if AZURE_BASE_URL:
+            provider_prefix = "azure/"
+        elif PREFERRED_PROVIDER == "google" and (
+            BIG_MODEL in GEMINI_MODELS or SMALL_MODEL in GEMINI_MODELS
+        ):
+            provider_prefix = "gemini/"
+
         # Map Haiku to SMALL_MODEL based on provider preference
         if "haiku" in clean_v.lower():
-            if PREFERRED_PROVIDER == "google" and SMALL_MODEL in GEMINI_MODELS:
-                new_model = f"gemini/{SMALL_MODEL}"
-                mapped = True
-            else:
-                new_model = f"openai/{SMALL_MODEL}"
-                mapped = True
+            new_model = f"{provider_prefix}{SMALL_MODEL}"
+            mapped = True
 
         # Map Sonnet to BIG_MODEL based on provider preference
         elif "sonnet" in clean_v.lower():
-            if PREFERRED_PROVIDER == "google" and BIG_MODEL in GEMINI_MODELS:
-                new_model = f"gemini/{BIG_MODEL}"
-                mapped = True
-            else:
-                new_model = f"openai/{BIG_MODEL}"
-                mapped = True
+            new_model = f"{provider_prefix}{BIG_MODEL}"
+            mapped = True
 
         # Add prefixes to non-mapped models if they match known lists
         elif not mapped:


### PR DESCRIPTION
## Problem

The proxy was failing with 404 errors when using Azure configuration. Root cause: Claude CLI's internal requests (for conversation titles, file analysis, etc.) use models like `claude-3-5-haiku-20241022`, but the proxy was hardcoded to map these to `openai/` prefix, ignoring Azure configuration.

**Error from logs:**
```json
{
  "error": {
    "code": "404",
    "message": "Resource not found"
  }
}
```

## Solution

Updated model mapping logic in `validate_model_field()` and `validate_model_token_count()` to detect and respect Azure configuration:

```python
# Determine provider based on configuration
# Azure takes precedence if configured
provider_prefix = "openai/"
if AZURE_BASE_URL:
    provider_prefix = "azure/"
elif PREFERRED_PROVIDER == "google" and (BIG_MODEL in GEMINI_MODELS or SMALL_MODEL in GEMINI_MODELS):
    provider_prefix = "gemini/"
```

## Changes

- Map Haiku → `azure/SMALL_MODEL` when Azure configured
- Map Sonnet → `azure/BIG_MODEL` when Azure configured  
- Fallback to `openai/` or `gemini/` based on `PREFERRED_PROVIDER`
- Applied fix to both validators (messages and token count)

## Testing

✅ Unit test: Model mapping logic validates correctly
- Haiku: `claude-3-5-haiku-20241022` → `azure/gpt-4.1-mini`
- Sonnet: `claude-3-5-sonnet-20241022` → `azure/gpt-5-codex`

⚠️ **Integration test needed**: Please test with actual Azure proxy:
```bash
uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding@fix/azure-model-mapping \
  amplihack launch --with-proxy-config .azure.env
```

## Related Issues

Fixes the 404 error reported in the conversation where Claude Code would hang/crash immediately after startup when using Azure proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>