### PR TITLE
feat(skills): Add session-replay skill for trace analysis

### DIFF
--- a/.claude/skills/session-replay/README.md
+++ b/.claude/skills/session-replay/README.md
@@ -77,20 +77,32 @@ Health Score: 82/100 (Good)
 
 ## Related Tools
 
-- `/transcripts` - Conversation transcript management
-- `context-management` skill - Proactive context optimization
-- `codex_transcripts_builder.py` - Knowledge extraction from sessions
+| Need                             | Use This                        |
+| -------------------------------- | ------------------------------- |
+| Session performance metrics      | **session-replay** (this skill) |
+| Conversation content/restoration | `/transcripts` command          |
+| Knowledge extraction             | `codex_transcripts_builder.py`  |
+| Token optimization               | `context-management` skill      |
 
-## Philosophy
+## Philosophy Alignment
 
-This skill follows amplihack principles:
+This skill strictly follows amplihack principles:
 
-- **Ruthless Simplicity**: Direct file parsing, no complex dependencies
-- **Zero-BS**: All functions work completely, no stubs
-- **Brick Philosophy**: Self-contained, regeneratable module
+- **Ruthless Simplicity**: Direct file parsing using only Python standard library (json, pathlib)
+- **Zero-BS**: Every code example runs without modification, no stubs or placeholders
+- **Brick Philosophy**: Self-contained module with clear inputs (trace files) and outputs (reports)
+- **Fail Fast**: Clear error messages for malformed files, missing traces, or permission issues
+
+## Limitations
+
+- **Read-only**: Cannot modify or generate trace files
+- **Local only**: Analyzes traces in current project only
+- **JSONL format**: Only claude-trace JSONL format supported
+- **Post-session**: Analyzes completed sessions, not real-time
 
 ## See Also
 
-- [SKILL.md](./SKILL.md) - Full skill specification
+- [SKILL.md](./SKILL.md) - Full skill specification with implementation details
 - `.claude-trace/` - Trace file location (project root)
 - `/transcripts` - Conversation transcript management command
+- `context-management` skill - Proactive context optimization


### PR DESCRIPTION
## Summary
- Adds new `session-replay` skill for analyzing claude-trace JSONL files
- Provides session health reports (token usage, latency, errors)
- Detects error patterns across multiple sessions
- Analyzes tool usage distribution

## Part of Issue #1611 (Enhancement 1)

## Files Added
- `.claude/skills/session-replay/SKILL.md` - Main skill definition
- `.claude/skills/session-replay/README.md` - Documentation

## How to Use
Triggers: 'analyze session', 'session health', 'trace analysis', 'debug session'

🤖 Generated with [Claude Code](https://claude.com/claude-code)