### PR TITLE
fix: StatusLine not working in UVX mode - use template instead of inline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ include = ["amplihack*"]
 # .claude/ is handled by custom build command in setup.py
 amplihack = [
     "prompts/*.md",
+    "utils/uvx_settings_template.json",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
Fixes statusLine not working when using amplihack via uvx.

## Problem
StatusLine feature wasn't configured in UVX mode even though:
- `statusline.sh` exists and works perfectly  
- `uvx_settings_template.json` has correct statusLine config
- `install.sh` has correct statusLine config for regular installs

**Root Cause**: cli.py created settings.json inline without statusLine, ignoring the template file.

## Changes
- **src/amplihack/cli.py**: Load settings from template instead of inline creation
- **pyproject.toml**: Add uvx_settings_template.json to package-data

## Implementation
1. Load settings from `uvx_settings_template.json`
2. Replace relative paths (`.claude/`) with `$CLAUDE_PROJECT_DIR/.claude/` for UVX
3. Fallback to minimal settings if template load fails
4. Ensure template is included in package distribution

## Impact
✅ StatusLine now works in UVX mode (shows dir, branch, model, tokens, cost, time)
✅ All hooks still configured correctly  
✅ Permissions preserved from template
✅ Graceful fallback if template missing

## Test Plan
```bash
cd /tmp && rm -rf test-statusline && mkdir test-statusline && cd test-statusline
uvx --from git+https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding@fix-statusline-uvx-mode amplihack launch
cat .claude/settings.json | grep -A3 statusLine
```

Expected output:
```json
  "statusLine": {
    "type": "command",
    "command": "$CLAUDE_PROJECT_DIR/.claude/tools/statusline.sh"
  },
```

Related: DISCOVERIES.md "StatusLine Configuration Missing from Installation Templates"

🤖 Generated with [Claude Code](https://claude.com/claude-code)