### PR TITLE
fix: Power-steering statusline counter now displays session_count

### DIFF
--- a/.claude/tools/statusline.sh
+++ b/.claude/tools/statusline.sh
@@ -169,15 +169,14 @@ else
     fi
 fi
 
-# Power-steering counter (per-session)
+# Power-steering global counter (total invocations across all sessions)
 power_steering_str=""
 if [ -n "$session_id" ]; then
-    redirects_file="$current_dir/.claude/runtime/power-steering/$session_id/redirects.jsonl"
-    if [ -f "$redirects_file" ]; then
-        # Count non-empty lines in redirects file
-        ps_count=$(grep -c . "$redirects_file" 2>/dev/null || echo "0")
+    ps_count_file="$current_dir/.claude/runtime/power-steering/session_count"
+    if [ -f "$ps_count_file" ]; then
+        ps_count=$(cat "$ps_count_file" 2>/dev/null || echo "0")
         if [ "$ps_count" -gt 0 ] 2>/dev/null; then
-            power_steering_str=" \033[35m🚦×$ps_count\033[0m"
+            power_steering_str=" \033[35m🎯×$ps_count\033[0m"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary
- Fixed power-steering statusline counter that was being incremented but never displayed
- Changed from per-session redirects (🚦) to global invocation counter (🎯)
- Simplified implementation: cat file instead of grep -c on JSONL

## Problem
The power-steering counter in `stop.py` was writing to `session_count` but the statusline was reading from a different file (`redirects.jsonl`). The counter was incremented every time power-steering ran, but never displayed in the statusline.

## Root Cause
- **stop.py:128** calls `_increment_power_steering_counter()`
- **stop.py:446-471** writes to: `.claude/runtime/power-steering/session_count`
- **statusline.sh:172-183** read from: `.claude/runtime/power-steering/$session_id/redirects.jsonl`
- Result: session_count incremented but never read

## Solution
Modified `statusline.sh` (lines 172-182) to read the global session_count file:
- Changed file path from `$session_id/redirects.jsonl` to `session_count`
- Changed read method from `grep -c .` (count lines) to `cat` (read number)
- Changed icon from 🚦 (traffic light for redirects) to 🎯 (target for invocations)
- Kept same color (magenta) for visual consistency

## Test plan
✅ **Test 1:** Counter file exists with value 5 → Displays 🎯×5
✅ **Test 2:** Counter file missing → No icon (graceful degradation)
✅ **Test 3:** Counter file with zero → No icon (skip empty)
✅ **Test 4:** Counter file with value 42 → Displays 🎯×42

All tests passed with expected behavior.

## Files Changed
- `.claude/tools/statusline.sh` (11 lines: 5 insertions, 6 deletions)

## Branch History
This is a clean PR with ONLY the statusline fix. Previous PR #1564 was closed due to unrelated commits from base branch.

## Philosophy Compliance
✅ Ruthless simplicity - replaced file processing with simple counter read
✅ Zero-BS implementation - every line works, no TODOs or stubs
✅ Fail-open error handling - gracefully handles missing/invalid files

Fixes #1563
Supersedes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)