### PR TITLE
feat: Add hook synchronization validation system

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,3 +152,11 @@ repos:
         language: system
         pass_filenames: false
         files: '^src/.*\.py$'
+
+      # Validate hooks synchronization between settings.json and UVX template
+      - id: sync-hooks-validation
+        name: Validate hooks sync between settings files
+        entry: python3 src/amplihack/utils/sync_validator.py
+        language: system
+        files: '^(\.claude/settings\.json|src/amplihack/utils/uvx_settings_template\.json)$'
+        pass_filenames: false

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Sync hooks from .claude/settings.json to UVX template.
+
+This script ensures the UVX settings template stays in sync with the authoritative
+settings.json by copying hooks and transforming paths appropriately.
+"""
+
+import argparse
+import json
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+
+def transform_hook_path(path: str) -> str:
+    """Transform hook path from source to template format.
+
+    Transforms:
+    - "$CLAUDE_PROJECT_DIR/.claude/..." → ".claude/..."
+    - ".claude/..." → ".claude/..." (unchanged)
+
+    Args:
+        path: Source hook command path
+
+    Returns:
+        Template-formatted path
+    """
+    # Remove $CLAUDE_PROJECT_DIR prefix
+    return re.sub(r'^\$CLAUDE_PROJECT_DIR/', '', path)
+
+
+def transform_hooks_dict(hooks: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform hooks dictionary for template format.
+
+    Args:
+        hooks: Hooks section from source settings.json
+
+    Returns:
+        Transformed hooks dictionary for template
+    """
+    transformed = {}
+
+    for hook_name, hook_configs in hooks.items():
+        transformed_configs = []
+
+        for config in hook_configs:
+            transformed_config = config.copy()
+
+            if 'hooks' in transformed_config:
+                transformed_hooks = []
+                for hook_def in transformed_config['hooks']:
+                    transformed_hook = hook_def.copy()
+                    if 'command' in transformed_hook:
+                        transformed_hook['command'] = transform_hook_path(
+                            transformed_hook['command']
+                        )
+                    transformed_hooks.append(transformed_hook)
+                transformed_config['hooks'] = transformed_hooks
+
+            transformed_configs.append(transformed_config)
+
+        transformed[hook_name] = transformed_configs
+
+    return transformed
+
+
+def sync_hooks(
+    source_path: Path,
+    template_path: Path,
+    dry_run: bool = False
+) -> bool:
+    """Sync hooks from source to template.
+
+    Args:
+        source_path: Path to authoritative .claude/settings.json
+        template_path: Path to UVX template
+        dry_run: If True, only show what would be done
+
+    Returns:
+        True if sync succeeded, False otherwise
+    """
+    try:
+        # Load source settings
+        print(f"Reading source: {source_path}")
+        with open(source_path, 'r', encoding='utf-8') as f:
+            source_data = json.load(f)
+
+        source_hooks = source_data.get('hooks', {})
+        print(f"Found {len(source_hooks)} hook types in source")
+
+        # Load template settings
+        print(f"Reading template: {template_path}")
+        with open(template_path, 'r', encoding='utf-8') as f:
+            template_data = json.load(f)
+
+        # Transform and update hooks
+        transformed_hooks = transform_hooks_dict(source_hooks)
+        template_data['hooks'] = transformed_hooks
+
+        if dry_run:
+            print("\n[DRY RUN] Would update template with:")
+            print(json.dumps(transformed_hooks, indent=2))
+            print("\n[DRY RUN] No files modified")
+            return True
+
+        # Write atomically (temp file + rename)
+        print(f"Writing updated template...")
+        temp_fd, temp_path = tempfile.mkstemp(
+            suffix='.json',
+            dir=template_path.parent,
+            text=True
+        )
+
+        try:
+            with open(temp_fd, 'w', encoding='utf-8') as f:
+                json.dump(template_data, f, indent=2, ensure_ascii=False)
+                f.write('\n')  # Add trailing newline
+
+            # Atomic replace
+            shutil.move(temp_path, template_path)
+            print(f"✅ Successfully synced {len(transformed_hooks)} hook types")
+            return True
+
+        except Exception:
+            # Clean up temp file on error
+            Path(temp_path).unlink(missing_ok=True)
+            raise
+
+    except FileNotFoundError as e:
+        print(f"❌ File not found: {e.filename}", file=sys.stderr)
+        return False
+    except json.JSONDecodeError as e:
+        print(f"❌ Invalid JSON: {e}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"❌ Sync error: {e}", file=sys.stderr)
+        return False
+
+
+def check_sync(source_path: Path, template_path: Path) -> bool:
+    """Check if hooks are currently in sync.
+
+    Args:
+        source_path: Path to authoritative settings.json
+        template_path: Path to UVX template
+
+    Returns:
+        True if in sync, False otherwise
+    """
+    # Import the validator
+    sys.path.insert(0, str(source_path.parent.parent / 'src'))
+    from amplihack.utils.sync_validator import validate_hooks_sync
+
+    is_valid, errors = validate_hooks_sync(source_path, template_path)
+
+    if is_valid:
+        print("✅ Hooks are synchronized")
+        return True
+    else:
+        print("❌ Hooks are OUT OF SYNC")
+        for error in errors:
+            print(f"  • {error}")
+        return False
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description='Sync hooks from settings.json to UVX template'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Show what would be done without modifying files'
+    )
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='Check if hooks are in sync without modifying files'
+    )
+
+    args = parser.parse_args()
+
+    # Determine paths (run from project root)
+    script_dir = Path(__file__).parent.parent
+    source_path = script_dir / '.claude' / 'settings.json'
+    template_path = script_dir / 'src' / 'amplihack' / 'utils' / 'uvx_settings_template.json'
+
+    if args.check:
+        return 0 if check_sync(source_path, template_path) else 1
+
+    print("=" * 60)
+    print("Hook Synchronization Tool")
+    print("=" * 60)
+    print()
+
+    success = sync_hooks(source_path, template_path, dry_run=args.dry_run)
+
+    if success and not args.dry_run:
+        print()
+        print("Verifying sync...")
+        check_sync(source_path, template_path)
+
+    return 0 if success else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/amplihack/utils/sync_validator.py
+++ b/src/amplihack/utils/sync_validator.py
@@ -1,0 +1,169 @@
+"""Hook synchronization validator for settings.json and UVX template.
+
+Ensures hooks in .claude/settings.json match src/amplihack/utils/uvx_settings_template.json
+with appropriate path normalization.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+def normalize_hook_path(path: str) -> str:
+    """Normalize hook command path for comparison.
+
+    Transforms:
+    - "$CLAUDE_PROJECT_DIR/.claude/..." → ".claude/..."
+    - ".claude/..." → ".claude/..."
+
+    Args:
+        path: Hook command path
+
+    Returns:
+        Normalized path string
+    """
+    # Remove $CLAUDE_PROJECT_DIR prefix if present
+    normalized = re.sub(r'^\$CLAUDE_PROJECT_DIR/', '', path)
+    return normalized
+
+
+def normalize_hooks_dict(hooks: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize hooks dictionary for comparison.
+
+    Args:
+        hooks: Hooks section from settings JSON
+
+    Returns:
+        Normalized hooks dictionary with consistent paths
+    """
+    normalized = {}
+
+    for hook_name, hook_configs in hooks.items():
+        normalized_configs = []
+
+        for config in hook_configs:
+            normalized_config = config.copy()
+
+            if 'hooks' in normalized_config:
+                normalized_hooks = []
+                for hook_def in normalized_config['hooks']:
+                    normalized_hook = hook_def.copy()
+                    if 'command' in normalized_hook:
+                        normalized_hook['command'] = normalize_hook_path(
+                            normalized_hook['command']
+                        )
+                    normalized_hooks.append(normalized_hook)
+                normalized_config['hooks'] = normalized_hooks
+
+            normalized_configs.append(normalized_config)
+
+        normalized[hook_name] = normalized_configs
+
+    return normalized
+
+
+def compare_hooks(source_hooks: Dict[str, Any], template_hooks: Dict[str, Any]) -> List[str]:
+    """Compare two hooks dictionaries and return differences.
+
+    Args:
+        source_hooks: Hooks from authoritative settings.json
+        template_hooks: Hooks from UVX template
+
+    Returns:
+        List of error messages describing differences (empty if synced)
+    """
+    errors = []
+
+    # Normalize both for comparison
+    norm_source = normalize_hooks_dict(source_hooks)
+    norm_template = normalize_hooks_dict(template_hooks)
+
+    # Find hooks in source but not in template
+    missing_hooks = set(norm_source.keys()) - set(norm_template.keys())
+    if missing_hooks:
+        errors.append(f"Missing in template: {', '.join(sorted(missing_hooks))}")
+
+    # Find hooks in template but not in source (unexpected)
+    extra_hooks = set(norm_template.keys()) - set(norm_source.keys())
+    if extra_hooks:
+        errors.append(f"Extra in template (not in source): {', '.join(sorted(extra_hooks))}")
+
+    # Compare hooks that exist in both
+    for hook_name in norm_source.keys() & norm_template.keys():
+        if norm_source[hook_name] != norm_template[hook_name]:
+            errors.append(f"Hook '{hook_name}' differs between source and template")
+
+    return errors
+
+
+def validate_hooks_sync(source_path: Path, template_path: Path) -> Tuple[bool, List[str]]:
+    """Validate hooks synchronization between settings files.
+
+    Args:
+        source_path: Path to authoritative .claude/settings.json
+        template_path: Path to UVX template
+
+    Returns:
+        Tuple of (is_valid, error_messages)
+    """
+    try:
+        # Load source settings
+        with open(source_path, 'r', encoding='utf-8') as f:
+            source_data = json.load(f)
+
+        source_hooks = source_data.get('hooks', {})
+
+        # Load template settings
+        with open(template_path, 'r', encoding='utf-8') as f:
+            template_data = json.load(f)
+
+        template_hooks = template_data.get('hooks', {})
+
+        # Compare
+        errors = compare_hooks(source_hooks, template_hooks)
+
+        return (len(errors) == 0, errors)
+
+    except FileNotFoundError as e:
+        return (False, [f"File not found: {e.filename}"])
+    except json.JSONDecodeError as e:
+        return (False, [f"Invalid JSON: {e}"])
+    except Exception as e:
+        return (False, [f"Validation error: {e}"])
+
+
+def main() -> int:
+    """Main entry point for CLI usage.
+
+    Returns:
+        0 if hooks are synced, 1 otherwise
+    """
+    # Determine paths relative to this script
+    script_dir = Path(__file__).parent
+
+    # Source: ../../.claude/settings.json (from src/amplihack/utils/)
+    source_path = script_dir.parent.parent.parent / '.claude' / 'settings.json'
+
+    # Template: ./uvx_settings_template.json (same directory)
+    template_path = script_dir / 'uvx_settings_template.json'
+
+    is_valid, errors = validate_hooks_sync(source_path, template_path)
+
+    if is_valid:
+        print("✅ Hooks are synchronized")
+        return 0
+    else:
+        print("❌ Hooks are OUT OF SYNC")
+        print()
+        for error in errors:
+            print(f"  • {error}")
+        print()
+        print("To fix, run:")
+        print("  python scripts/sync_hooks.py")
+        return 1
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())

--- a/tests/test_uvx_settings_sync.py
+++ b/tests/test_uvx_settings_sync.py
@@ -1,0 +1,151 @@
+"""Tests for UVX settings template synchronization."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from amplihack.utils.sync_validator import (
+    compare_hooks,
+    normalize_hook_path,
+    normalize_hooks_dict,
+    validate_hooks_sync,
+)
+
+
+@pytest.fixture
+def project_root():
+    """Get project root directory."""
+    return Path(__file__).parent.parent
+
+
+@pytest.fixture
+def settings_path(project_root):
+    """Get path to authoritative settings.json."""
+    return project_root / ".claude" / "settings.json"
+
+
+@pytest.fixture
+def template_path(project_root):
+    """Get path to UVX settings template."""
+    return project_root / "src" / "amplihack" / "utils" / "uvx_settings_template.json"
+
+
+def test_normalize_hook_path():
+    """Test hook path normalization."""
+    # Test with $CLAUDE_PROJECT_DIR prefix
+    assert normalize_hook_path("$CLAUDE_PROJECT_DIR/.claude/tools/hook.py") == ".claude/tools/hook.py"
+
+    # Test without prefix
+    assert normalize_hook_path(".claude/tools/hook.py") == ".claude/tools/hook.py"
+
+    # Test empty string
+    assert normalize_hook_path("") == ""
+
+
+def test_settings_files_exist(settings_path, template_path):
+    """Verify required settings files exist."""
+    assert settings_path.exists(), f"Settings file not found: {settings_path}"
+    assert template_path.exists(), f"Template file not found: {template_path}"
+
+
+def test_settings_files_valid_json(settings_path, template_path):
+    """Verify settings files contain valid JSON."""
+    with open(settings_path) as f:
+        settings_data = json.load(f)
+    assert isinstance(settings_data, dict)
+    assert "hooks" in settings_data
+
+    with open(template_path) as f:
+        template_data = json.load(f)
+    assert isinstance(template_data, dict)
+    assert "hooks" in template_data
+
+
+def test_hooks_are_synchronized(settings_path, template_path):
+    """Ensure template hooks match authoritative settings.
+
+    This is the critical test that prevents the UserPromptSubmit bug from recurring.
+    """
+    is_valid, errors = validate_hooks_sync(settings_path, template_path)
+
+    if not is_valid:
+        error_msg = "Hooks are out of sync:\n" + "\n".join(f"  • {e}" for e in errors)
+        error_msg += "\n\nTo fix, run: python scripts/sync_hooks.py"
+        pytest.fail(error_msg)
+
+
+def test_normalize_hooks_dict_preserves_structure():
+    """Test that normalization preserves hook structure."""
+    test_hooks = {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "$CLAUDE_PROJECT_DIR/.claude/tools/hook.py",
+                        "timeout": 10000
+                    }
+                ]
+            }
+        ]
+    }
+
+    normalized = normalize_hooks_dict(test_hooks)
+
+    assert "SessionStart" in normalized
+    assert len(normalized["SessionStart"]) == 1
+    assert "hooks" in normalized["SessionStart"][0]
+    assert normalized["SessionStart"][0]["hooks"][0]["command"] == ".claude/tools/hook.py"
+    assert normalized["SessionStart"][0]["hooks"][0]["timeout"] == 10000
+
+
+def test_compare_hooks_detects_missing():
+    """Test that compare_hooks detects missing hooks."""
+    source = {
+        "SessionStart": [],
+        "UserPromptSubmit": []
+    }
+    template = {
+        "SessionStart": []
+    }
+
+    errors = compare_hooks(source, template)
+    assert len(errors) > 0
+    assert any("UserPromptSubmit" in error for error in errors)
+
+
+def test_compare_hooks_detects_extra():
+    """Test that compare_hooks detects unexpected hooks."""
+    source = {
+        "SessionStart": []
+    }
+    template = {
+        "SessionStart": [],
+        "UnknownHook": []
+    }
+
+    errors = compare_hooks(source, template)
+    assert len(errors) > 0
+    assert any("UnknownHook" in error for error in errors)
+
+
+def test_all_required_hooks_present(settings_path, template_path):
+    """Verify all required hooks are present in both files."""
+    with open(settings_path) as f:
+        settings_data = json.load(f)
+    with open(template_path) as f:
+        template_data = json.load(f)
+
+    required_hooks = {"SessionStart", "Stop", "PostToolUse", "PreCompact", "UserPromptSubmit"}
+
+    settings_hooks = set(settings_data.get("hooks", {}).keys())
+    template_hooks = set(template_data.get("hooks", {}).keys())
+
+    # All required hooks must be in settings
+    missing_in_settings = required_hooks - settings_hooks
+    assert not missing_in_settings, f"Missing hooks in settings.json: {missing_in_settings}"
+
+    # All required hooks must be in template
+    missing_in_template = required_hooks - template_hooks
+    assert not missing_in_template, f"Missing hooks in template: {missing_in_template}"


### PR DESCRIPTION
## Summary

Multi-layer defense to prevent hooks from drifting between .claude/settings.json and the UVX template.

## Problem

When hooks are added/modified in settings.json, they must be manually copied to uvx_settings_template.json. This caused the UserPromptSubmit hook bug.

## Solution

Three-layer validation system:

1. **sync_validator.py** - Core validation with path normalization
2. **sync_hooks.py** - CLI tool to auto-sync hooks  
3. **Pre-commit hook** - Automatic validation on commits
4. **Pytest tests** - CI validation

## Features

- Path normalization: $CLAUDE_PROJECT_DIR/ → relative paths
- Deep equality check on hook configurations
- Clear error messages with fix instructions
- Atomic file writes for safety
- Dry-run mode for preview

## Usage

```bash
# Check sync status
python scripts/sync_hooks.py --check

# Preview changes
python scripts/sync_hooks.py --dry-run

# Sync hooks
python scripts/sync_hooks.py
```

## Testing

- 8 pytest tests covering validation and sync
- Pre-commit hook runs automatically
- CI validates on every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)