### PR TITLE
feat: Add Step 0 Workflow Preparation to prevent step skipping

### DIFF
--- a/.claude/workflow/DEFAULT_WORKFLOW.md
+++ b/.claude/workflow/DEFAULT_WORKFLOW.md
@@ -156,6 +156,8 @@ Agents that skip workflow steps (especially mandatory review steps 10, 16-17) cr
 
 ### Step 1: Prepare the Workspace
 
+**Prerequisite Check:** Verify Step 0 is complete - you should have 22 todos visible (Steps 0-21) before proceeding.
+
 - [ ] start with a clean local environment and make sure it is up to date (no unstashed changes, git fetch)
 
 ### Step 2: Rewrite and Clarify Requirements


### PR DESCRIPTION
## Summary

Adds mandatory **Step 0: Workflow Preparation** to `DEFAULT_WORKFLOW.md` to address Issue #1607 where agents skip mandatory review steps.

**Problem:** Agents were completing implementation and creating PRs without executing mandatory code review steps (Steps 10, 16-17), leading to quality issues and eroded user trust.

**Root Causes Identified:**
- **Completion Bias**: Agents consider "PR created" as task completion
- **Context Decay**: After heavy implementation, agents lose sight of remaining steps
- **Autonomy Misapplication**: Confusing "autonomous implementation" with "skip mandatory process"

## Changes

- Added **Step 0: Workflow Preparation (MANDATORY - DO NOT SKIP)** with:
  - Root cause analysis explanation
  - Checklist requiring TodoWrite for ALL 22 steps (0-21) at task start
  - Self-verification checkpoint before proceeding to Step 1
  - Anti-pattern prevention guidelines (DO/DON'T visual list)
  - Reference to Issue #1607

- Updated workflow metadata:
  - Version: 1.0.0 → 1.1.0
  - Steps: 21 → 22

- Updated example todo structures to include Step 0 and highlight mandatory steps

## Test Plan

- [x] Verified all 22 steps (0-21) present in sequential order
- [x] Confirmed markdown formatting is correct
- [x] Pre-commit hooks pass (prettier, merge conflicts, etc.)
- [x] Reviewed by reviewer agent for philosophy compliance

Closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)