### PR TITLE
feat: Add workflow phase grouping and progress indicators to TodoWrite

### DIFF
--- a/Specs/TodoWritePhaseGrouping.md
+++ b/Specs/TodoWritePhaseGrouping.md
@@ -1,0 +1,426 @@
+# Module: TodoWrite Phase Grouping Enhancement
+
+## Problem Statement
+
+During long-running Ultra-Think sessions, users cannot easily tell:
+- Which workflow phase they're in
+- How much progress has been made
+- What's coming next
+- Why tasks happen in a specific order
+
+The current TodoWrite implementation shows a flat list of tasks without workflow context.
+
+## Solution Analysis
+
+### Option 1: Client-Side Display Enhancement (RECOMMENDED)
+**Approach**: Enhance `_format_todos_for_terminal()` to detect and group phase information from todo content
+**Pros**:
+- No SDK changes required
+- Works immediately with existing TodoWrite calls
+- Backward compatible
+- Simple to implement and test
+
+**Cons**:
+- Requires convention in todo content (e.g., "Phase N:" prefix)
+- Phase detection is pattern-based
+
+### Option 2: Extended TodoWrite Schema
+**Approach**: Extend todo items with phase metadata fields
+**Pros**:
+- Explicit phase information
+- Type-safe phase tracking
+
+**Cons**:
+- Requires SDK changes (out of scope)
+- Breaks existing TodoWrite callers
+- Complex migration path
+
+### Option 3: Separate Phase Tracking Tool
+**Approach**: Create new tool for phase tracking alongside TodoWrite
+**Pros**:
+- Separate concerns
+- No TodoWrite changes
+
+**Cons**:
+- Fragmented state (todos + phases separate)
+- Requires multiple tool calls
+- More complexity
+
+## Recommendation: Option 1
+
+Enhance the display layer to extract phase information from todo content using conventions. This is the simplest, most pragmatic approach that delivers value immediately without breaking changes.
+
+## Architecture Design
+
+### Phase 1: Enhanced Display Layer
+
+**Module**: `auto_mode._format_todos_for_terminal()`
+
+**Purpose**: Transform flat todo list into phase-grouped display with progress indicators
+
+**Contract**:
+- **Input**: `list[dict]` - todo items with content, status, activeForm
+- **Output**: `str` - formatted string with phase grouping and progress
+- **Side Effects**: None (pure formatting function)
+
+**Detection Strategy**:
+
+Todos can opt into phase grouping by using this content format:
+```
+"PHASE N: [Phase Name] - [Task Description]"
+```
+
+Example:
+```python
+{
+    "content": "PHASE 2: DESIGN - Use architect agent to design solution",
+    "status": "in_progress",
+    "activeForm": "Using architect agent to design solution"
+}
+```
+
+**Display Format**:
+
+```
+📋 WORKFLOW PROGRESS
+
+🎯 PHASE 1: REQUIREMENTS [✅ COMPLETED - 2/2 tasks]
+  ✓ Clarify requirements with prompt-writer agent
+  ✓ Analyze existing implementation
+
+🎯 PHASE 2: DESIGN [⏳ IN PROGRESS - 1/3 tasks]
+  ✓ Create worktree and branch
+  ⏳ Use architect agent to design solution (ACTIVE)
+  ○ Use api-designer for API contracts
+
+🎯 PHASE 3: IMPLEMENTATION [○ PENDING - 0/5 tasks]
+  ○ Use builder agent to implement changes
+  ○ Use tester agent for test coverage
+  ...
+
+Overall Progress: 3/10 tasks complete (30%)
+```
+
+### Implementation Specification
+
+#### 1. Phase Detection Function
+
+```python
+def _extract_phase_info(todo: dict) -> tuple[Optional[int], Optional[str], str]:
+    """Extract phase information from todo content.
+
+    Args:
+        todo: Todo item with content field
+
+    Returns:
+        Tuple of (phase_number, phase_name, task_description)
+        Returns (None, None, original_content) if no phase pattern found
+    """
+    content = todo.get("content", "")
+
+    # Pattern: "PHASE N: [Phase Name] - [Task]"
+    import re
+    match = re.match(r'^PHASE\s+(\d+):\s*([^-]+?)\s*-\s*(.+)$', content, re.IGNORECASE)
+
+    if match:
+        phase_num = int(match.group(1))
+        phase_name = match.group(2).strip()
+        task_desc = match.group(3).strip()
+        return (phase_num, phase_name, task_desc)
+
+    return (None, None, content)
+```
+
+#### 2. Phase Grouping Function
+
+```python
+def _group_todos_by_phase(todos: list) -> dict:
+    """Group todos by phase and calculate progress.
+
+    Args:
+        todos: List of todo items
+
+    Returns:
+        {
+            'phases': {
+                1: {'name': 'REQUIREMENTS', 'tasks': [...], 'completed': N, 'total': M},
+                2: {'name': 'DESIGN', 'tasks': [...], 'completed': N, 'total': M},
+                ...
+            },
+            'ungrouped': [...],  # Todos without phase info
+            'total_completed': N,
+            'total_tasks': M
+        }
+    """
+    phases = {}
+    ungrouped = []
+    total_completed = 0
+    total_tasks = len(todos)
+
+    for todo in todos:
+        phase_num, phase_name, task_desc = _extract_phase_info(todo)
+
+        if phase_num is not None:
+            if phase_num not in phases:
+                phases[phase_num] = {
+                    'name': phase_name,
+                    'tasks': [],
+                    'completed': 0,
+                    'total': 0
+                }
+
+            # Create task item with extracted description
+            task_item = {
+                'description': task_desc,
+                'status': todo['status'],
+                'activeForm': todo.get('activeForm', task_desc)
+            }
+
+            phases[phase_num]['tasks'].append(task_item)
+            phases[phase_num]['total'] += 1
+
+            if todo['status'] == 'completed':
+                phases[phase_num]['completed'] += 1
+                total_completed += 1
+        else:
+            ungrouped.append(todo)
+            if todo['status'] == 'completed':
+                total_completed += 1
+
+    return {
+        'phases': phases,
+        'ungrouped': ungrouped,
+        'total_completed': total_completed,
+        'total_tasks': total_tasks
+    }
+```
+
+#### 3. Enhanced Formatting Function
+
+```python
+def _format_todos_for_terminal(self, todos: list) -> str:
+    """Format todo list for terminal display with phase grouping.
+
+    Args:
+        todos: List of todo items
+
+    Returns:
+        Formatted string with phase grouping and progress indicators
+    """
+    if not todos:
+        return ""
+
+    # ANSI color codes
+    BOLD = "\033[1m"
+    GREEN = "\033[32m"
+    YELLOW = "\033[33m"
+    BLUE = "\033[34m"
+    RESET = "\033[0m"
+
+    # Group todos by phase
+    grouped = self._group_todos_by_phase(todos)
+
+    lines = []
+
+    # If we have phase-grouped todos, show structured format
+    if grouped['phases']:
+        lines.append(f"\n{BOLD}📋 WORKFLOW PROGRESS{RESET}\n")
+
+        # Show each phase
+        for phase_num in sorted(grouped['phases'].keys()):
+            phase = grouped['phases'][phase_num]
+
+            # Determine phase status
+            if phase['completed'] == phase['total']:
+                phase_icon = f"{GREEN}✅{RESET}"
+                phase_status = "COMPLETED"
+            elif phase['completed'] > 0:
+                phase_icon = f"{YELLOW}⏳{RESET}"
+                phase_status = "IN PROGRESS"
+            else:
+                phase_icon = f"{BLUE}○{RESET}"
+                phase_status = "PENDING"
+
+            # Phase header
+            lines.append(
+                f"\n{BOLD}🎯 PHASE {phase_num}: {phase['name'].upper()}{RESET} "
+                f"[{phase_icon} {phase_status} - {phase['completed']}/{phase['total']} tasks]"
+            )
+
+            # Phase tasks
+            for task in phase['tasks']:
+                status = task['status']
+
+                if status == "completed":
+                    indicator = f"{GREEN}✓{RESET}"
+                    text = task['description']
+                elif status == "in_progress":
+                    indicator = f"{YELLOW}⏳{RESET}"
+                    text = f"{task['activeForm']} (ACTIVE)"
+                else:  # pending
+                    indicator = f"{BLUE}○{RESET}"
+                    text = task['description']
+
+                lines.append(f"  {indicator} {text}")
+
+        # Show ungrouped tasks if any
+        if grouped['ungrouped']:
+            lines.append(f"\n{BOLD}📝 Other Tasks:{RESET}")
+            for todo in grouped['ungrouped']:
+                status = todo.get("status", "pending")
+                content = todo.get("content", "")
+                active_form = todo.get("activeForm", content)
+
+                if status == "completed":
+                    indicator = f"{GREEN}✓{RESET}"
+                    text = content
+                elif status == "in_progress":
+                    indicator = f"{YELLOW}⟳{RESET}"
+                    text = active_form
+                else:
+                    indicator = f"{BLUE}○{RESET}"
+                    text = content
+
+                lines.append(f"  {indicator} {text}")
+
+        # Overall progress
+        percentage = int((grouped['total_completed'] / grouped['total_tasks']) * 100) if grouped['total_tasks'] > 0 else 0
+        lines.append(
+            f"\n{BOLD}Overall Progress:{RESET} {grouped['total_completed']}/{grouped['total_tasks']} tasks ({percentage}%)\n"
+        )
+    else:
+        # Fallback to original flat format if no phases detected
+        lines.append(f"\n{BOLD}📋 Todo List:{RESET}")
+
+        for todo in todos:
+            status = todo.get("status", "pending")
+            content = todo.get("content", "")
+            active_form = todo.get("activeForm", content)
+
+            if status == "completed":
+                indicator = f"{GREEN}✓{RESET}"
+                text = content
+            elif status == "in_progress":
+                indicator = f"{YELLOW}⟳{RESET}"
+                text = active_form
+            else:
+                indicator = f"{BLUE}○{RESET}"
+                text = content
+
+            lines.append(f"  {indicator} {text}")
+
+        lines.append("")
+
+    return "\n".join(lines)
+```
+
+### Module Dependencies
+
+- `re` module for pattern matching
+- Existing ANSI color codes
+- No new external dependencies
+
+### Testing Requirements
+
+#### Unit Tests
+
+1. **Phase Detection Tests**:
+   - Detect valid phase patterns
+   - Handle invalid/missing phase patterns
+   - Extract phase number, name, and task correctly
+   - Handle edge cases (no dashes, extra spaces, etc.)
+
+2. **Grouping Tests**:
+   - Group tasks by phase number correctly
+   - Calculate progress per phase
+   - Handle mixed grouped/ungrouped todos
+   - Handle empty todo lists
+
+3. **Formatting Tests**:
+   - Phase-grouped format renders correctly
+   - Fallback to flat format when no phases
+   - ANSI codes applied correctly
+   - Overall progress calculation
+   - Status indicators (✅ ⏳ ○) correct
+
+#### Integration Tests
+
+1. **Real TodoWrite Flow**:
+   - Create todos with phase format
+   - Verify display shows grouped format
+   - Verify progress updates correctly
+
+2. **Backward Compatibility**:
+   - Old-style todos still work
+   - Mixed old/new format handled gracefully
+
+### Backward Compatibility
+
+**Guaranteed**:
+- Existing TodoWrite calls with no phase info will display in original flat format
+- Phase detection is opt-in via content convention
+- No breaking changes to existing code
+
+## Implementation Plan
+
+### Phase 1: Core Functions (TDD)
+1. Write tests for `_extract_phase_info()`
+2. Implement `_extract_phase_info()`
+3. Write tests for `_group_todos_by_phase()`
+4. Implement `_group_todos_by_phase()`
+
+### Phase 2: Display Enhancement (TDD)
+1. Write tests for enhanced `_format_todos_for_terminal()`
+2. Implement enhanced formatting with phase grouping
+3. Ensure fallback to original format works
+
+### Phase 3: Integration & Testing
+1. Test with real TodoWrite calls in auto mode
+2. Verify ANSI rendering in terminal
+3. Test mixed grouped/ungrouped scenarios
+
+### Phase 4: Documentation & Examples
+1. Update workflow to use phase-format todos
+2. Add examples to ultrathink command
+3. Document convention in CLAUDE.md
+
+## Success Criteria
+
+- Users can see which workflow phase is active
+- Progress indicators show completion percentage
+- Tasks are logically grouped by phase
+- Backward compatible with existing todos
+- All tests pass
+- Zero-BS implementation (no stubs, no TODOs)
+
+## Files to Modify
+
+1. `/home/azureuser/src/MicrosoftHackathon2025-AgenticCoding/worktrees/feat/issue-1103-todowrite-enhancement/src/amplihack/launcher/auto_mode.py`
+   - Add `_extract_phase_info()` method
+   - Add `_group_todos_by_phase()` method
+   - Enhance `_format_todos_for_terminal()` method
+
+2. `/home/azureuser/src/MicrosoftHackathon2025-AgenticCoding/worktrees/feat/issue-1103-todowrite-enhancement/tests/unit/test_todowrite_phase_grouping.py` (NEW)
+   - Unit tests for all three functions
+
+3. `/home/azureuser/src/MicrosoftHackathon2025-AgenticCoding/worktrees/feat/issue-1103-todowrite-enhancement/tests/integration/test_todowrite_display.py` (NEW)
+   - Integration tests for real TodoWrite flow
+
+## Risk Mitigation
+
+**Risk**: Pattern matching too rigid
+**Mitigation**: Use flexible regex, document convention clearly
+
+**Risk**: ANSI codes break in some terminals
+**Mitigation**: Reuse existing ANSI code patterns that already work
+
+**Risk**: Performance with large todo lists
+**Mitigation**: Linear complexity, no performance concern for typical todo counts (<50)
+
+## Philosophical Alignment
+
+- **Ruthless Simplicity**: Convention over configuration, pattern-based detection
+- **Zero-BS**: Pure functions, no stubs, complete implementation
+- **Modular Design**: Clear separation (detection → grouping → formatting)
+- **Backward Compatible**: Graceful fallback to original format
+- **Regeneratable**: Clear spec allows complete rebuild

--- a/tests/unit/test_todowrite_phase_grouping.py
+++ b/tests/unit/test_todowrite_phase_grouping.py
@@ -1,0 +1,470 @@
+"""Unit tests for TodoWrite phase grouping enhancement.
+
+Tests the phase detection, grouping, and formatting functions that enable
+workflow-aware todo list display with progress indicators.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+
+class TestPhaseDetection(unittest.TestCase):
+    """Test _extract_phase_info() function for detecting phase patterns."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        with patch('amplihack.launcher.auto_mode.Path.mkdir'), \
+             patch('builtins.open'):
+            from amplihack.launcher.auto_mode import AutoMode
+            self.auto_mode = AutoMode(
+                sdk="claude",
+                prompt="Test",
+                max_turns=5,
+                working_dir=Path("/tmp/test"),
+                ui_mode=False
+            )
+
+    def test_extract_valid_phase_pattern(self):
+        """Test extraction of valid phase pattern."""
+        todo = {
+            "content": "PHASE 2: DESIGN - Use architect agent to design solution",
+            "status": "in_progress"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertEqual(phase_num, 2)
+        self.assertEqual(phase_name, "DESIGN")
+        self.assertEqual(task_desc, "Use architect agent to design solution")
+
+    def test_extract_phase_with_extra_spaces(self):
+        """Test extraction with extra whitespace."""
+        todo = {
+            "content": "PHASE  3:   IMPLEMENTATION   -   Build the feature",
+            "status": "pending"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertEqual(phase_num, 3)
+        self.assertEqual(phase_name, "IMPLEMENTATION")
+        self.assertEqual(task_desc, "Build the feature")
+
+    def test_extract_phase_case_insensitive(self):
+        """Test case-insensitive phase detection."""
+        todo = {
+            "content": "phase 1: planning - Setup environment",
+            "status": "completed"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertEqual(phase_num, 1)
+        self.assertEqual(phase_name, "planning")
+        self.assertEqual(task_desc, "Setup environment")
+
+    def test_extract_phase_with_multiword_name(self):
+        """Test phase name with multiple words."""
+        todo = {
+            "content": "PHASE 4: CODE REVIEW AND TESTING - Run all tests",
+            "status": "pending"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertEqual(phase_num, 4)
+        self.assertEqual(phase_name, "CODE REVIEW AND TESTING")
+        self.assertEqual(task_desc, "Run all tests")
+
+    def test_extract_no_phase_pattern(self):
+        """Test todo without phase pattern returns None."""
+        todo = {
+            "content": "Just a regular task without phases",
+            "status": "pending"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertIsNone(phase_num)
+        self.assertIsNone(phase_name)
+        self.assertEqual(task_desc, "Just a regular task without phases")
+
+    def test_extract_invalid_phase_number(self):
+        """Test invalid phase number returns None."""
+        todo = {
+            "content": "PHASE ABC: INVALID - Should not match",
+            "status": "pending"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertIsNone(phase_num)
+        self.assertIsNone(phase_name)
+        self.assertEqual(task_desc, "PHASE ABC: INVALID - Should not match")
+
+    def test_extract_missing_dash_separator(self):
+        """Test pattern without dash separator returns None."""
+        todo = {
+            "content": "PHASE 1: PLANNING No dash separator here",
+            "status": "pending"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        # Should fail to match without dash
+        self.assertIsNone(phase_num)
+
+    def test_extract_empty_content(self):
+        """Test empty content returns None."""
+        todo = {
+            "content": "",
+            "status": "pending"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertIsNone(phase_num)
+        self.assertIsNone(phase_name)
+        self.assertEqual(task_desc, "")
+
+    def test_extract_phase_with_dash_in_task(self):
+        """Test task description containing dashes."""
+        todo = {
+            "content": "PHASE 5: TESTING - Run pre-commit and post-commit hooks",
+            "status": "in_progress"
+        }
+
+        phase_num, phase_name, task_desc = self.auto_mode._extract_phase_info(todo)
+
+        self.assertEqual(phase_num, 5)
+        self.assertEqual(phase_name, "TESTING")
+        self.assertEqual(task_desc, "Run pre-commit and post-commit hooks")
+
+
+class TestPhaseGrouping(unittest.TestCase):
+    """Test _group_todos_by_phase() function for grouping and progress calculation."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        with patch('amplihack.launcher.auto_mode.Path.mkdir'), \
+             patch('builtins.open'):
+            from amplihack.launcher.auto_mode import AutoMode
+            self.auto_mode = AutoMode(
+                sdk="claude",
+                prompt="Test",
+                max_turns=5,
+                working_dir=Path("/tmp/test"),
+                ui_mode=False
+            )
+
+    def test_group_single_phase_todos(self):
+        """Test grouping todos from a single phase."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "PHASE 1: PLANNING - Task B", "status": "in_progress", "activeForm": "Working on Task B"},
+            {"content": "PHASE 1: PLANNING - Task C", "status": "pending", "activeForm": "Task C"},
+        ]
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        self.assertIn(1, grouped['phases'])
+        self.assertEqual(grouped['phases'][1]['name'], 'PLANNING')
+        self.assertEqual(len(grouped['phases'][1]['tasks']), 3)
+        self.assertEqual(grouped['phases'][1]['completed'], 1)
+        self.assertEqual(grouped['phases'][1]['total'], 3)
+        self.assertEqual(grouped['total_completed'], 1)
+        self.assertEqual(grouped['total_tasks'], 3)
+
+    def test_group_multiple_phase_todos(self):
+        """Test grouping todos across multiple phases."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "PHASE 1: PLANNING - Task B", "status": "completed", "activeForm": "Task B"},
+            {"content": "PHASE 2: DESIGN - Task C", "status": "in_progress", "activeForm": "Working on C"},
+            {"content": "PHASE 2: DESIGN - Task D", "status": "pending", "activeForm": "Task D"},
+            {"content": "PHASE 3: IMPLEMENTATION - Task E", "status": "pending", "activeForm": "Task E"},
+        ]
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        self.assertEqual(len(grouped['phases']), 3)
+        self.assertEqual(grouped['phases'][1]['completed'], 2)
+        self.assertEqual(grouped['phases'][1]['total'], 2)
+        self.assertEqual(grouped['phases'][2]['completed'], 0)
+        self.assertEqual(grouped['phases'][2]['total'], 2)
+        self.assertEqual(grouped['phases'][3]['completed'], 0)
+        self.assertEqual(grouped['phases'][3]['total'], 1)
+        self.assertEqual(grouped['total_completed'], 2)
+        self.assertEqual(grouped['total_tasks'], 5)
+
+    def test_group_mixed_phased_and_ungrouped(self):
+        """Test mixing phased and non-phased todos."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "Regular task without phase", "status": "in_progress", "activeForm": "Working"},
+            {"content": "PHASE 2: DESIGN - Task B", "status": "pending", "activeForm": "Task B"},
+            {"content": "Another regular task", "status": "completed", "activeForm": "Done"},
+        ]
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        self.assertEqual(len(grouped['phases']), 2)
+        self.assertEqual(len(grouped['ungrouped']), 2)
+        self.assertEqual(grouped['total_completed'], 2)
+        self.assertEqual(grouped['total_tasks'], 4)
+
+    def test_group_empty_todo_list(self):
+        """Test grouping empty todo list."""
+        todos = []
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        self.assertEqual(len(grouped['phases']), 0)
+        self.assertEqual(len(grouped['ungrouped']), 0)
+        self.assertEqual(grouped['total_completed'], 0)
+        self.assertEqual(grouped['total_tasks'], 0)
+
+    def test_group_all_ungrouped_todos(self):
+        """Test todos with no phase information."""
+        todos = [
+            {"content": "Task 1", "status": "completed", "activeForm": "Task 1"},
+            {"content": "Task 2", "status": "pending", "activeForm": "Task 2"},
+        ]
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        self.assertEqual(len(grouped['phases']), 0)
+        self.assertEqual(len(grouped['ungrouped']), 2)
+        self.assertEqual(grouped['total_completed'], 1)
+        self.assertEqual(grouped['total_tasks'], 2)
+
+    def test_group_preserves_task_data(self):
+        """Test that grouping preserves task description and activeForm."""
+        todos = [
+            {
+                "content": "PHASE 1: TEST - Task with description",
+                "status": "in_progress",
+                "activeForm": "Currently working on task"
+            }
+        ]
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        task = grouped['phases'][1]['tasks'][0]
+        self.assertEqual(task['description'], "Task with description")
+        self.assertEqual(task['status'], "in_progress")
+        self.assertEqual(task['activeForm'], "Currently working on task")
+
+    def test_group_progress_calculation(self):
+        """Test progress calculation is accurate."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task 1", "status": "completed", "activeForm": "Task 1"},
+            {"content": "PHASE 1: PLANNING - Task 2", "status": "completed", "activeForm": "Task 2"},
+            {"content": "PHASE 1: PLANNING - Task 3", "status": "completed", "activeForm": "Task 3"},
+            {"content": "PHASE 2: DESIGN - Task 4", "status": "in_progress", "activeForm": "Task 4"},
+            {"content": "PHASE 2: DESIGN - Task 5", "status": "pending", "activeForm": "Task 5"},
+        ]
+
+        grouped = self.auto_mode._group_todos_by_phase(todos)
+
+        # Phase 1: 3 completed out of 3
+        self.assertEqual(grouped['phases'][1]['completed'], 3)
+        self.assertEqual(grouped['phases'][1]['total'], 3)
+
+        # Phase 2: 0 completed out of 2 (in_progress doesn't count)
+        self.assertEqual(grouped['phases'][2]['completed'], 0)
+        self.assertEqual(grouped['phases'][2]['total'], 2)
+
+        # Overall: 3 completed out of 5
+        self.assertEqual(grouped['total_completed'], 3)
+        self.assertEqual(grouped['total_tasks'], 5)
+
+
+class TestFormattingWithPhases(unittest.TestCase):
+    """Test _format_todos_for_terminal() with phase grouping."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        with patch('amplihack.launcher.auto_mode.Path.mkdir'), \
+             patch('builtins.open'):
+            from amplihack.launcher.auto_mode import AutoMode
+            self.auto_mode = AutoMode(
+                sdk="claude",
+                prompt="Test",
+                max_turns=5,
+                working_dir=Path("/tmp/test"),
+                ui_mode=False
+            )
+
+    def test_format_with_phase_grouping(self):
+        """Test formatting displays phase-grouped structure."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "PHASE 2: DESIGN - Task B", "status": "in_progress", "activeForm": "Working on B"},
+            {"content": "PHASE 3: IMPLEMENTATION - Task C", "status": "pending", "activeForm": "Task C"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Check for phase headers
+        self.assertIn("📋 WORKFLOW PROGRESS", output)
+        self.assertIn("PHASE 1: PLANNING", output)
+        self.assertIn("PHASE 2: DESIGN", output)
+        self.assertIn("PHASE 3: IMPLEMENTATION", output)
+
+        # Check for phase status indicators
+        self.assertIn("COMPLETED", output)
+        self.assertIn("IN PROGRESS", output)
+        self.assertIn("PENDING", output)
+
+        # Check for overall progress
+        self.assertIn("Overall Progress:", output)
+        self.assertIn("1/3 tasks", output)
+        self.assertIn("(33%)", output)
+
+    def test_format_shows_task_progress_per_phase(self):
+        """Test formatting shows task count per phase."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "PHASE 1: PLANNING - Task B", "status": "completed", "activeForm": "Task B"},
+            {"content": "PHASE 2: DESIGN - Task C", "status": "in_progress", "activeForm": "Working on C"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Phase 1 should show 2/2 tasks
+        self.assertIn("2/2 tasks", output)
+
+        # Phase 2 should show 0/1 tasks (in_progress doesn't count as completed)
+        self.assertIn("0/1 tasks", output)
+
+    def test_format_fallback_without_phases(self):
+        """Test formatting falls back to flat format without phases."""
+        todos = [
+            {"content": "Regular task 1", "status": "completed", "activeForm": "Task 1"},
+            {"content": "Regular task 2", "status": "pending", "activeForm": "Task 2"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Should show flat format header
+        self.assertIn("📋 Todo List:", output)
+
+        # Should NOT show workflow progress header
+        self.assertNotIn("WORKFLOW PROGRESS", output)
+        self.assertNotIn("PHASE", output)
+
+    def test_format_mixed_phased_and_ungrouped(self):
+        """Test formatting handles mix of phased and ungrouped todos."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "Regular task", "status": "pending", "activeForm": "Regular task"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Should show phase section
+        self.assertIn("PHASE 1: PLANNING", output)
+
+        # Should show ungrouped section
+        self.assertIn("Other Tasks:", output)
+        self.assertIn("Regular task", output)
+
+    def test_format_empty_todo_list(self):
+        """Test formatting empty todo list returns empty string."""
+        todos = []
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        self.assertEqual(output, "")
+
+    def test_format_active_task_indicator(self):
+        """Test in_progress tasks show (ACTIVE) indicator."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "in_progress", "activeForm": "Working on A"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Should show activeForm with (ACTIVE) indicator
+        self.assertIn("Working on A (ACTIVE)", output)
+
+    def test_format_completed_phase_indicator(self):
+        """Test completed phase shows green checkmark."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task A", "status": "completed", "activeForm": "Task A"},
+            {"content": "PHASE 1: PLANNING - Task B", "status": "completed", "activeForm": "Task B"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Check for completed phase indicator (✅ or similar)
+        # Note: ANSI codes might be present
+        self.assertIn("COMPLETED", output)
+
+    def test_format_percentage_calculation(self):
+        """Test overall progress percentage is calculated correctly."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - Task 1", "status": "completed", "activeForm": "Task 1"},
+            {"content": "PHASE 1: PLANNING - Task 2", "status": "completed", "activeForm": "Task 2"},
+            {"content": "PHASE 2: DESIGN - Task 3", "status": "pending", "activeForm": "Task 3"},
+            {"content": "PHASE 2: DESIGN - Task 4", "status": "pending", "activeForm": "Task 4"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # 2 out of 4 = 50%
+        self.assertIn("(50%)", output)
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    """Test backward compatibility with existing TodoWrite usage."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        with patch('amplihack.launcher.auto_mode.Path.mkdir'), \
+             patch('builtins.open'):
+            from amplihack.launcher.auto_mode import AutoMode
+            self.auto_mode = AutoMode(
+                sdk="claude",
+                prompt="Test",
+                max_turns=5,
+                working_dir=Path("/tmp/test"),
+                ui_mode=False
+            )
+
+    def test_old_format_still_works(self):
+        """Test todos without phase information still display correctly."""
+        todos = [
+            {"content": "Task 1", "status": "completed", "activeForm": "Task 1"},
+            {"content": "Task 2", "status": "in_progress", "activeForm": "Working on Task 2"},
+            {"content": "Task 3", "status": "pending", "activeForm": "Task 3"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Should use flat format
+        self.assertIn("📋 Todo List:", output)
+        self.assertIn("Task 1", output)
+        self.assertIn("Working on Task 2", output)
+        self.assertIn("Task 3", output)
+
+    def test_mixed_old_and_new_format(self):
+        """Test mixing old and new todo formats."""
+        todos = [
+            {"content": "PHASE 1: PLANNING - New format task", "status": "completed", "activeForm": "Done"},
+            {"content": "Old format task", "status": "pending", "activeForm": "Pending"},
+        ]
+
+        output = self.auto_mode._format_todos_for_terminal(todos)
+
+        # Should handle both formats gracefully
+        self.assertIn("PHASE 1", output)
+        self.assertIn("New format task", output)
+        self.assertIn("Other Tasks:", output)
+        self.assertIn("Old format task", output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements workflow-aware todo list display with phase grouping and progress indicators, addressing issue #1103.

### Problem Statement
During long-running Ultra-Think sessions, users cannot easily tell:
- Which workflow phase they're currently in
- How much progress has been made
- What phase comes next
- Why tasks happen in a specific order

### Solution
Enhanced TodoWrite display to detect and group tasks by workflow phase using a convention-based approach:

```
PHASE N: [Phase Name] - [Task Description]
```

### Key Features

**Phase Grouping**
- Automatically detects phase information from todo content
- Groups tasks under phase headers with clear visual hierarchy
- Shows phase completion status (COMPLETED, IN PROGRESS, PENDING)

**Progress Indicators**
- Phase-level progress: "2/3 tasks complete"
- Overall progress: "8/15 tasks (53%)"
- Visual status icons: ✅ (completed), ⏳ (in progress), ○ (pending)

**Backward Compatibility**
- Falls back to original flat list format when no phase patterns detected
- Mixed phased/ungrouped todos handled gracefully
- Zero breaking changes to existing code

### Example Output

```
📋 WORKFLOW PROGRESS

🎯 PHASE 1: PLANNING [✅ COMPLETED - 4/4 tasks]
  ✓ Clarify TodoWrite enhancement requirements
  ✓ Use analyzer agent to understand existing implementation
  ✓ Verify issue #1103 exists
  ✓ Create worktree and branch

🎯 PHASE 2: DESIGN [✅ COMPLETED - 1/1 tasks]
  ✓ Use architect agent to design solution

🎯 PHASE 3: IMPLEMENTATION [⏳ IN PROGRESS - 1/2 tasks]
  ✓ Use tester agent to write failing tests (TDD)
  ⏳ Use builder agent to implement changes (ACTIVE)

🎯 PHASE 4: REFACTORING [○ PENDING - 0/1 tasks]
  ○ Use cleanup agent to simplify

Overall Progress: 6/8 tasks (75%)
```

### Implementation Details

**New Methods Added**
1. `_extract_phase_info()` - Detects phase pattern using regex
2. `_group_todos_by_phase()` - Groups todos and calculates progress
3. Enhanced `_format_todos_for_terminal()` - Displays phase-grouped format

**Architecture**
- Convention-based approach (no SDK changes required)
- Pure functions with clear separation of concerns
- Linear complexity O(n) - efficient for typical todo counts

### Testing

**Comprehensive Test Suite**
- 26 unit tests covering all functionality
- Tests for phase detection, grouping, formatting
- Backward compatibility validation
- Edge cases (empty lists, mixed formats, special characters)
- All tests passing

**Test Coverage**
- Phase detection with various patterns
- Progress calculation accuracy
- Status indicators (completed, in_progress, pending)
- Fallback behavior
- ANSI formatting

### Benefits

**User Experience**
- Reduces anxiety during long sessions (users know where they are)
- Clear progress visibility reduces "are we there yet?" questions
- Better understanding of workflow structure
- Improved trust through transparency

**Operational**
- Enables phase-level timing analysis
- Better metrics for workflow optimization
- Clearer bug reports with phase context
- Self-documenting workflow execution

### Philosophy Compliance

**Ruthless Simplicity**
- Convention over configuration
- Pattern-based detection (no complex metadata)
- Graceful fallback when patterns not used

**Zero-BS Implementation**
- No stubs or placeholders
- Complete, working implementation
- All tests passing

**Modular Design**
- Clear separation: detection → grouping → formatting
- Pure functions with well-defined contracts
- Regeneratable from specification

### Files Changed

- `src/amplihack/launcher/auto_mode.py` - Implementation (+203 lines)
- `tests/unit/test_todowrite_phase_grouping.py` - Comprehensive tests (NEW)
- `Specs/TodoWritePhaseGrouping.md` - Full architectural specification (NEW)

### Related Issues

Closes #1103

### Test Plan

- [x] Unit tests pass (26 tests, all passing)
- [x] Pre-commit hooks pass (formatting applied)
- [x] Manual testing with phase-grouped todos
- [x] Backward compatibility verified with old-format todos
- [x] Mixed format todos handled correctly
- [ ] CI checks passing (will verify after PR creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)