### PR TITLE
fix: Add YAML frontmatter to all slash commands for proper discovery

### DIFF
--- a/.claude/commands/amplihack/analyze.md
+++ b/.claude/commands/amplihack/analyze.md
@@ -1,3 +1,8 @@
+---
+description: Comprehensive code review for philosophy compliance
+argument-hint: <path>
+---
+
 # Analyze Command
 
 ## Input Validation

--- a/.claude/commands/amplihack/auto.md
+++ b/.claude/commands/amplihack/auto.md
@@ -1,3 +1,8 @@
+---
+description: Run autonomous agentic mode with iterative loop
+argument-hint: [--max-turns <number>] <prompt>
+---
+
 # Auto Mode - Autonomous Agentic Loop
 
 ## Input Validation

--- a/.claude/commands/amplihack/cascade.md
+++ b/.claude/commands/amplihack/cascade.md
@@ -1,3 +1,8 @@
+---
+description: Execute fallback cascade pattern for resilient operations
+argument-hint: <task-description>
+---
+
 # Fallback Cascade Command
 
 ## Usage

--- a/.claude/commands/amplihack/debate.md
+++ b/.claude/commands/amplihack/debate.md
@@ -1,3 +1,8 @@
+---
+description: Multi-agent debate for complex decisions
+argument-hint: <question-or-decision>
+---
+
 # Multi-Agent Debate Command
 
 ## Usage

--- a/.claude/commands/amplihack/expert-panel.md
+++ b/.claude/commands/amplihack/expert-panel.md
@@ -1,3 +1,8 @@
+---
+description: Byzantine-robust decision-making through expert panel review
+argument-hint: <solution-to-review>
+---
+
 # Expert Panel Review Command
 
 Execute the Expert Panel Review orchestration pattern where multiple expert agents independently review a solution, each casting a vote with detailed rationale, and votes are aggregated for a final decision.

--- a/.claude/commands/amplihack/fix.md
+++ b/.claude/commands/amplihack/fix.md
@@ -1,3 +1,8 @@
+---
+description: Intelligent fix workflow for common error patterns
+argument-hint: [pattern] [scope]
+---
+
 # Fix Command
 
 ## Input Validation

--- a/.claude/commands/amplihack/improve.md
+++ b/.claude/commands/amplihack/improve.md
@@ -1,3 +1,8 @@
+---
+description: Self-improvement and learning capture
+argument-hint: [target]
+---
+
 # Improve Command
 
 ## Input Validation

--- a/.claude/commands/amplihack/ingest-code.md
+++ b/.claude/commands/amplihack/ingest-code.md
@@ -1,3 +1,8 @@
+---
+description: Ingest code into knowledge base for analysis
+argument-hint: [path]
+---
+
 # Ingest Code Command
 
 ## Input Validation

--- a/.claude/commands/amplihack/install.md
+++ b/.claude/commands/amplihack/install.md
@@ -1,3 +1,7 @@
+---
+description: Install amplihack agents and tools to project
+---
+
 # Install the amplihack tools
 
 Amplihack is a collection of claude code customizations designed to enhance productivity and streamline workflows.

--- a/.claude/commands/amplihack/lock.md
+++ b/.claude/commands/amplihack/lock.md
@@ -1,3 +1,8 @@
+---
+description: Enable continuous work mode to prevent stops
+argument-hint: [lock-message]
+---
+
 # Lock: Enable Continuous Work Mode
 
 **Purpose**: Enable continuous work mode to prevent Claude from stopping until explicitly unlocked.

--- a/.claude/commands/amplihack/modular-build.md
+++ b/.claude/commands/amplihack/modular-build.md
@@ -1,3 +1,8 @@
+---
+description: Build modular components from specifications
+argument-hint: [mode] [target]
+---
+
 # Modular Build Command
 
 ## Input Validation

--- a/.claude/commands/amplihack/n-version.md
+++ b/.claude/commands/amplihack/n-version.md
@@ -1,3 +1,8 @@
+---
+description: N-version programming for critical implementations
+argument-hint: <task-description>
+---
+
 # N-Version Programming Command
 
 ## Usage

--- a/.claude/commands/amplihack/reflect.md
+++ b/.claude/commands/amplihack/reflect.md
@@ -1,3 +1,8 @@
+---
+description: Session reflection analysis and learning capture
+argument-hint: [session-id]
+---
+
 # /amplihack:reflect - Session Reflection Analysis
 
 ## Input Validation

--- a/.claude/commands/amplihack/socratic.md
+++ b/.claude/commands/amplihack/socratic.md
@@ -1,3 +1,8 @@
+---
+description: Generate Socratic questions to challenge claims systematically
+argument-hint: [--domain <domain>] [--audience <level>] <claim>
+---
+
 # /socratic - Socratic Question Generation
 
 Generate deep, probing Socratic questions using the Three-Dimensional Attack pattern to challenge claims and explore assumptions systematically.

--- a/.claude/commands/amplihack/transcripts.md
+++ b/.claude/commands/amplihack/transcripts.md
@@ -1,3 +1,8 @@
+---
+description: Conversation transcript management and history
+argument-hint: [action] [session-id]
+---
+
 # /transcripts - Conversation Transcript Management
 
 **Purpose**: amplihack-style transcript management for context preservation and restoration.

--- a/.claude/commands/amplihack/ultrathink.md
+++ b/.claude/commands/amplihack/ultrathink.md
@@ -1,3 +1,8 @@
+---
+description: Deep analysis mode for complex tasks with multi-agent orchestration
+argument-hint: <task-description>
+---
+
 # Ultra-Think Command
 
 ## Input Validation

--- a/.claude/commands/amplihack/uninstall.md
+++ b/.claude/commands/amplihack/uninstall.md
@@ -1,3 +1,7 @@
+---
+description: Uninstall amplihack agents and tools from project
+---
+
 # unintalling the amplihack tools
 
 To uninstall the amplihack tools, run the following command:

--- a/.claude/commands/amplihack/unlock.md
+++ b/.claude/commands/amplihack/unlock.md
@@ -1,3 +1,7 @@
+---
+description: Disable continuous work mode to allow normal stops
+---
+
 # Unlock: Disable Continuous Work Mode
 
 Disable continuous work mode to allow Claude to stop normally.

--- a/.claude/commands/amplihack/xpia.md
+++ b/.claude/commands/amplihack/xpia.md
@@ -1,3 +1,8 @@
+---
+description: XPIA security system management and health monitoring
+argument-hint: [subcommand]
+---
+
 # XPIA Security Command
 
 XPIA (Cross-Platform Injection Attack) Defense system management and health monitoring.


### PR DESCRIPTION
## Problem
Most slash commands (19/23) were missing YAML frontmatter, which can cause:
- Commands not appearing in /help listings
- Poor discoverability
- Missing context for command descriptions

## Root Cause
Commands were created without following Claude Code's frontmatter specification:
```yaml
---
description: Brief description of command
argument-hint: [optional] <required>
---
```

While frontmatter is technically optional, the `description` field is critical for proper command discovery and user experience.

## Solution
Added proper YAML frontmatter to all 19 commands that were missing it.

### Commands Fixed
| Command | Description |
|---------|-------------|
| ultrathink | Deep analysis mode for complex tasks with multi-agent orchestration |
| analyze | Comprehensive code review for philosophy compliance |
| auto | Run autonomous agentic mode with iterative loop |
| cascade | Execute fallback cascade pattern for resilient operations |
| debate | Multi-agent debate for complex decisions |
| expert-panel | Byzantine-robust decision-making through expert panel review |
| fix | Intelligent fix workflow for common error patterns |
| improve | Self-improvement and learning capture |
| ingest-code | Ingest code into knowledge base for analysis |
| install | Install amplihack agents and tools to project |
| lock | Enable continuous work mode to prevent stops |
| modular-build | Build modular components from specifications |
| n-version | N-version programming for critical implementations |
| reflect | Session reflection analysis and learning capture |
| socratic | Generate Socratic questions to challenge claims systematically |
| transcripts | Conversation transcript management and history |
| uninstall | Uninstall amplihack agents and tools from project |
| unlock | Disable continuous work mode to allow normal stops |
| xpia | XPIA security system management and health monitoring |

### Already Had Frontmatter (No Changes)
- customize.md ✅
- knowledge-builder.md ✅
- skill-builder.md ✅
- All DDD commands (8 files) ✅

## Frontmatter Format Used
```yaml
---
description: [What the command does]
argument-hint: [Expected arguments]
---
```

## Impact
✅ All 23 amplihack commands now have proper frontmatter
✅ Commands show descriptive text in /help
✅ Better command discovery
✅ Improved autocomplete hints
✅ Follows official Claude Code documentation standards

## Reference
- Claude Code Docs: https://code.claude.com/docs/en/slash-commands
- All frontmatter fields are optional but `description` is recommended

## Test Plan
```bash
# Test command discovery
uvx --from git+...@fix-command-frontmatter amplihack launch
# In Claude session:
/help
# Should show all amplihack commands with descriptions

# Test autocomplete
/amplihack:
# Should show all commands with their descriptions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)