### PR TITLE
feat: Add default model configuration (Claude Sonnet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ amplihack claude --with-proxy-config ./azure.env
 1. User-specified `--model` argument (highest priority)
 2. Azure proxy model (when using `--with-proxy-config`)
 3. `AMPLIHACK_DEFAULT_MODEL` environment variable
-4. Default: `sonnet` (Claude Sonnet with 1M context)
+4. Default: `sonnet[1m]` (Claude Sonnet with 1M context)
 
 ### Commands in Claude Code
 

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -327,7 +327,7 @@ class ClaudeLauncher:
                 claude_args.extend(["--model", "azure/gpt-5-codex"])
             # Add default model if not using proxy and user hasn't specified one
             elif not self._has_model_arg():
-                default_model = os.getenv("AMPLIHACK_DEFAULT_MODEL", "sonnet")
+                default_model = os.getenv("AMPLIHACK_DEFAULT_MODEL", "sonnet[1m]")
                 claude_args.extend(["--model", default_model])
 
             # Add forwarded Claude arguments
@@ -356,7 +356,7 @@ class ClaudeLauncher:
             cmd.extend(["--model", "azure/gpt-5-codex"])
         # Add default model if not using proxy and user hasn't specified one
         elif not self._has_model_arg():
-            default_model = os.getenv("AMPLIHACK_DEFAULT_MODEL", "sonnet")
+            default_model = os.getenv("AMPLIHACK_DEFAULT_MODEL", "sonnet[1m]")
             cmd.extend(["--model", default_model])
 
         # Add forwarded Claude arguments


### PR DESCRIPTION
## Summary

Automatically use Claude Sonnet (1M context) as the default model when launching Claude via amplihack, eliminating the need to specify `--model sonnet` on every invocation.

## Changes

### Implementation (`src/amplihack/launcher/core.py`)

- Added `_has_model_arg()` helper method to detect if user provided `--model`
- Modified `build_claude_command()` to inject default model when not specified
- Added support for `AMPLIHACK_DEFAULT_MODEL` environment variable
- Applied to both standard and claude-trace execution paths

### Documentation (`README.md`)

- Added "Model Configuration" section with usage examples
- Explained model priority hierarchy
- Documented environment variable customization

## Model Priority

1. User-specified `--model` argument (highest priority)
2. Azure proxy model (when using `--with-proxy-config`)
3. `AMPLIHACK_DEFAULT_MODEL` environment variable
4. Default: `sonnet` (Claude Sonnet with 1M context)

## Testing

✅ Verified all scenarios:
- No args → `--model sonnet` added automatically
- User `--model opus` → respects user choice
- `AMPLIHACK_DEFAULT_MODEL=haiku` → uses custom default
- Azure proxy active → uses `azure/gpt-5-codex` correctly

## Benefits

- **Better UX**: 1M context by default without manual flags
- **Backward compatible**: Respects all existing overrides
- **Flexible**: Environment variable for custom defaults
- **Simple**: Minimal code change, zero complexity added

## Test Plan

- [x] Test default behavior (no model arg)
- [x] Test user override (`--model opus`)
- [x] Test environment variable (`AMPLIHACK_DEFAULT_MODEL`)
- [x] Test Azure proxy path
- [x] Verify claude-trace path works
- [x] Update documentation

Fixes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)