### PR TITLE
fix: Add proper exit codes to hook error handlers

### DIFF
--- a/.claude/tools/amplihack/hooks/hook_processor.py
+++ b/.claude/tools/amplihack/hooks/hook_processor.py
@@ -233,6 +233,7 @@ class HookProcessor(ABC):
         except json.JSONDecodeError as e:
             self.log(f"Invalid JSON input: {e}", "ERROR")
             self.write_output({"error": "Invalid JSON input"})
+            sys.exit(1)  # Exit with error code so Claude Code can detect failure
 
         except Exception as e:
             # Log full traceback for debugging
@@ -264,9 +265,10 @@ class HookProcessor(ABC):
                 print("\nFull error details available in log file", file=sys.stderr)
             print("=" * 60, file=sys.stderr)
 
-            # Return empty dict to allow graceful continuation
-            # (exit code 0 ensures non-blocking error)
+            # Return empty dict and exit with error code
+            # Exit code 1 = non-blocking error (stderr shown to user)
             self.write_output({})
+            sys.exit(1)  # Exit with error code so Claude Code can detect failure
 
     def get_session_id(self) -> str:
         """Generate or retrieve a session ID.


### PR DESCRIPTION
## Problem

The hook processor in `.claude/tools/amplihack/hooks/hook_processor.py` was catching exceptions and logging errors properly, but never calling `sys.exit()` with non-zero exit codes. This caused Python to exit with code 0 (success) even when errors occurred.

## Impact

When hooks encountered errors:
- Errors were logged to files ✓
- Error messages printed to stderr ✓
- But Python exited with code 0 (success) ✗
- Claude Code couldn't detect the error properly
- Users saw generic "hook error" messages without details

## Root Cause

Lines 233-269 in `hook_processor.py`:
- Caught exceptions ✓
- Wrote output to stdout ✓
- But never called `sys.exit(1)` or similar ✗

## Solution

Added proper `sys.exit(1)` calls after error handling in two places:

1. **After JSON decode errors** (line 236)
2. **After general exceptions** (line 271)

This allows Claude Code to properly detect and report hook failures according to the exit code conventions documented in the Claude Code hooks documentation.

## Testing Results

✅ **Valid input**: Returns exit code 0 (success)
✅ **Invalid JSON**: Returns exit code 1 with error message  
✅ **Forced exception**: Returns exit code 1 and shows error details on stderr

Test commands used:
```bash
# Success case
echo '{}' | python3 .claude/tools/amplihack/hooks/stop.py
# Exit code: 0

# JSON error case
echo 'invalid json' | python3 .claude/tools/amplihack/hooks/stop.py
# Exit code: 1, error message shown

# Exception case
# (tested with forced ValueError)
# Exit code: 1, full error details on stderr
```

## Changes

- Added `sys.exit(1)` after JSON decode error handling
- Added `sys.exit(1)` after general exception handling
- Updated comments to reflect correct behavior

## References

- Claude Code hooks documentation: https://docs.claude.com/en/docs/claude-code/hooks
- Exit code 0 = success (stdout shown to user)
- Exit code 1 = non-blocking error (stderr shown to user)
- Exit code 2 = blocking error (stderr fed to Claude)

## Files Changed

- `.claude/tools/amplihack/hooks/hook_processor.py` (4 insertions, 2 deletions)