### PR TITLE
fix: Ignore deleted files in conflict detection

### DIFF
--- a/src/amplihack/safety/git_conflict_detector.py
+++ b/src/amplihack/safety/git_conflict_detector.py
@@ -69,7 +69,9 @@ class GitConflictDetector:
                     continue
                 status = line[:2]
                 filename = line[3:]
-                if any(c in status for c in ["M", "A", "D", "R"]):
+                # Only treat Modified, Added, and Renamed as conflicts
+                # Deleted files (D) are NOT conflicts - we're copying fresh files anyway
+                if any(c in status for c in ["M", "A", "R"]):
                     uncommitted.append(filename)
 
             return uncommitted


### PR DESCRIPTION
## Problem
When .claude/ was tracked in git but deleted from disk, GitConflictDetector treated all deleted files as "uncommitted changes" and showed confusing prompt.

**User scenario:**
```bash
cd ~/src/azure-tenant-grapher
ls -la .claude  # doesn't exist  
amplihack launch

# Showed:
⚠️  Uncommitted changes detected in .claude/
📁 The following files have uncommitted changes:
  ⚠️  .claude/config/cs-validator.json
  ⚠️  .claude/config/modular-build.json
  # ... but .claude doesn't even exist!
```

## Root Cause
GitConflictDetector (line 72) included "D" (deleted) in status check:
```python
if any(c in status for c in ["M", "A", "D", "R"]):  # "D" = deleted
    uncommitted.append(filename)
```

When .claude tracked in git but deleted on disk:
- git status shows: `D .claude/config/test.json`
- Detector treats as conflict
- User gets confusing prompt about files that don't exist

## Fix
Only treat Modified, Added, and Renamed as conflicts. Deleted files are NOT conflicts - we're copying fresh files anyway.

```python
if any(c in status for c in ["M", "A", "R"]):  # Removed "D"
    uncommitted.append(filename)
```

## Impact

✅ When .claude deleted: No prompt, just creates fresh (correct!)
✅ When .claude has real changes (M/A): Still prompts (correct!)
✅ No more confusing prompts when directory doesn't exist

## Test

```bash
cd /tmp/test && git init  
mkdir -p .claude/config && echo "test" > .claude/config/test.json
git add .claude && git commit -m "test"
rm -rf .claude  # Delete it
git status  # Shows: D .claude/config/test.json

# Test conflict detection
python3 -c "
from amplihack.safety import GitConflictDetector
result = GitConflictDetector('.').detect_conflicts(['config'])
print(f'has_conflicts: {result.has_conflicts}')  # Should be False
"
```

**Before:** has_conflicts=True (wrong - directory doesn't exist!)  
**After:** has_conflicts=False (correct - deleted files ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)