### PR TITLE
fix: Integrate Neo4j credential detection into launcher startup (Issue #1190)

### DIFF
--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -85,37 +85,40 @@ class ClaudeLauncher:
         if not check_prerequisites():
             return False
 
-        # 2. Interactive Neo4j startup (blocks until ready or user decides)
+        # 2. Check and sync Neo4j credentials from existing containers (if any)
+        self._check_neo4j_credentials()
+
+        # 3. Interactive Neo4j startup (blocks until ready or user decides)
         if not self._interactive_neo4j_startup():
             # User chose to exit rather than continue without Neo4j
             return False
 
-        # 3. Handle repository checkout if needed
+        # 4. Handle repository checkout if needed
         if self.checkout_repo:
             if not self._handle_repo_checkout():
                 return False
 
-        # 3. Find and validate target directory
+        # 5. Find and validate target directory
         target_dir = self._find_target_directory()
         if not target_dir:
             print("Failed to determine target directory")
             return False
 
-        # 4. Ensure required runtime directories exist
+        # 6. Ensure required runtime directories exist
         if not self._ensure_runtime_directories(target_dir):
             print("Warning: Could not create runtime directories")
             # Don't fail - just warn
 
-        # 5. Fix hook paths in settings.json to use absolute paths
+        # 7. Fix hook paths in settings.json to use absolute paths
         if not self._fix_hook_paths_in_settings(target_dir):
             print("Warning: Could not fix hook paths in settings.json")
             # Don't fail - hooks might still work
 
-        # 6. Handle directory change if needed (unless UVX with --add-dir)
+        # 8. Handle directory change if needed (unless UVX with --add-dir)
         if not self._handle_directory_change(target_dir):
             return False
 
-        # 7. Start proxy if needed
+        # 9. Start proxy if needed
         return self._start_proxy_if_needed()
 
     def _handle_repo_checkout(self) -> bool:


### PR DESCRIPTION
## Summary

Fixes integration bug where PR #1174's Neo4j credential detection code existed but was never called during launcher startup.

Resolves #1190

## Problem

PR #1174 merged the `Neo4jManager` class and credential detection functionality, but the code was never integrated into the launcher's startup flow. The `_check_neo4j_credentials()` method existed but was never invoked in `prepare_launch()`, causing:

- Authentication failures with existing containers
- Container name conflicts
- No credential sync prompts shown to users

## Root Cause Analysis

1. PR #1174 was merged to main after branch `feat/fix-auto-mode-import` was created
2. After merging main into the branch, the code existed but lacked integration
3. The `_check_neo4j_credentials()` method at line 771 was never called

## Solution

**Files Changed:**
- `src/amplihack/launcher/core.py`: Added call to `self._check_neo4j_credentials()` in `prepare_launch()` at line 89, before Neo4j startup wizard

**Integration Point:**
```python
# 2. Check and sync Neo4j credentials from existing containers (if any)
self._check_neo4j_credentials()

# 3. Interactive Neo4j startup (blocks until ready or user decides)
if not self._interactive_neo4j_startup():
    return False
```

## Testing Completed

### Unit Tests
- ✅ 44/44 tests passed in `test_neo4j_container_detection.py`
- ✅ All pre-commit hooks passed

### Integration Tests
- ✅ Verified `Neo4jManager.check_and_sync()` works with existing container
- ✅ Verified `prepare_launch()` calls `_check_neo4j_credentials()`
- ✅ Tested with running container having different credentials
- ✅ Credential detection triggers correctly

### Code Review
- ✅ Architect agent review: Grade A
- ✅ Cleanup agent review: No simplification needed
- ✅ Philosophy compliance: Ruthless simplicity maintained

## Impact

- **Minimal**: Single line addition + comment renumbering
- **Safe**: Graceful degradation maintains launcher stability
- **Tested**: Full test coverage + integration verification

## Test Plan for Reviewers

1. Ensure existing Neo4j container with different credentials exists:
   ```bash
   docker ps -a | grep amplihack-neo4j
   docker inspect amplihack-neo4j | grep NEO4J_AUTH
   ```

2. Run `amplihack launch` and verify:
   - No crashes during startup
   - Credential detection runs silently (non-interactive mode)
   - Neo4j starts successfully

## Philosophy Compliance

- ✅ Ruthless simplicity: One functional line added
- ✅ Zero-BS: No stubs, complete functionality
- ✅ Modular design: Clean delegation to Neo4jManager
- ✅ Graceful degradation: Silent failure for optional feature

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>