### PR TITLE
fix: Add blarify as project dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "claude-agent-sdk>=0.1.0", # Claude Python Agent SDK for auto mode streaming
     "rich>=13.0.0", # Required for --ui interactive TUI mode
     "neo4j>=5.15.0,<6.0.0", # Neo4j driver for memory system
+    "blarify>=1.3.0", # Code understanding engine for indexing codebases
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes #1200 - Adds blarify as a required project dependency

## Problem

The Code Understanding Engine requires `blarify` to analyze codebases and create knowledge graphs in Neo4j. However, blarify wasn't declared as a project dependency in `pyproject.toml`, meaning:

- Users had to manually install blarify after installing amplihack
- The Code Understanding Engine failed on first startup with error:
  ```
  blarify not found. Install with: pip install blarify
  ⚠️  Indexing failed: Blarify execution failed
  ```
- Poor out-of-box user experience

## Solution

Added `blarify>=1.3.0` to the dependencies list in `pyproject.toml` so it's automatically installed when users install amplihack.

## Changes

**File**: `pyproject.toml`
- Added `blarify>=1.3.0` to the `dependencies` array (line 22)
- Added comment explaining its purpose: "Code understanding engine for indexing codebases"

## Testing

- [x] Verified pyproject.toml is valid TOML (parsed successfully with tomllib)
- [x] Confirmed blarify dependency is in the list
- [x] Will be automatically installed on next `pip install -e .` or `pip install amplihack`
- [ ] CI will verify the dependency installs correctly

## Impact

After this PR merges:
- ✅ New users get blarify automatically with amplihack installation
- ✅ Code Understanding Engine works out of the box
- ✅ No manual installation steps required
- ✅ Better user experience during startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>