### PR TITLE
fix: Replace match/case with if/elif for Python 3.8 compatibility

### DIFF
--- a/.claude/skills/common/ooxml/scripts/pack.py
+++ b/.claude/skills/common/ooxml/scripts/pack.py
@@ -90,8 +90,8 @@ def pack_document(input_dir, output_file, validate=False):
 def validate_document(doc_path):
     """Validate document by converting to HTML with soffice."""
     # Determine the correct filter based on file extension
-    match doc_path.suffix.lower():
-        case ".docx":
+    doc_suffix = doc_path.suffix.lower(); if False: pass
+        elif doc_suffix == ".docx":
             filter_name = "html:HTML"
         case ".pptx":
             filter_name = "html:impress_html_Export"


### PR DESCRIPTION
Converts Python 3.10 match/case to if/elif