### PR TITLE
feat: Add power-steering visibility on first stop

### DIFF
--- a/.claude/tools/amplihack/hooks/power_steering_checker.py
+++ b/.claude/tools/amplihack/hooks/power_steering_checker.py
@@ -495,6 +495,10 @@ class PowerSteeringChecker:
             # 7. Make decision based on first/subsequent stop
             if analysis.has_blockers:
                 # Actual failures - always block
+                # Mark results shown on first stop to prevent race condition
+                if is_first_stop:
+                    self._mark_results_shown(session_id)
+
                 prompt = self._generate_continuation_prompt(analysis)
 
                 # Save redirect record for session reflection
@@ -518,7 +522,8 @@ class PowerSteeringChecker:
             # All checks passed
             if is_first_stop:
                 # FIRST STOP: Block to show results (visibility feature)
-                # stop.py will display all results and then call _mark_results_shown()
+                # Mark results shown immediately to prevent race condition
+                self._mark_results_shown(session_id)
                 self._log("First stop - blocking to display all results for visibility", "INFO")
                 self._emit_progress(
                     progress_callback,

--- a/.claude/tools/amplihack/hooks/stop.py
+++ b/.claude/tools/amplihack/hooks/stop.py
@@ -131,6 +131,7 @@ class StopHook(HookProcessor):
                         # Check if this is first stop (visibility feature)
                         if ps_result.is_first_stop and ps_result.analysis:
                             # FIRST STOP: Display all results for visibility
+                            # Note: Semaphore marking already done in checker to prevent race condition
                             self.log(
                                 "First stop - displaying all consideration results for visibility"
                             )
@@ -139,8 +140,6 @@ class StopHook(HookProcessor):
                                 considerations=ps_checker.considerations,
                                 is_first_stop=True,
                             )
-                            # Mark results as shown so next stop won't block (if all pass)
-                            ps_checker._mark_results_shown(session_id)
                             self.save_metric("power_steering_first_stop_visibility", 1)
                         else:
                             # Subsequent stop with failures OR first stop with failures

--- a/.claude/tools/amplihack/power_steering_progress.py
+++ b/.claude/tools/amplihack/power_steering_progress.py
@@ -245,7 +245,7 @@ class ProgressTracker:
     ) -> None:
         """Display all consideration results for visibility (first stop feature).
 
-        Shows all 22 considerations grouped by category with ✓/✗ indicators.
+        Shows all considerations grouped by category with ✓/✗ indicators.
 
         Args:
             analysis: ConsiderationAnalysis with results


### PR DESCRIPTION
## Summary

Implements the always-block-first visibility mechanism for power-steering:

- **First stop always blocks** to display all 22 consideration results
- **Results grouped by category** with visual indicators (✅ passed, ❌ failed, ⬜ not applicable)
- **Filesystem semaphore** tracks if results were already shown for the session
- **Subsequent stops** only block if actual failures exist; passes proceed without re-check

Closes #1592

## Implementation Details

**Modified files:**
- `power_steering_checker.py`: Added `analysis` and `is_first_stop` fields to result, plus semaphore methods
- `power_steering_progress.py`: Added `display_all_results()` for visual output
- `stop.py`: Integrated visibility display and semaphore marking

**Key Design Decisions:**
- Fail-open pattern: Bugs in visibility feature never block users
- Semaphore uses session ID for isolation (`.{session_id}_results_shown`)
- Output goes to stderr to not interfere with JSON responses

## Test Plan

- [ ] Pre-commit hooks pass (verified)
- [ ] Syntax validation passes (verified)
- [ ] CI tests pass
- [ ] Manual testing: Start session, attempt stop, verify results display
- [ ] Manual testing: Second stop should proceed if all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)