### PR TITLE
HOTFIX: Remove redundant Path imports causing UnboundLocalError

### DIFF
--- a/src/amplihack/cli.py
+++ b/src/amplihack/cli.py
@@ -679,7 +679,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.command == "install":
         # Install from the package's .claude directory (wherever uvx installed it)
         # This ensures we use the exact version the user installed via uvx --from git+...@branch
-        from pathlib import Path
 
         # Find package location using __file__
         # __file__ is amplihack/cli.py, so parent is amplihack/
@@ -818,8 +817,6 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0
 
     elif args.command == "new":
-        from pathlib import Path
-
         from .goal_agent_generator.cli import new_goal_agent
 
         # Convert string paths to Path objects


### PR DESCRIPTION
## CRITICAL HOTFIX

Fixes the UnboundLocalError that broke main after PR #1438 merge.

## Bug

Lines 682 and 820 had redundant `from pathlib import Path` statements.
Since Path is already imported at line 6, these local re-imports caused
Python to treat Path as a local variable throughout the function scope.

When line 555 tries to use `Path(copy_strategy.target_dir)`, Python
sees the later local imports and raises UnboundLocalError.

## Error

```
UnboundLocalError: cannot access local variable 'Path' where it is not associated with a value
```

## Fix

Removed redundant local imports:
- Line 682: Removed `from pathlib import Path`
- Line 820: Removed `from pathlib import Path`

Path is already imported globally at line 6.

## Testing

✅ Tested with: `uvx --from git+...@hotfix/remove-redundant-path-imports amplihack launch`
✅ Works correctly, no UnboundLocalError

## Impact

- Fixes broken main branch
- amplihack launch now works
- All functionality restored