### PR TITLE
fix: Correct lock path mismatch between commands and stop hook

### DIFF
--- a/.claude/commands/amplihack/lock.md
+++ b/.claude/commands/amplihack/lock.md
@@ -13,7 +13,7 @@ Use this mode when you want Claude to work autonomously through a complex task w
 
 ## Custom Continuation Prompts
 
-You can customize the message Claude sees when trying to stop by creating a continuation prompt file at `.claude/tools/amplihack/.continuation_prompt`. This allows you to:
+You can customize the message Claude sees when trying to stop by creating a continuation prompt file at `.claude/runtime/locks/.continuation_prompt`. This allows you to:
 
 - Provide task-specific guidance
 - Add context about what to prioritize
@@ -36,15 +36,15 @@ If the file is empty or doesn't exist, the default continuation prompt is used.
 
 Execute the following to enable lock:
 
-Create the lock flag file at `.claude/tools/amplihack/.lock_active`:
+Create the lock flag file at `.claude/runtime/locks/.lock_active`:
 
 ```python
 import os
 from pathlib import Path
 import tempfile
 
-lock_flag = Path(".claude/tools/amplihack/.lock_active")
-continuation_prompt = Path(".claude/tools/amplihack/.continuation_prompt")
+lock_flag = Path(".claude/runtime/locks/.lock_active")
+continuation_prompt = Path(".claude/runtime/locks/.continuation_prompt")
 lock_flag.parent.mkdir(parents=True, exist_ok=True)
 
 # Atomic file creation with exclusive flag

--- a/.claude/commands/amplihack/unlock.md
+++ b/.claude/commands/amplihack/unlock.md
@@ -14,12 +14,12 @@ Use this command to exit continuous work mode after `/amplihack:lock` was enable
 
 Execute the following to disable lock:
 
-Remove the lock flag file at `.claude/tools/amplihack/.lock_active`:
+Remove the lock flag file at `.claude/runtime/locks/.lock_active`:
 
 ```python
 from pathlib import Path
 
-lock_flag = Path(".claude/tools/amplihack/.lock_active")
+lock_flag = Path(".claude/runtime/locks/.lock_active")
 
 try:
     lock_flag.unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

The lock/unlock commands and stop hook were using **different paths** for the lock file, causing continuous work mode to fail completely:

- **lock.md/unlock.md**: Created/removed lock at `.claude/tools/amplihack/.lock_active`
- **stop.py**: Looked for lock at `.claude/runtime/locks/.lock_active`

**Result**: Lock was created but stop hook couldn't find it → continuous work mode didn't work!

## Root Cause

Path mismatch between:
1. Lock creation (lock.md line 46)
2. Lock removal (unlock.md line 22)
3. Lock checking (stop.py line 21)

The three files were not coordinated.

## Solution

Standardized on `.claude/runtime/locks/.lock_active` because:
- ✅ Follows runtime file pattern (logs, metrics in `.claude/runtime/`)
- ✅ Separates runtime state from command definitions
- ✅ Matches stop hook expectations (stop.py already used this path)

## Changes

### lock.md
- Updated lock path: `.claude/tools/amplihack/.lock_active` → `.claude/runtime/locks/.lock_active`
- Updated continuation_prompt path: `.claude/tools/amplihack/.continuation_prompt` → `.claude/runtime/locks/.continuation_prompt`

### unlock.md
- Updated lock path: `.claude/tools/amplihack/.lock_active` → `.claude/runtime/locks/.lock_active`

### stop.py
- ✅ No changes needed (already correct!)

## Testing

```bash
✓ Path consistency verified across all files
✓ Directory creation works (.claude/runtime/locks/)
✓ Lock creation tested successfully
✓ Lock removal tested successfully
All paths match: True
```

## Impact

**HIGH** - This fix makes lock mode actually work! Before this:
- `/amplihack:lock` would create a lock file
- Stop hook couldn't find it
- Claude would stop anyway
- Continuous work mode was completely broken

After this fix:
- Lock file created in correct location
- Stop hook finds it
- Claude continues working as intended
- Continuous work mode functional!

Fixes #984