### PR TITLE
fix: Add missing .claude subdirectories to ESSENTIAL_DIRS (Issue #1312)

### DIFF
--- a/src/amplihack/__init__.py
+++ b/src/amplihack/__init__.py
@@ -18,6 +18,13 @@ ESSENTIAL_DIRS = [
     "tools/xpia",  # XPIA security hooks (Issue #458)
     "context",  # Philosophy, patterns, project info
     "workflow",  # DEFAULT_WORKFLOW.md
+    "skills",  # Claude Code Skills (12 production skills)
+    "templates",  # Investigation & architecture doc templates
+    "scenarios",  # Production scenario tools
+    "docs",  # Investigation examples and documentation
+    "schemas",  # JSON/YAML schemas for validation
+    "config",  # Configuration files for tools
+    "data",  # Learning paths and reference data
 ]
 
 # Runtime directories that need to be created
@@ -538,7 +545,7 @@ def _local_install(repo_root):
     # Step 3.5: Smart PROJECT.md initialization
     print("\n📝 Initializing PROJECT.md:")
     try:
-        from .utils.project_initializer import initialize_project_md, InitMode
+        from .utils.project_initializer import InitMode, initialize_project_md
 
         # Use FORCE mode during installation to fix amplihack-describing PROJECT.md
         result = initialize_project_md(Path(CLAUDE_DIR).parent, mode=InitMode.FORCE)
@@ -549,7 +556,7 @@ def _local_install(repo_root):
             elif result.action_taken.value == "offered":
                 print(f"   ℹ️  {result.message}")
             else:
-                print(f"   ✅ PROJECT.md valid (skipped)")
+                print("   ✅ PROJECT.md valid (skipped)")
         else:
             print(f"   ⚠️  {result.message}")
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes bug where 7 production .claude subdirectories were not being copied during uvx installation, including the user-reported **skills/** directory.

## Problem

When running `uvx --from git+https://github.com/...`, the following directories were missing from `$HOME/.claude`:

- **skills/** (12 production Claude Code Skills) ← User explicitly reported
- templates/ (investigation & architecture doc templates)
- scenarios/ (production scenario tools)
- docs/ (investigation examples and documentation)
- schemas/ (JSON/YAML validation schemas)
- config/ (tool configuration files)
- data/ (learning paths and reference data)

## Root Cause

The `ESSENTIAL_DIRS` constant in `src/amplihack/__init__.py:14-21` only included 6 directories:

```python
ESSENTIAL_DIRS = [
    "agents/amplihack",
    "commands/amplihack",
    "tools/amplihack",
    "tools/xpia",
    "context",
    "workflow",
]
```

The `copytree_manifest()` function (lines 143-163) only copies directories listed in `ESSENTIAL_DIRS` to `$HOME/.claude` during installation.

## Solution

Added all 7 missing production directories to `ESSENTIAL_DIRS`:

```python
ESSENTIAL_DIRS = [
    "agents/amplihack",
    "commands/amplihack",
    "tools/amplihack",
    "tools/xpia",
    "context",
    "workflow",
    "skills",        # NEW
    "templates",     # NEW
    "scenarios",     # NEW
    "docs",          # NEW
    "schemas",       # NEW
    "config",        # NEW
    "data",          # NEW
]
```

## Changes

**Files Modified:** 1
- `src/amplihack/__init__.py` - Added 7 directories to ESSENTIAL_DIRS

**Lines Changed:** +9, -2

## Testing

- ✅ Verified all 7 directories exist in repo
- ✅ Pre-commit hooks passed
- ✅ Total directories in ESSENTIAL_DIRS: 13 (was 6)
- 🔄 CI will verify packaging and installation

## Impact

- **Fixes:** User-reported bug where skills/ directory is missing
- **Scope:** ALL uvx installations will now include complete .claude structure
- **Risk:** Low (additive change, no logic modifications)

## Related

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>