### PR TITLE
chore(docs): Add weekly broken link checker for documentation

### DIFF
--- a/.github/workflows/docs-link-checker.yml
+++ b/.github/workflows/docs-link-checker.yml
@@ -39,12 +39,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install requests aiohttp
+          pip install requests
 
       - name: Run link checker
         id: linkcheck
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PAGES_URL: ${{ vars.GITHUB_PAGES_URL }}
         run: |
           set +x  # Disable command echoing


### PR DESCRIPTION
## Summary

Automated weekly workflow to check for broken links across all documentation and GitHub Pages.

### What It Does

- **Internal Links**: Validates relative markdown links (`./path/to/file.md`)
- **Anchor References**: Checks `#section-name` links exist in target files
- **External URLs**: Verifies HTTP/HTTPS links return 200 OK
- **Image References**: Validates image and asset paths

### Features

| Feature | Description |
|---------|-------------|
| GitHub-style slugs | Generates anchors matching GitHub's format |
| Rate limiting | 0.5s delay between external requests to avoid abuse |
| URL caching | Avoids redundant checks for repeated URLs |
| Severity levels | Categorizes as error, warning, or info |
| Issue creation | Automatically creates/updates GitHub issue with findings |

### Schedule

- **When**: Every Saturday at 5 AM UTC
- **Why**: Before Sunday's docs cleanup workflow (6 AM UTC)
- **Manual**: Can also be triggered via `workflow_dispatch`

### Files Added

| File | Purpose |
|------|---------|
| `.github/workflows/docs-link-checker.yml` | Workflow definition |
| `.github/scripts/link_checker.py` | Link validation logic |

### Link Types Checked

```
✅ [text](./relative/path.md)     # Internal markdown links
✅ [text](#anchor-name)            # Anchor references
✅ [text](https://example.com)     # External URLs
✅ ![alt](./images/pic.png)        # Image references
❌ mailto:, tel:, javascript:      # Skipped (not HTTP)
```

## Test Plan

- [x] Pre-commit hooks pass
- [x] Script syntax validated
- [ ] Manual workflow trigger (after merge)

## Related

- Complements #1670 (docs cleanup automation)
- Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)