### PR TITLE
fix: Correct script path in PM PR triage workflow

### DIFF
--- a/.github/workflows/pm-pr-triage.yml
+++ b/.github/workflows/pm-pr-triage.yml
@@ -62,7 +62,7 @@ jobs:
           # NOTE M3.4: PM scripts must validate for prompt injection in PR descriptions
 
           # Run sophisticated PR triage using Claude Agent SDK
-          python .github/scripts/pr_triage.py
+          python .github/scripts/pr_triage_main.py
 
       # SECURITY: Error handling without exposing secrets
       - name: Handle errors


### PR DESCRIPTION
## Summary

Fixes the PM PR triage workflow failure caused by incorrect script path reference.

**Problem**: The workflow was failing with:
```
python: can't open file '/home/runner/work/MicrosoftHackathon2025-AgenticCoding/MicrosoftHackathon2025-AgenticCoding/.github/scripts/pr_triage.py': [Errno 2] No such file or directory
```

**Root Cause**: The workflow referenced `pr_triage.py` but the actual file is named `pr_triage_main.py` (as created in PR #1548).

**Solution**: Updated `.github/workflows/pm-pr-triage.yml` line 65 to reference the correct filename: `pr_triage_main.py`

## Changes

- `.github/workflows/pm-pr-triage.yml`: Changed script path from `pr_triage.py` to `pr_triage_main.py`

## Test Plan

- [x] Verified the actual script file is named `pr_triage_main.py`
- [x] Confirmed no other references to the old filename exist
- [x] Code review completed (10/10 score from reviewer agent)
- [ ] Will verify workflow runs successfully on next PR

## Related Issues

Fixes workflow failures like: https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/actions/runs/19642106160/job/56248041175

🤖 Generated with [Claude Code](https://claude.com/claude-code)