### PR TITLE
fix: Add missing pytest-asyncio configuration to resolve async test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ exclude = [
 
 [tool.pytest.ini_options]
 # Pytest configuration
+asyncio_mode = "auto"
 testpaths = ["tests", "src"]
 python_files = ["test_*.py", "*_test.py"]
 python_functions = ["test_*"]


### PR DESCRIPTION
## Summary

- Adds `asyncio_mode = "auto"` to `pyproject.toml` under `[tool.pytest.ini_options]`
- Resolves 245+ async test failures in PR #669
- Enables pytest-asyncio to automatically detect and handle async test functions

## Problem

PR #669 introduced 245+ async test failures because pytest-asyncio was installed but missing the required configuration. Without `asyncio_mode = "auto"`, pytest-asyncio doesn't automatically recognize async test functions.

## Solution

Added a single line to `pyproject.toml`:
```toml
asyncio_mode = "auto"
```

This configuration tells pytest-asyncio to automatically detect async test functions without requiring explicit markers or manual configuration on each test.

## Test Plan

- [x] Configuration added to pyproject.toml
- [x] Pre-commit hooks pass
- [ ] Verify CI tests pass (automatic in this PR)
- [ ] Confirms this unblocks PR #669

## Related Issues

Fixes #672

Generated with [Claude Code](https://claude.com/claude-code)