### PR TITLE
fix: Add UserPromptSubmit hook to UVX settings template

### DIFF
--- a/src/amplihack/utils/uvx_settings_template.json
+++ b/src/amplihack/utils/uvx_settings_template.json
@@ -68,6 +68,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/tools/amplihack/hooks/user_prompt_submit.py",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Fixes user preferences not being applied in interactive mode when using UVX staging.

## Root Cause

The UserPromptSubmit hook was missing from the UVX settings template. When amplihack stages files via UVX, the template is used for settings.json, and it was missing this critical hook.

## Impact

- User preferences work in auto mode (explicitly injects USER_PREFERENCES.md)
- User preferences FAIL in interactive mode (relies on UserPromptSubmit hook)

## Changes

- Added UserPromptSubmit hook configuration to uvx_settings_template.json
- Matches hook configuration from .claude/settings.json
- Hook timeout: 5000ms

## Testing

- JSON syntax validated
- Hook will inject user preferences on every message in interactive mode

## Related

- See PR for hook-sync-validation-system (prevents this from happening again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)