### PR TITLE
fix: make power steering counter session-specific

### DIFF
--- a/.claude/tools/statusline.sh
+++ b/.claude/tools/statusline.sh
@@ -169,16 +169,18 @@ else
     fi
 fi
 
-# Power-steering global counter (total invocations across all sessions)
-# Note: session_id is NOT required - counter should show regardless
+# Power-steering session counter (invocations for current session)
+# Uses session_id in path like lock counter
 power_steering_str=""
 # Use CLAUDE_PROJECT_DIR to find counter (works in worktrees)
 project_dir="${CLAUDE_PROJECT_DIR:-$current_dir}"
-ps_count_file="$project_dir/.claude/runtime/power-steering/session_count"
-if [ -f "$ps_count_file" ]; then
-    ps_count=$(cat "$ps_count_file" 2>/dev/null || echo "0")
-    if [ "$ps_count" -gt 0 ] 2>/dev/null; then
-        power_steering_str=" \033[35m🚦×$ps_count\033[0m"
+if [ -n "$session_id" ]; then
+    ps_count_file="$project_dir/.claude/runtime/power-steering/$session_id/session_count"
+    if [ -f "$ps_count_file" ]; then
+        ps_count=$(cat "$ps_count_file" 2>/dev/null || echo "0")
+        if [ "$ps_count" -gt 0 ] 2>/dev/null; then
+            power_steering_str=" \033[35m🚦×$ps_count\033[0m"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

The power steering counter was showing total invocations across ALL sessions instead of just the current session's invocations.

## Root Cause

`_increment_power_steering_counter()` was writing to a global path (`power-steering/session_count`) instead of a session-specific path like the lock counter uses.

## Changes

- **stop.py**: Update `_increment_power_steering_counter()` to accept `session_id` parameter and store counter in `power-steering/{session_id}/session_count`
- **statusline.sh**: Look for counter in session-specific path when `session_id` is available (matches lock counter pattern)

## Test Plan

- [x] Create test session counter file
- [x] Verify statusline shows session-specific count
- [x] Verify different session doesn't show wrong count
- [x] Pre-commit hooks pass
- [x] Bash syntax validation

## Testing Results

```bash
# Session test-session-123 with count=5
~/src/amplihack3 (main* → origin) Claude Sonnet 💰$0.50 ⏱1m 🚦×5

# Different session (no counter file) - correctly shows no count
~/src/amplihack3 (main* → origin) Claude Sonnet 💰$0.50 ⏱1m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)