### PR TITLE
Use --add-dir / for full filesystem access in Copilot

### DIFF
--- a/src/amplihack/launcher/auto_mode.py
+++ b/src/amplihack/launcher/auto_mode.py
@@ -46,7 +46,7 @@ class AutoMode:
             (exit_code, output)
         """
         if self.sdk == "copilot":
-            cmd = ["copilot", "--allow-all-tools", "-p", prompt]
+            cmd = ["copilot", "--allow-all-tools", "--add-dir", "/", "-p", prompt]
         else:
             cmd = ["claude", "--dangerously-skip-permissions", "-p", prompt]
 

--- a/src/amplihack/launcher/copilot.py
+++ b/src/amplihack/launcher/copilot.py
@@ -45,14 +45,12 @@ def launch_copilot(args: Optional[List[str]] = None, interactive: bool = True) -
             print("Failed to install Copilot CLI")
             return 1
 
-    # Build command with default --add-dir flags
+    # Build command with full filesystem access (safe in VM environment)
     cmd = [
         "copilot",
         "--allow-all-tools",
         "--add-dir",
-        "/tmp",
-        "--add-dir",
-        "..",
+        "/",
     ]
     if args:
         cmd.extend(args)


### PR DESCRIPTION
## Problem

Subagents are getting blocked when trying to access paths outside of limited directories:

```
The following paths are outside the allowed directories:
  - /Users/ryan/src/seldon-issue-17
```

## Root Cause

Current implementation uses:
```python
--add-dir /tmp --add-dir ..
```

This is insufficient for all use cases. Users working in different directories get blocked.

## Solution

Change to full filesystem access:
```python
--add-dir /
```

Safe in VM environment as confirmed by user.

## Changes

### copilot.py
```python
# Before
cmd = ["copilot", "--allow-all-tools", "--add-dir", "/tmp", "--add-dir", ".."]

# After
cmd = ["copilot", "--allow-all-tools", "--add-dir", "/"]
```

### auto_mode.py
```python
# Before
cmd = ["copilot", "--allow-all-tools", "-p", prompt]

# After  
cmd = ["copilot", "--allow-all-tools", "--add-dir", "/", "-p", prompt]
```

## Testing
- [x] Pre-commit hooks pass
- [x] Type checking passes
- [x] Applied to both launcher and auto mode

## Benefits
- ✅ No more "paths outside allowed directories" errors
- ✅ Copilot can access any path
- ✅ Subagents work without restrictions
- ✅ Simplified from 2 flags to 1 flag

## Closes
Fixes #912