### PR TITLE
fix: Enable import sorting (I001) in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,6 @@ repos:
           - --ignore=C414,C401
           - --ignore=ERA001
           - --ignore=A001,A002,A004
-          - --ignore=I001
           - --ignore=PIE810
       - id: ruff-format
 


### PR DESCRIPTION
Removes I001 from ignore list. Imports will now be auto-sorted on commit.