### PR TITLE
fix: Stop hook returns correct JSON decision value (#990)

### DIFF
--- a/.claude/tools/amplihack/hooks/stop.py
+++ b/.claude/tools/amplihack/hooks/stop.py
@@ -35,7 +35,7 @@ class StopHook(HookProcessor):
         except (PermissionError, OSError) as e:
             self.log(f"Cannot access lock file: {e}", "WARNING")
             # Fail-safe: allow stop if we can't read lock
-            return {"decision": "allow", "continue": False}
+            return {"decision": "approve", "continue": False}
 
         if lock_exists:
             # Lock is active - block stop and continue working
@@ -52,7 +52,7 @@ class StopHook(HookProcessor):
 
         # Allow stop
         self.log("No lock active - allowing stop")
-        return {"decision": "allow", "continue": False}
+        return {"decision": "approve", "continue": False}
 
     def _trigger_reflection_if_enabled(self):
         """Trigger reflection analysis if enabled and not already running."""


### PR DESCRIPTION
## Summary

Fixes stop hook JSON schema validation error where hook returned `"decision": "allow"` but Claude Code expects `"decision": "approve" | "block"`.

## Changes

- Line 38: Changed `"decision": "allow"` → `"decision": "approve"`
- Line 55: Changed `"decision": "allow"` → `"decision": "approve"`

## Testing

✅ All tests passed:
- JSON format verification
- Schema compliance  
- Functionality preserved (lock checking, reflection triggering, logging, metrics)
- Philosophy compliance (ruthless simplicity - only 2 lines changed)

See: `TEST_RESULTS_990.md` for details

## Test plan

**Manual verification:**
- [ ] Run Claude Code with stop hook
- [ ] Try to stop without lock - should work, no JSON errors
- [ ] Activate lock (`/amplihack:lock`)
- [ ] Try to stop with lock - should block and continue
- [ ] Deactivate lock (`/amplihack:unlock`)
- [ ] Stop should work again

## Root Cause

The value "allow" is for `permissionDecision` field, not `decision` field.

Fixes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)