### PR TITLE
Fix: Add dirs_exist_ok to copytree

### DIFF
--- a/src/amplihack/__init__.py
+++ b/src/amplihack/__init__.py
@@ -154,7 +154,7 @@ def copytree_manifest(repo_root, dst, rel_top=".claude"):
 
         # Copy the directory
         try:
-            shutil.copytree(source_dir, target_dir)
+            shutil.copytree(source_dir, target_dir, dirs_exist_ok=True)
 
             # Fix: Set execute permissions on hook Python files
             # This fixes the "Permission denied" error when hooks are copied


### PR DESCRIPTION
Fixes 'File exists' error when launching in directory with existing .claude files.

Added dirs_exist_ok=True to shutil.copytree call.

Tested: Syntax valid, imports work

🤖 Generated with [Claude Code](https://claude.com/claude-code)