### PR TITLE
feat: Simple PreToolUse hook to prevent git --no-verify

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/tools/amplihack/hooks/pre_tool_use.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "*",

--- a/.claude/tools/amplihack/hooks/pre_tool_use.py
+++ b/.claude/tools/amplihack/hooks/pre_tool_use.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Claude Code hook for pre tool use events.
+Prevents dangerous operations like git commit --no-verify.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).parent))
+from hook_processor import HookProcessor
+
+
+class PreToolUseHook(HookProcessor):
+    """Hook processor for pre tool use events."""
+
+    def __init__(self):
+        super().__init__("pre_tool_use")
+
+    def process(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Process pre tool use event and block dangerous operations.
+
+        Args:
+            input_data: Input from Claude Code containing tool use details
+
+        Returns:
+            Dict with 'block' key set to True if operation should be blocked
+        """
+        tool_use = input_data.get("toolUse", {})
+        tool_name = tool_use.get("name", "")
+        tool_input = tool_use.get("input", {})
+
+        # Check for git commit --no-verify in Bash commands
+        if tool_name == "Bash":
+            command = tool_input.get("command", "")
+
+            # Block --no-verify flag in any git command
+            if "--no-verify" in command and ("git commit" in command or "git push" in command):
+                self.log(f"BLOCKED: Dangerous operation detected: {command}", "ERROR")
+
+                return {
+                    "block": True,
+                    "message": """
+🚫 OPERATION BLOCKED
+
+You attempted to use --no-verify which bypasses critical quality checks:
+- Code formatting (ruff, prettier)
+- Type checking (pyright)
+- Secret detection
+- Trailing whitespace fixes
+
+This defeats the purpose of our quality gates.
+
+✅ Instead, fix the underlying issues:
+1. Run: pre-commit run --all-files
+2. Fix the violations
+3. Commit without --no-verify
+
+For true emergencies, ask a human to override this protection.
+
+🔒 This protection cannot be disabled programmatically.
+""".strip(),
+                }
+
+        # Allow all other operations
+        return {}
+
+
+def main():
+    """Entry point for the pre tool use hook."""
+    hook = PreToolUseHook()
+    hook.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements issue #836 with the CORRECT, simple solution: a PreToolUse hook that intercepts Bash commands and blocks any containing `--no-verify`.

## Problem (Issue #836)

Developers can bypass pre-commit hooks using `git commit --no-verify`, which skips critical quality checks:
- Code formatting (ruff, prettier)
- Type checking (pyright)
- Secret detection
- Trailing whitespace fixes

## Solution

A PreToolUse hook that:
1. Intercepts Bash tool calls BEFORE they execute
2. Checks if the command contains `--no-verify`
3. Blocks it with a clear error message
4. Provides remediation guidance

## Implementation

**File**: `.claude/tools/amplihack/hooks/pre_tool_use.py` (70 lines)
- Extends HookProcessor
- Checks Bash commands for `--no-verify`
- Returns `{"block": True}` if detected
- Provides clear error message with remediation

**File**: `.claude/settings.json`
- Registers PreToolUse hook for Bash tool matcher
- Automatic activation - no manual installation needed

## Testing

✅ Hook blocks `git commit --no-verify`
✅ Hook blocks `git push --no-verify`
✅ Clear error message with remediation steps
✅ Only human can override (must manually remove from settings.json)

## Philosophy Compliance

- **Ruthless Simplicity**: 70 lines, single responsibility, one clear purpose
- **Zero-BS**: No complex parallel execution, no quality checkers, just works
- **Elegant**: Solves at the right level (Claude Code intercepts, not git hooks)

Fixes #836

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>