### PR TITLE
feat: Integrate Claude SDK with streaming for auto mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "litellm>=1.0.0",
     "python-dotenv>=0.19.0",
     "pathlib2>=2.3.0; python_version<'3.6'",
+    "claude-agent-sdk>=0.1.0",  # Claude Python Agent SDK for auto mode streaming
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Integrates Claude Python Agent SDK with streaming support for auto mode, resolving stop hook error visibility issues and improving real-time output.

## Problem Solved

User reported: "after your recent updates now every session stop is resulting in a stop hook error without any error message that we can action."

**Root Cause:**
- Subprocess execution hid hook errors in child process stderr
- Line 160 in auto_mode.py returned early for Claude SDK, assuming hooks run automatically, but they weren't being executed at all
- No visibility into hook failures

**Solution:**
- Claude SDK provides native hook integration (hooks run automatically)
- Proper error handling and visibility through SDK's async streaming interface
- Real-time console output via `async for message in query(...)`

## Changes Made

### 1. Claude SDK Integration (`src/amplihack/launcher/auto_mode.py`)

**Added graceful SDK import** (lines 14-20):
```python
try:
    from claude_agent_sdk import query, ClaudeAgentOptions
    CLAUDE_SDK_AVAILABLE = True
except ImportError:
    CLAUDE_SDK_AVAILABLE = False
```

**New async SDK method** `_run_turn_with_sdk()` (lines 183-229):
- Configures SDK with working directory and permission settings
- Streams responses in real-time to console
- Proper error handling with detailed logging
- Returns `(exit_code, output_text)` tuple

**Refactored `run_sdk()`** (lines 52-67):
- Routes by provider: Claude uses SDK, Copilot uses subprocess
- Uses `asyncio.run()` for sync/async boundary
- Falls back to subprocess if SDK unavailable

**Renamed original method** to `_run_sdk_subprocess()` (line 69)

### 2. Fixed Hook Execution Bug

**Cleaned up `run_hook()`** (lines 231-278):
- Removed ~25 lines of duplicate code (old lines 205-212)
- Claude SDK skips manual execution (hooks run automatically by SDK)
- Copilot still uses manual hook execution via subprocess
- Clear logging for each path

### 3. Added Dependency

**Updated `pyproject.toml`** (line 19):
```python
"claude-agent-sdk>=0.1.0",  # Claude Python Agent SDK for auto mode streaming
```

## Benefits

1. **Visibility**: Hook errors are now visible through SDK's error handling
2. **Real-time output**: Streaming provides immediate console feedback
3. **Proper hook integration**: SDK handles hooks automatically with full error reporting
4. **Clean architecture**: Clear async/sync boundary with `asyncio.run()`
5. **Graceful fallback**: Falls back to subprocess if SDK unavailable
6. **Code quality**: Removed duplicate code, clearer separation of concerns

## Testing

- Pre-commit hooks pass (pyright, prettier, security checks)
- Type checking passes with `# type: ignore` for optional SDK import
- Code follows philosophy principles (ruthless simplicity, modular design)

## References

- SDK Documentation: https://docs.claude.com/en/api/agent-sdk/overview
- Python SDK: https://docs.claude.com/en/api/agent-sdk/python
- Streaming Mode: https://docs.claude.com/en/api/agent-sdk/streaming-vs-single-mode

## Test Plan

- [ ] Install SDK: `pip install claude-agent-sdk`
- [ ] Run auto mode with Claude: `amplihack claude --auto -- -p "test task"`
- [ ] Verify streaming output appears in real-time
- [ ] Verify hooks run without errors
- [ ] Test error scenarios (invalid prompts, SDK failures)
- [ ] Verify fallback to subprocess works if SDK unavailable
- [ ] Run full workflow with `/amplihack:auto` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)