### PR TITLE
fix: Pass working_dir to ClaudeTranscriptBuilder in auto mode

### DIFF
--- a/src/amplihack/launcher/auto_mode.py
+++ b/src/amplihack/launcher/auto_mode.py
@@ -577,7 +577,9 @@ Document your decisions and reasoning in comments/logs."""
                                 # Handle tool_use blocks (TodoWrite)
                                 elif hasattr(block, "type") and block.type == "tool_use":
                                     tool_name = getattr(block, "name", None)
-                                    self.log(f"🔍 Detected tool_use block: {tool_name}", level="INFO")
+                                    self.log(
+                                        f"🔍 Detected tool_use block: {tool_name}", level="INFO"
+                                    )
 
                                     if tool_name == "TodoWrite":
                                         self.log("🎯 TodoWrite tool detected!", level="INFO")
@@ -599,7 +601,10 @@ Document your decisions and reasoning in comments/logs."""
                                                 )
                                                 self._handle_todo_write(todos)
                                             # Fallback: try dict-style access for backwards compatibility
-                                            elif isinstance(tool_input, dict) and "todos" in tool_input:
+                                            elif (
+                                                isinstance(tool_input, dict)
+                                                and "todos" in tool_input
+                                            ):
                                                 todos = tool_input["todos"]
                                                 self.log(
                                                     f"✓ Input is dict with todos key ({len(todos)} items)",
@@ -612,7 +617,9 @@ Document your decisions and reasoning in comments/logs."""
                                                     level="WARNING",
                                                 )
                                         else:
-                                            self.log("⚠️  Block has no input attribute", level="WARNING")
+                                            self.log(
+                                                "⚠️  Block has no input attribute", level="WARNING"
+                                            )
 
                         elif msg_type == "ResultMessage":
                             # Check if there was an error
@@ -1334,7 +1341,9 @@ Current Turn: {turn}/{self.max_turns}"""
                 self.log("Transcript builder not found, skipping export", level="INFO")
                 return
 
-            builder = ClaudeTranscriptBuilder(session_id=self.log_dir.name)
+            builder = ClaudeTranscriptBuilder(
+                session_id=self.log_dir.name, working_dir=self.working_dir
+            )
             messages = self.message_capture.get_messages()
 
             if not messages:


### PR DESCRIPTION
## Summary

Fixes #1577 - Auto mode transcript export was failing when run from a different project directory.

## Problem

Auto mode transcript export was failing with path mismatch error:
```
[AUTO CLAUDE] Critical transcript export error: Transcript export path mismatch detected!
  Expected: /Users/ryan/src/AzureHayMaker/.claude/runtime/logs/auto_claude_1764005068
  Actual:   /Users/ryan/.cache/uv/archive-v0/.../amplihack/.claude/runtime/logs/auto_claude_1764005068
  This usually means project root detection failed.
```

The `ClaudeTranscriptBuilder` was incorrectly detecting the amplihack package installation directory instead of the actual project directory.

## Root Cause

In `auto_mode.py` line 1337, `ClaudeTranscriptBuilder` was instantiated without passing the `working_dir` parameter, causing it to fall back to `get_project_root()` which incorrectly detected the amplihack package location.

## Solution

Added `working_dir=self.working_dir` parameter to the `ClaudeTranscriptBuilder` constructor call:

\`\`\`python
builder = ClaudeTranscriptBuilder(
    session_id=self.log_dir.name,
    working_dir=self.working_dir  # Added this parameter
)
\`\`\`

## Testing

- ✓ Pre-commit hooks pass
- ✓ Manual test: Path validation verified
- ✓ Transcript paths match when run from different project

## Changes

- **Modified**: `src/amplihack/launcher/auto_mode.py` (line 1337)
  - Added `working_dir` parameter to `ClaudeTranscriptBuilder` constructor

## Impact

- **Scope**: Minimal - single parameter addition
- **Risk**: Low - uses existing API, no breaking changes
- **Benefit**: Fixes critical bug blocking cross-project auto mode usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)