### PR TITLE
fix: Prevent Neo4j container setup prompt at session end

### DIFF
--- a/.claude/tools/amplihack/hooks/stop.py
+++ b/.claude/tools/amplihack/hooks/stop.py
@@ -191,10 +191,9 @@ class StopHook(HookProcessor):
 
             # Initialize components with credentials from environment
             # Note: Connection tracker will raise ValueError if password not set and
-            # NEO4J_ALLOW_DEFAULT_PASSWORD != "true". This is intentional for production security.
+            # NEO4J_ALLOW_DEFAULT_PASSWORD != "true". This is intentional for production security.  # pragma: allowlist secret
             tracker = Neo4jConnectionTracker(
-                username=os.getenv("NEO4J_USERNAME"),
-                password=os.getenv("NEO4J_PASSWORD")
+                username=os.getenv("NEO4J_USERNAME"), password=os.getenv("NEO4J_PASSWORD")
             )
             manager = Neo4jContainerManager()
             coordinator = Neo4jShutdownCoordinator(

--- a/src/amplihack/memory/neo4j/container_selection.py
+++ b/src/amplihack/memory/neo4j/container_selection.py
@@ -340,7 +340,9 @@ def resolve_container_name(
     if cleanup_mode:
         # During cleanup, silently use default without any prompts
         default_name = get_default_container_name(context.current_dir)
-        logger.info("Cleanup mode detected: Using default container without prompt: %s", default_name)
+        logger.info(
+            "Cleanup mode detected: Using default container without prompt: %s", default_name
+        )
         return default_name
 
     # Priority 3: Auto mode or Interactive selection
@@ -354,6 +356,7 @@ def resolve_container_name(
     # Interactive mode: Use unified dialog (combines container selection + credential sync)
     try:
         from .unified_startup_dialog import unified_container_and_credential_dialog
+
         container_name = unified_container_and_credential_dialog(default_name, auto_mode=False)
         if container_name:
             return container_name


### PR DESCRIPTION
## Summary

Fixes #1347 - Prevents the Neo4j Container Setup dialog from appearing when ending a Claude session.

## Problem

Users were incorrectly prompted with the Neo4j Container Setup dialog at session END:

```
Claude session completed

======================================================================
Neo4j Container Setup
======================================================================

Existing containers:
  1. ✓ amplihack-fix-issue-1341-preference-mechanism (Up 41 minutes)
     ...
```

This prompt should ONLY appear at session START (when selecting which container to use), NOT at session END (when deciding whether to shut down).

## Root Cause

1. The `stop.py` hook's `_handle_neo4j_cleanup()` creates a `Neo4jContainerManager` instance
2. `Neo4jContainerManager.__init__()` calls `get_config()` which triggers container name resolution
3. Container name resolution showed an interactive dialog during cleanup
4. Environment variable inconsistency:
   - stop.py line 179: checked `AMPLIHACK_AUTO_MODE == "true"` 
   - container_selection.py line 313: checked `AMPLIHACK_AUTO_MODE == "1"`
   - These didn't match, so auto_mode didn't propagate correctly

## Solution

1. **stop.py**: Set `AMPLIHACK_CLEANUP_MODE=1` before creating Neo4j components
2. **container_selection.py**: Check for cleanup mode and skip all prompts (Priority 2.5)
3. **stop.py**: Standardize `AMPLIHACK_AUTO_MODE` format to "1"/"0"

## Changes

### `.claude/tools/amplihack/hooks/stop.py`
- Set `AMPLIHACK_CLEANUP_MODE=1` at start of `_handle_neo4j_cleanup()`
- Standardize auto_mode check to `"0" == "1"` format

### `src/amplihack/memory/neo4j/container_selection.py`
- Add Priority 2.5: Cleanup mode check before interactive selection
- Skip all prompts when `AMPLIHACK_CLEANUP_MODE=1`

## Testing

Manual testing required:
1. End a Claude session with Neo4j running
2. Verify NO container setup prompt appears
3. Verify shutdown prompt still appears (if `neo4j_auto_shutdown: ask`)
4. Verify startup container selection still works

## Impact

- **User Impact**: HIGH - Fixes blocking UX bug that interrupts normal workflow
- **Risk**: LOW - Changes isolated to cleanup flow, startup behavior unchanged
- **Breaking Changes**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>