### PR TITLE
fix: Relax power-steering path validation and improve error visibility

### DIFF
--- a/.claude/tools/amplihack/hooks/stop.py
+++ b/.claude/tools/amplihack/hooks/stop.py
@@ -122,6 +122,11 @@ class StopHook(HookProcessor):
                 self.log(f"Power-steering error (fail-open): {e}", "WARNING")
                 self.save_metric("power_steering_errors", 1)
 
+                # Surface error to user via stderr for visibility
+                print("\n⚠️  Power-Steering Warning", file=sys.stderr)
+                print(f"Power-steering encountered an error and was skipped: {e}", file=sys.stderr)
+                print("Check .claude/runtime/power-steering/power_steering.log for details", file=sys.stderr)
+
         # Check if reflection should run
         if not self._should_run_reflection():
             self.log("Reflection not enabled or skipped - allowing stop")
@@ -228,11 +233,7 @@ class StopHook(HookProcessor):
             self.log(f"Neo4j cleanup handler started (auto_mode={auto_mode})")
 
             # Initialize components with credentials from environment
-<<<<<<< HEAD
-            # Note: Connection tracker will raise ValueError if password not set and
-=======
             # Note: Connection tracker will raise ValueError if password not set and  # pragma: allowlist secret
->>>>>>> origin/main
             # NEO4J_ALLOW_DEFAULT_PASSWORD != "true". This is intentional for production security.  # pragma: allowlist secret
             tracker = Neo4jConnectionTracker(
                 username=os.getenv("NEO4J_USERNAME"), password=os.getenv("NEO4J_PASSWORD")


### PR DESCRIPTION
## Summary

Fixes power-steering mode path validation bug that prevented it from working with Claude Code's transcript storage location.

Closes #1383

## Problem

Power-steering was **enabled but failing silently** due to overly strict path validation:
- Only allowed: project root and temp directories (/tmp, /var/tmp)
- Rejected: `~/.claude/projects/` (where Claude Code stores transcripts)
- Impact: Power-steering loaded 21 considerations but couldn't analyze sessions

**Error:**
```
Transcript path /home/azureuser/.claude/projects/.../session.jsonl is outside project root
```

## Solution

### 1. Relax Path Validation ✅

Updated `_validate_path()` in `power_steering_checker.py` to allow:
- ✅ User's home directory (`Path.home()`) - **NEW**
- ✅ Project root (backward compatibility)
- ✅ Temp directories (backward compatibility)

**Security Analysis:**
- Power-steering only READ files (no writes)
- User explicitly requested permissive validation
- No privilege escalation risk
- Running as user, accessing user files
- Fail-open design prevents abuse

**User Requirement:**
> "I'm super not interested in strict path validation - the required files and folders might be in /tmp or anywhere in the users homedir etc."

### 2. Improve Error Visibility ✅

Added stderr output in `stop.py` when power-steering fails:
```python
print("\n⚠️  Power-Steering Warning", file=sys.stderr)
print(f"Power-steering encountered an error and was skipped: {e}", file=sys.stderr)
print("Check .claude/runtime/power-steering/power_steering.log for details", file=sys.stderr)
```

### 3. Comprehensive Testing ✅

Added 5 new tests in `test_security_features.py`:
- `test_validate_path_in_home_directory` - Home directory paths allowed
- `test_validate_path_claude_projects_directory` - Claude Code paths allowed
- `test_validate_path_temp_directories` - Temp directory paths still work
- `test_validate_path_truly_outside_all_allowed` - Rejection still works
- Updated `test_validate_path_with_symlink_escape` - Symlinks to /tmp allowed
- Updated `test_load_transcript_validates_path` - Validation still enforced

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `power_steering_checker.py` | +39, -4 | Relaxed path validation logic |
| `stop.py` | +5 | Added stderr error output |
| `test_security_features.py` | +82, -10 | Comprehensive test coverage |
| `DISCOVERIES.md` | +86 | Documented bug and solution |

## Testing

### Manual Verification ✅
```python
Test 1 - Project root path: True (expected: True)
Test 2 - Home directory path: True (expected: True)
Test 3 - /tmp path: True (expected: True)
Test 4 - /etc path: False (expected: False)

✅ All tests passed!
```

### CI Tests
- Unit tests for path validation
- Security boundary tests
- Backward compatibility tests

## Backward Compatibility

✅ **All existing use cases still work:**
- Project root paths: Still validated (Check 1)
- Temp directory paths: Still validated (Check 3)
- **NEW**: Home directory paths now work (Check 2)

## Reviewer Notes

**Security Trade-off:**
- Now allows reading ANY file in user's home directory
- This was explicitly requested by user
- Power-steering only reads, never writes
- User already has read access to their own files
- No real security risk for this use case

**Merge Conflict:**
- Resolved merge conflict in stop.py (pragma comment)

## Test Plan

- [x] Manual verification of path validation logic
- [x] Unit tests for home directory validation
- [x] Backward compatibility with existing paths
- [x] Error visibility improvement
- [ ] CI passes (verify in GitHub Actions)
- [ ] Real-world test: Power-steering works with actual Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)