### PR TITLE
docs: Fix profile management README - Remove non-existent features

### DIFF
--- a/.claude/tools/amplihack/profile_management/README.md
+++ b/.claude/tools/amplihack/profile_management/README.md
@@ -1,15 +1,27 @@
 # Profile Management System
 
-Comprehensive profile management for amplihack - organize and customize collections of commands, context, agents, and skills.
+Profile management for amplihack - collections of commands, context, agents, and skills.
+
+## Table of Contents
+
+- [Features](#features)
+- [Usage](#usage)
+  - [Load a Profile](#load-a-profile)
+  - [Discover Components](#discover-components)
+  - [Filter Components](#filter-components)
+- [Built-in Profiles](#built-in-profiles)
+- [Security](#security)
+- [Testing](#testing)
+- [Architecture](#architecture)
 
 ## Features
 
 - **YAML-based profiles**: Human-readable configuration
-- **URI support**: file://, amplihack:// schemes
+- **URI support**: file:// scheme for local profiles
 - **Component filtering**: Pattern-based with wildcards
 - **Category filtering**: Scalable to 100k+ skills
 - **CLI commands**: list, show, switch, validate, current
-- **Persistent config**: Saved to ~/.amplihack/config.yaml
+- **Persistent config**: ~/.amplihack/config.yaml
 - **Environment override**: AMPLIHACK_PROFILE variable
 
 ## Usage
@@ -22,7 +34,12 @@ from profile_management import ProfileLoader, ProfileParser
 loader = ProfileLoader()
 parser = ProfileParser()
 
-yaml_content = loader.load("amplihack://profiles/coding")
+# Load with relative path
+yaml_content = loader.load("file://.claude/profiles/coding.yaml")
+profile = parser.parse(yaml_content)
+
+# Or load with absolute path
+yaml_content = loader.load("file:///home/user/.amplihack/profiles/coding.yaml")
 profile = parser.parse(yaml_content)
 ```
 
@@ -51,23 +68,15 @@ print(f"Token estimate: {filtered.token_count_estimate()} tokens")
 
 ## Built-in Profiles
 
-- **all**: Complete environment (default)
-- **coding**: Development-focused
-- **research**: Investigation-focused
+Built-in profiles are located in `.claude/profiles/` and can be loaded using file:// URIs:
 
-## CLI Commands
-
-```bash
-/amplihack:profile list              # List available profiles
-/amplihack:profile show [uri]        # Show profile details
-/amplihack:profile current           # Show active profile
-/amplihack:profile switch <uri>      # Switch profile
-/amplihack:profile validate <uri>    # Validate profile
-```
+- **all**: Complete environment (default) - `file://.claude/profiles/all.yaml`
+- **coding**: Development-focused - `file://.claude/profiles/coding.yaml`
+- **research**: Investigation-focused - `file://.claude/profiles/research.yaml`
 
 ## Security
 
-- Path traversal protection for file:// URIs
+- Path traversal protection for all file:// URIs
 - YAML bomb protection (size + depth limits)
 - Version validation before parsing
 - Pattern complexity limits
@@ -82,11 +91,11 @@ python -m pytest tests/ -v
 
 ## Architecture
 
-- **models.py**: Pydantic data models
-- **loader.py**: URI-based loading
+- **models.py**: Pydantic data models (Profile, ComponentSet)
+- **loader.py**: URI-based loading (file://)
 - **parser.py**: YAML parsing + validation
-- **discovery.py**: Component discovery
-- **filter.py**: Pattern matching
-- **index.py**: Skill indexing
-- **config.py**: Configuration persistence
-- **cli.py**: Rich console interface
+- **discovery.py**: Component discovery (filesystem scanning)
+- **filter.py**: Pattern matching (wildcards)
+- **index.py**: Skill indexing (category-based)
+- **config.py**: Configuration persistence (~/.amplihack)
+- **cli.py**: Rich console interface (list, show, switch)


### PR DESCRIPTION
## Summary

Fixes #1573 

This PR fixes the profile management README which incorrectly documented features that don't exist:

- ❌ Documented `amplihack://` URI scheme that's not implemented
- ❌ Documented `/amplihack:profile` CLI commands after command file was deleted  
- ✅ Now shows only working `file://` URIs
- ✅ Added table of contents for navigation
- ✅ Enhanced architecture section with module descriptions

## Changes Made

1. **Removed `amplihack://` scheme** from features and all examples
2. **Removed CLI Commands section** entirely (/amplihack:profile command file deleted)
3. **Added table of contents** before Quick Start for navigation
4. **Updated usage examples** to show only working file:// URIs
5. **Simplified descriptions** - removed marketing speak, kept essentials
6. **Enhanced Architecture section** - added one-line descriptions for each module

## Testing

✅ Verified zero `amplihack://` references remain
✅ Verified zero `/amplihack:profile` references remain  
✅ Verified table of contents present and functional
✅ Verified all code examples show working syntax only
✅ Pre-commit hooks all passed

## Impact

- Users won't be confused by non-existent features
- Documentation accurately reflects implementation
- Better navigation with table of contents
- Clearer, more concise documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)