### PR TITLE
feat: Add power-steering counter to statusline

### DIFF
--- a/.claude/tools/statusline.sh
+++ b/.claude/tools/statusline.sh
@@ -148,5 +148,15 @@ else
     fi
 fi
 
+# Power-steering counter (if exists)
+power_steering_str=""
+counter_file="$current_dir/.claude/runtime/power-steering/session_count"
+if [ -f "$counter_file" ]; then
+    ps_count=$(cat "$counter_file" 2>/dev/null || echo "0")
+    if [ "$ps_count" -gt 0 ] 2>/dev/null; then
+        power_steering_str=" \033[35m🎯×$ps_count\033[0m"
+    fi
+fi
+
 # Output status line
-echo -e "\033[32m$display_dir\033[0m$git_info \033[${model_color}m$model_name\033[0m$tokens_str 💰\$$cost_formatted$duration_str"
+echo -e "\033[32m$display_dir\033[0m$git_info \033[${model_color}m$model_name\033[0m$tokens_str 💰\$$cost_formatted$duration_str$power_steering_str"


### PR DESCRIPTION
## Summary

Fixes #1527 - Adds power-steering invocation counter to statusline with 🎯 emoji.

### Problem

After PR #1525 added progress visibility during power-steering execution, users can see it running in real-time. However, once it completes, there's no persistent indicator showing whether power-steering ran or how many times.

### Solution

Display power-steering counter in statusline:

```
~/project (main → origin) Sonnet 🎫 234K 💰$1.23 ⏱2m 🎯×3
```

The **🎯×3** (in magenta) shows power-steering has been invoked 3 times this session.

### Implementation

**Simple file-based counter** (~40 lines total):

**Modified: stop.py** (+27 lines)
- New method: `_increment_power_steering_counter()`
- Writes count to `.claude/runtime/power-steering/session_count`
- Called after each power-steering invocation
- Fail-safe: Errors don't break hook

**Modified: statusline.sh** (+13 lines)
- Reads counter from session_count file
- Displays 🎯×count in magenta if count > 0
- Graceful: Missing file = no display

### Example Output

**Statusline with no power-steering invocations**:
```
~/amplihack (main → origin) Sonnet 🎫 150K 💰$0.42 ⏱45s
```

**Statusline after power-steering runs 2 times**:
```
~/amplihack (main → origin) Sonnet 🎫 234K 💰$1.23 ⏱2m 🎯×2
```

### Key Features

✅ **Visual indicator**: 🎯 steering wheel emoji  
✅ **Session counter**: Shows invocations for current session  
✅ **Persistent**: Visible even after power-steering completes  
✅ **Fail-safe**: Missing counter file = no display (graceful)  
✅ **Simple**: File-based counter, no complex state management  
✅ **Philosophy-aligned**: Ruthless simplicity (~40 lines)  

### Complements PR #1525

This PR builds on the progress visibility from #1525:
- **PR #1525**: Real-time progress during execution (console messages)
- **This PR**: Persistent indicator after execution (statusline counter)

Together, users now have complete visibility into power-steering:
1. See it running (real-time progress)
2. See it ran (statusline counter)

### Test Plan

- [x] Manually tested statusline with counter file
- [x] Verified 🎯×count displays correctly in magenta
- [x] Tested graceful handling when counter file missing
- [x] Verified counter increments on each invocation
- [x] Pre-commit hooks: All passed
- [x] No regressions in existing statusline functionality

### Impact

Users get at-a-glance confirmation that power-steering is working and how active it's been during the session. Complements the real-time progress from PR #1525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)