### PR TITLE
fix: Prevent SystemExit race condition during graceful shutdown (Issue #1314)

### DIFF
--- a/.claude/tools/amplihack/hooks/hook_processor.py
+++ b/.claude/tools/amplihack/hooks/hook_processor.py
@@ -142,6 +142,11 @@ class HookProcessor(ABC):
         Raises:
             json.JSONDecodeError: If input is not valid JSON
         """
+        # Skip stdin read during interrupt shutdown to avoid SystemExit race condition
+        if os.environ.get("AMPLIHACK_SHUTDOWN_IN_PROGRESS") == "1":
+            self.log("Skipping stdin read during shutdown", "DEBUG")
+            return {}
+
         raw_input = sys.stdin.read()
         if not raw_input.strip():
             return {}

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -603,6 +603,8 @@ class ClaudeLauncher:
                 print("\nReceived interrupt signal. Shutting down...")
                 if self.proxy_manager:
                     self.proxy_manager.stop_proxy()
+                # Set flag to prevent stdin reads during shutdown (avoids SystemExit race)
+                os.environ["AMPLIHACK_SHUTDOWN_IN_PROGRESS"] = "1"
                 sys.exit(0)
 
             signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
## Summary

Fixes race condition where pressing Ctrl+C causes `SystemExit` exception in atexit callback, producing an ugly stack trace.

## Problem

When users press Ctrl+C:
1. Signal handler calls `sys.exit(0)`
2. atexit triggers `_cleanup_on_exit` callback
3. Stop hook tries to read from stdin via `sys.stdin.read()`
4. The pending `sys.exit(0)` interrupts stdin read → **SystemExit exception**

**Before Fix:**
```
^C
Received interrupt signal. Shutting down...
Exception ignored in atexit callback: <bound method ClaudeLauncher._cleanup_on_exit...>
Traceback (most recent call last):
  ...
  File ".../hook_processor.py", line 145, in read_input
    raw_input = sys.stdin.read()
SystemExit: 0
```

## Solution

Add shutdown flag to skip stdin reads during interrupt:

1. **Signal Handler**: Set `AMPLIHACK_SHUTDOWN_IN_PROGRESS=1` before `sys.exit(0)`
2. **Hook Processor**: Check flag in `read_input()`, return `{}` if shutdown in progress
3. **Result**: No stdin read attempted, no SystemExit exception

**After Fix:**
```
^C
Received interrupt signal. Shutting down...
(Clean exit, no exception)
```

## Changes

**Files Modified:** 3
- `src/amplihack/launcher/core.py` - Set shutdown flag in signal handler
- `.claude/tools/amplihack/hooks/hook_processor.py` - Check flag, skip stdin
- `tests/unit/test_hook_processor_run.py` - Add 2 unit tests

**Lines Changed:** +71 insertions

## Testing

- ✅ Pre-commit hooks passed
- ✅ Unit tests added for shutdown flag behavior
- 🔄 CI will run full test suite
- 📋 Manual verification needed: Press Ctrl+C and verify no stack trace

## Philosophy Compliance

- **Ruthless Simplicity**: 2-line changes per file, minimal complexity
- **Zero-BS**: No stubs, works immediately
- **Modular**: Clean separation via environment variable
- **Clear**: Comments explain the "why"

## Impact

- **Severity**: Medium (cosmetic but poor UX)
- **Users Affected**: All users who press Ctrl+C
- **Risk**: Low (additive change, only affects interrupt path)
- **Cleanup**: All cleanup functionality preserved

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>