### PR TITLE
chore(docs): Move SKILL_BUILDER_EXAMPLES from commands to docs

### DIFF
--- a/docs/skills/SKILL_BUILDER_EXAMPLES.md
+++ b/docs/skills/SKILL_BUILDER_EXAMPLES.md
@@ -1,13 +1,3 @@
----
-name: skill-builder-examples
-version: 1.0.0
-description: Practical examples for using the skill-builder command
-triggers:
-  - "skill-builder examples"
-  - "how to use skill-builder"
-  - "skill-builder usage"
----
-
 # Skill Builder Command - Usage Examples
 
 This document provides practical examples of using the `/amplihack:skill-builder` command.


### PR DESCRIPTION
## Summary
- Move `SKILL_BUILDER_EXAMPLES.md` from `.claude/commands/amplihack/` to `docs/skills/`
- Remove command YAML frontmatter since it's documentation, not a slash command
- File was incorrectly registered as a command when it's actually usage examples/documentation

## Changes
- `.claude/commands/amplihack/SKILL_BUILDER_EXAMPLES.md` → `docs/skills/SKILL_BUILDER_EXAMPLES.md`
- Removed YAML frontmatter (name, version, description, triggers)

## Test Plan
- [x] File moved successfully
- [x] No references to the old path found
- [x] File renders correctly as documentation

Fixes #1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)