### PR TITLE
hotfix: Add missing Any import to fork_manager.py

### DIFF
--- a/src/amplihack/launcher/fork_manager.py
+++ b/src/amplihack/launcher/fork_manager.py
@@ -6,7 +6,7 @@ Monitors session duration and triggers SDK fork before hitting the
 
 import threading
 import time
-from typing import Optional
+from typing import Any, Optional
 
 
 # Try to import SDK, gracefully handle if unavailable


### PR DESCRIPTION
Critical fix - fork_manager.py crashes with NameError: name Any is not defined. Added Any to typing imports.