### PR TITLE
fix: Remove duplicate [project.optional-dependencies] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,17 +30,11 @@ dev = [
     "black>=22.0.0",
     "ruff>=0.1.0",
     "build>=1.0.0",  # Required for test_uvx_packaging.py
+    "pre-commit",
 ]
 
 [project.scripts]
 amplihack = "amplihack:main"
-
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0",
-    "pytest-asyncio>=0.21.0",
-    "pre-commit",
-]
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary

Fix critical TOML parse error that broke all uvx installations from git.

## Problem

**User Error:**
```
× Failed to resolve `--with` requirement
╰─▶ Failed to parse metadata from built wheel
```

**Root Cause:**
Duplicate `[project.optional-dependencies]` sections in pyproject.toml:
- Line 22: First section with `tui-testing` and `dev`
- Line 38: Second section with duplicate `dev` key

TOML parser error: `duplicate key 'optional-dependencies' in table 'project'`

**Impact:**
- ❌ Blocks ALL uvx installations: `uvx --from git+https://... amplihack`
- ❌ Wheel builds but metadata parsing fails during installation
- ❌ Critical blocker for users installing from git

## Solution

Merged the duplicate sections:
- Removed duplicate `[project.optional-dependencies]` at line 38
- Added `pre-commit` to the existing `dev` dependencies
- Kept all unique dependencies from both sections

## Testing

✅ **TOML validation**: No parse errors
✅ **Wheel build**: `uv build --wheel` succeeds
✅ **Module import**: `python -c 'import amplihack.cli'` succeeds
✅ **Ready for uvx testing**: Metadata can be parsed from wheel

## Verification Steps

To verify the fix works:

```bash
# Update alias to use fix branch
alias amplihack='uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding@fix/uvx-cli-parser-name-error amplihack'

# Test installation
amplihack --help

# Test launch
amplihack launch
```

Once merged to main, the user's existing alias will work:
```bash
amplihack: aliased to uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding amplihack
```

## Files Changed

- `pyproject.toml`: Removed duplicate section, merged dependencies

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>