### PR TITLE
fix: Resolve merge conflict in stop.py causing session exit failure

### DIFF
--- a/.claude/tools/amplihack/hooks/stop.py
+++ b/.claude/tools/amplihack/hooks/stop.py
@@ -228,11 +228,7 @@ class StopHook(HookProcessor):
             self.log(f"Neo4j cleanup handler started (auto_mode={auto_mode})")
 
             # Initialize components with credentials from environment
-<<<<<<< HEAD
-            # Note: Connection tracker will raise ValueError if password not set and
-=======
             # Note: Connection tracker will raise ValueError if password not set and  # pragma: allowlist secret
->>>>>>> origin/main
             # NEO4J_ALLOW_DEFAULT_PASSWORD != "true". This is intentional for production security.  # pragma: allowlist secret
             tracker = Neo4jConnectionTracker(
                 username=os.getenv("NEO4J_USERNAME"), password=os.getenv("NEO4J_PASSWORD")


### PR DESCRIPTION
## Summary

Fixes #1392 - Resolves git merge conflict markers that were accidentally committed to `.claude/tools/amplihack/hooks/stop.py`, causing a Python syntax error on every session exit.

**Impact:** This bug was blocking ALL session exits with a syntax error, affecting 100% of amplihack users.

## Changes

- Removed git merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from lines 231-235
- Kept the version with `# pragma: allowlist secret` comments for consistency
- Both comment lines now have the pragma marker for uniform security scanning

## Root Cause

The merge conflict markers were accidentally committed to the repository instead of being resolved during a previous merge. The Python parser encountered these markers and failed with:

```
Failed to execute stop hook: expected 'except' or 'finally' block (stop.py, line 231)
```

## Resolution Strategy

Per architect agent analysis:
- The `# pragma: allowlist secret` directive prevents false positives in security scans
- Line 236 already had the pragma marker, so line 234 was updated to match
- This maintains consistency and follows security best practices

## Test Plan

- [x] Python syntax validation (`python -m py_compile stop.py`) - ✓ Passed
- [x] Module import test (`import stop`) - ✓ Passed  
- [x] Pre-commit hooks (`pre-commit run`) - ✓ All passed
- [x] AST parsing validation - ✓ No syntax errors
- [x] Manual verification: No remaining merge conflict markers

## Files Changed

- `.claude/tools/amplihack/hooks/stop.py` (4 lines removed)

## Philosophy Compliance

- ✅ **Ruthless Simplicity**: Minimal change to fix the issue
- ✅ **Zero-BS Implementation**: Complete fix with no stubs or workarounds
- ✅ **Quality Gates**: All tests and pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)