### PR TITLE
fix: Suppress Neo4j unknown label/property warnings on first startup

### DIFF
--- a/src/amplihack/memory/neo4j/connector.py
+++ b/src/amplihack/memory/neo4j/connector.py
@@ -14,9 +14,18 @@ try:
     from neo4j import GraphDatabase
     from neo4j.exceptions import Neo4jError, ServiceUnavailable
 
+    # Import NotificationDisabledCategory for suppressing warnings
+    try:
+        from neo4j import NotificationDisabledCategory
+        NOTIFICATION_CATEGORIES_AVAILABLE = True
+    except ImportError:
+        # Older versions of neo4j driver may not have this
+        NOTIFICATION_CATEGORIES_AVAILABLE = False
+
     NEO4J_AVAILABLE = True
 except ImportError:
     NEO4J_AVAILABLE = False
+    NOTIFICATION_CATEGORIES_AVAILABLE = False
 
     # Create placeholder classes for when neo4j not installed
     class GraphDatabase:
@@ -230,7 +239,16 @@ class Neo4jConnector:
             return self  # Already connected
 
         try:
-            self._driver = GraphDatabase.driver(self.uri, auth=(self.user, self.password))
+            # Configure driver with warning suppression if available
+            # This suppresses warnings about unknown labels/properties on first startup
+            driver_kwargs = {"auth": (self.user, self.password)}
+
+            if NOTIFICATION_CATEGORIES_AVAILABLE:
+                driver_kwargs["notifications_disabled_categories"] = {
+                    NotificationDisabledCategory.UNKNOWN,  # Suppress unknown label/property warnings
+                }
+
+            self._driver = GraphDatabase.driver(self.uri, **driver_kwargs)
             logger.debug("Connected to Neo4j: %s", self.uri)
             return self
 


### PR DESCRIPTION
## Summary

Fixes issue #1303 - Suppresses Neo4j UnknownLabelWarning and UnknownPropertyKeyWarning on first startup.

**Problem:**
During first startup with an empty Neo4j database, users see confusing warnings:
```
Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.UnknownLabelWarning}
{description: One of the labels in your query is not available in the database...the missing label name is: CodeIndexMetadata}

Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.UnknownPropertyKeyWarning}
{description: One of the property names in your query is not available in the database...the missing property name is: last_updated}
```

These warnings are expected behavior (database is empty on first run) but confuse users into thinking something is broken.

**Solution:**
Configure Neo4j driver to suppress UNKNOWN notification category warnings. This includes warnings about missing labels and properties that are normal during first startup before the schema is created.

**Changes:**
- Import `NotificationDisabledCategory` from neo4j driver
- Configure driver with `notifications_disabled_categories={UNKNOWN}` to suppress unknown label/property warnings
- Maintain backward compatibility with older neo4j versions that don't have this feature

**Files Modified:**
- `/home/azureuser/src/amplihack/src/amplihack/memory/neo4j/connector.py`

## Test plan

- [x] Syntax check passes
- [x] Changes committed to fix branch
- [ ] Test with: `uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding@fix/issue-1303-neo4j-warnings amplihack` in clean tmp directory
- [ ] Verify no warnings during first startup with fresh Neo4j container
- [ ] Verify database initialization completes successfully

**Testing Notes:**
The uvx installation command should be tested in a clean environment with a fresh Neo4j container to verify warnings are suppressed.

## Expected Outcome

Clean output during first startup showing database is ready without any UnknownLabel or UnknownPropertyKey warnings.

Generated with [Claude Code](https://claude.com/claude-code)