### PR TITLE
fix(statusline): Normalize JSON input by removing newlines

### DIFF
--- a/.claude/tools/statusline.sh
+++ b/.claude/tools/statusline.sh
@@ -9,8 +9,8 @@
 #     "command": "$CLAUDE_PROJECT_DIR/.claude/tools/statusline.sh"
 #   }
 
-# Read JSON from Claude Code
-input=$(cat)
+# Read JSON from Claude Code and normalize (remove newlines for reliable parsing)
+input=$(cat | tr -d '\n\r')
 
 # Extract values without jq (portable)
 extract_json() {


### PR DESCRIPTION
## Summary

The statusline JSON extraction was failing when Claude Code sent multi-line JSON input. The grep-based patterns couldn't match across newlines, causing:
- Model name to show "Claude" instead of actual model
- Cost to show $0.00
- Duration to not display

## Changes

- Added `tr -d '\n\r'` to normalize JSON input before parsing
- Single line change, minimal risk

## Test Plan

- [x] Tested with single-line JSON input
- [x] Tested with multi-line JSON input
- [x] Verified model name, cost, and duration display correctly

## Test Results

```bash
$ echo '{"display_name":"Opus 4.5","id":"claude-opus-4-5","total_cost_usd":2.50,"total_duration_ms":120000}' | ./statusline.sh
~/src/amplihack (branch* → origin) Opus 4.5 💰$2.50 ⏱2m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)