### PR TITLE
fix: Correct Claude SDK parameter names in auto mode

### DIFF
--- a/src/amplihack/launcher/auto_mode.py
+++ b/src/amplihack/launcher/auto_mode.py
@@ -199,8 +199,8 @@ Document your decisions and reasoning in comments/logs."""
 
             # Configure SDK options
             options = ClaudeAgentOptions(
-                working_directory=str(self.working_dir),
-                dangerously_skip_permissions=True,
+                cwd=str(self.working_dir),
+                permission_mode="allow",
             )
 
             # Stream response


### PR DESCRIPTION
## Problem

PR #938 introduced SDK integration but used incorrect parameter names causing TypeError:

```python
TypeError: ClaudeAgentOptions.__init__() got an unexpected keyword argument 'working_directory'
```

**Root Cause:**
- Used `working_directory` instead of `cwd`
- Used `dangerously_skip_permissions` instead of `permission_mode`

## Fix

Updated `src/amplihack/launcher/auto_mode.py` line 201-204:

```python
# Before (incorrect)
options = ClaudeAgentOptions(
    working_directory=str(self.working_dir),
    dangerously_skip_permissions=True,
)

# After (correct)
options = ClaudeAgentOptions(
    cwd=str(self.working_dir),
    permission_mode="allow",
)
```

## Verification

- ✅ Pre-commit hooks pass
- ✅ Parameter names confirmed via [Claude SDK Python docs](https://docs.claude.com/en/api/agent-sdk/python)
- ⏳ Will test auto mode execution after deployment

## Impact

- Fixes SDK mode in auto mode (when `claude-agent-sdk` is installed)
- Fallback to subprocess still works if SDK unavailable
- No impact on existing functionality

## Testing Plan

After merge:
1. Install SDK: `uv pip install claude-agent-sdk`
2. Run: `amplihack claude --auto --max-turns 2 -- -p "test task"`
3. Verify SDK mode activates without TypeError
4. Verify streaming output works correctly
5. Verify stays in foreground

Fixes TypeError introduced in PR #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)