### PR TITLE
feat(config): Add Docker MCP server integration for container management

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "docker-mcp": {
+      "command": "uvx",
+      "args": ["docker-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1614

Adds Docker MCP server configuration to enable Docker container management directly from Claude Code sessions.

## What is Docker MCP?

Docker MCP is an MCP server that provides Docker container management tools:
- `list-containers`: List all Docker containers
- `create-container`: Create standalone containers
- `deploy-compose`: Deploy Docker Compose stacks
- `get-logs`: Retrieve container logs

## Why This Helps

When Neo4j Docker connection issues occur, users can now:
1. List containers to see what's running
2. View container logs for debugging
3. Manage container lifecycle without leaving Claude Code

## Installation

The MCP server is installed automatically via `uvx` when first used. No manual setup required.

## Usage

After session start, Docker MCP tools become available:

```python
# List containers
mcp__docker-mcp__list-containers()

# Get logs from Neo4j container
mcp__docker-mcp__get-logs(container_name="amplihack-neo4j-memory")
```

## Files Changed

- `.mcp.json` - Add docker-mcp server configuration (NEW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)