### PR TITLE
fix: Set shutdown flag in atexit to prevent stop hook hang and traceback

### DIFF
--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -842,6 +842,9 @@ class ClaudeLauncher:
         without receiving signals. Executes stop hook silently.
         """
         try:
+            # Set flag to prevent stdin reads during shutdown (avoids hang + traceback)
+            os.environ["AMPLIHACK_SHUTDOWN_IN_PROGRESS"] = "1"
+
             from amplihack.hooks.manager import execute_stop_hook
 
             execute_stop_hook()


### PR DESCRIPTION
## Summary

Fixes #1320 - Stop hook hangs on exit and shows Ctrl-C traceback despite previous fix attempt.

## Problem

When Claude exits normally, the stop hook hangs waiting for stdin input. When user presses Ctrl-C, a SystemExit traceback appears even though there was a previous fix to prevent this.

**Error observed**:
```
Claude session completed
^C
Received interrupt signal. Shutting down...
Exception ignored in atexit callback:
Traceback (most recent call last):
  File "...core.py", line 847, in _cleanup_on_exit
    execute_stop_hook()
  ...
  File "...hook_processor.py", line 145, in read_input
    raw_input = sys.stdin.read()  # <-- HANGS HERE
  File "...core.py", line 608, in signal_handler
    sys.exit(0)
SystemExit: 0
```

## Root Cause

The previous fix was **incomplete**. The `AMPLIHACK_SHUTDOWN_IN_PROGRESS` flag check exists in `hook_processor.py` (lines 146-148), but the flag is only set in ONE of TWO places:

1. ✅ `signal_handler()` (core.py:607) - **DOES** set the flag
2. ❌ `_cleanup_on_exit()` (core.py:845) - **DOES NOT** set the flag ← **THE BUG**

When Claude exits normally (not via signal), `_cleanup_on_exit()` runs from atexit but never sets the flag, so the stop hook tries to read from stdin and hangs.

## Solution

Set `os.environ["AMPLIHACK_SHUTDOWN_IN_PROGRESS"] = "1"` in `_cleanup_on_exit()` BEFORE calling `execute_stop_hook()`.

**One-line fix** (core.py:844):
```python
def _cleanup_on_exit(self):
    try:
        # ADD THIS LINE:
        os.environ["AMPLIHACK_SHUTDOWN_IN_PROGRESS"] = "1"
        
        from amplihack.hooks.manager import execute_stop_hook
        execute_stop_hook()
    except Exception:
        pass
```

## Changes

- **Modified**: `src/amplihack/launcher/core.py` (1 line added)
  - Added flag setting in `_cleanup_on_exit()` before stop hook execution

## Testing

**Verification Test**:
```
✓ Fix verified: AMPLIHACK_SHUTDOWN_IN_PROGRESS flag is set in _cleanup_on_exit
✓ Fix uses os.environ to set the flag
✓ All verification checks passed!
```

**Expected Behavior After Fix**:
1. Claude exits normally → atexit runs
2. `_cleanup_on_exit()` sets AMPLIHACK_SHUTDOWN_IN_PROGRESS=1
3. Stop hook checks flag → skips stdin read
4. Clean exit with no hang, no traceback ✓

## Impact

- Affects every user on every session exit
- Fixes annoying hang and ugly traceback
- Improves user experience significantly

## Philosophy Compliance

- ✅ **Ruthless Simplicity**: One-line fix
- ✅ **Zero-BS**: Complete fix, no stub or partial solution  
- ✅ **Clear Intent**: Comment explains why flag is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)