### PR TITLE
fix: Add statusLine configuration to installation templates

### DIFF
--- a/.claude/tools/amplihack/install.sh
+++ b/.claude/tools/amplihack/install.sh
@@ -133,6 +133,10 @@ else
   },
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [],
+  "statusLine": {
+    "type": "command",
+    "command": "HOME_PLACEHOLDER/.claude/tools/statusline.sh"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/src/amplihack/utils/uvx_settings_template.json
+++ b/src/amplihack/utils/uvx_settings_template.json
@@ -24,6 +24,10 @@
   },
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [],
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/tools/statusline.sh"
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Fixes #1433

This PR adds the missing statusLine configuration to both installation templates (regular and UVX), ensuring that the custom status line feature is automatically configured for all users.

## Problem

The statusline.sh script is production-ready and works perfectly, but neither installation method configured it in settings.json. This led to:
- Users losing statusLine config on install/update
- Zero feature discoverability
- Manual settings.json editing required

## Solution

Added statusLine configuration to both templates:

### 1. Regular Installation (`.claude/tools/amplihack/install.sh`)
```json
"statusLine": {
  "type": "command",
  "command": "HOME_PLACEHOLDER/.claude/tools/statusline.sh"
},
```

### 2. UVX Installation (`src/amplihack/utils/uvx_settings_template.json`)
```json
"statusLine": {
  "type": "command",
  "command": ".claude/tools/statusline.sh"
},
```

## What the StatusLine Shows

- Directory path (with ~ for home)
- Git branch with dirty state indicator (*) and remote tracking
- Model name (color-coded: Red=Opus, Green=Sonnet, Blue=Haiku)
- Token usage (formatted with K/M suffixes)
- Cost tracking (USD)
- Session duration

## Changes

- ✅ Added statusLine to install.sh template
- ✅ Added statusLine to uvx_settings_template.json
- ✅ Documented issue and solution in DISCOVERIES.md
- ✅ Verified JSON syntax validity
- ✅ Confirmed correct path formats (absolute for regular, relative for UVX)

## Testing

- [x] Verified statusLine configuration in both templates
- [x] Confirmed JSON syntax is valid
- [x] Tested statusline.sh script manually
- [ ] End-to-end test with fresh installation (requires clean environment)

## Impact

- **Regular users**: statusLine now auto-configured during install.sh
- **UVX users**: statusLine auto-configured on first run
- **Feature discovery**: Users can now use custom status line out-of-box
- **User experience**: No manual settings.json editing required

## Investigation

Full investigation and root cause analysis documented in `.claude/context/DISCOVERIES.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)