### PR TITLE
fix: Correct Claude SDK API usage in auto mode

### DIFF
--- a/src/amplihack/launcher/auto_mode.py
+++ b/src/amplihack/launcher/auto_mode.py
@@ -231,7 +231,7 @@ Document your decisions and reasoning in comments/logs."""
             options = ClaudeAgentOptions(
                 cwd=str(self.working_dir),
                 permission_mode="bypassPermissions",  # Auto mode needs non-interactive permissions
-                extra_args={"verbose": True},  # SDK adds -- prefix automatically
+                # Note: verbose flag can be added via extra_args if needed
             )
 
             # Stream response - messages are typed objects, not dicts


### PR DESCRIPTION
## Summary
Fixes multiple bugs in auto mode's Claude SDK integration that prevented auto mode from running. All issues were discovered through actual testing of the auto mode feature.

## Problems Fixed

### 1. Invalid SDK Parameter (Original Bug)
**Error**: `TypeError: ClaudeAgentOptions() got an unexpected keyword argument 'dangerously_allow_permissions'`
**Fix**: Replace with `permission_mode="bypassPermissions"` (verified against official Claude SDK docs)
**Commit**: 23d19e5

### 2. Set Literal Instead of Dict
**Error**: `AttributeError: 'set' object has no attribute 'items'`
**Issue**: `extra_args={"--verbose"}` is a set, not a dict
**Fix**: Changed to dict format: `extra_args={"verbose": True}`
**Commit**: 026258f

### 3. Double Dash Prefix
**Error**: `unknown option '----verbose'`
**Issue**: SDK adds `--` prefix automatically, resulting in `----verbose`
**Fix**: Removed `--` prefix from keys: `extra_args={"verbose": True}`
**Commit**: bbf294a

### 4. SDK Message Object Handling
**Error**: `AttributeError: 'SystemMessage' object has no attribute 'get'`
**Issue**: SDK returns typed message objects (AssistantMessage, ResultMessage), not dicts
**Fix**: Properly handle message types using `hasattr()` and `getattr()`
**Commit**: dcbf192

### 5. Verbose Flag Interference
**Issue**: Boolean flag value "True" was interpreted as prompt argument
**Fix**: Removed verbose flag for now (can be re-added with correct format later)
**Commit**: e2f11ce

## Testing
✅ Tested with: `amplihack launch --auto --max-turns 2 -- -p "create a simple hello.py file"`
✅ No SDK errors or TypeErrors
✅ Auto mode successfully runs through all turns
✅ SDK streaming and message handling works correctly

## Impact
- **Before**: Auto mode completely broken with TypeError on first SDK call
- **After**: Auto mode runs successfully using Claude SDK streaming API

## Documentation Reference
- Verified against official docs: https://docs.claude.com/en/api/agent-sdk/python
- All parameter names and message types confirmed from official SDK documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)