### PR TITLE
fix(devcontainer): Update comment to reflect Python 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
   },
   // Features to add to the dev container. More info: https://containers.dev/features.
   // Version alignment: Match CI configuration (ci.yml) for consistency
-  // CI uses: Python 3.11, Node.js 20
+  // CI uses: Python 3.12, Node.js 20
   "features": {
     "ghcr.io/jungaretti/features/make:1": {},
     "ghcr.io/jungaretti/features/vim:1": {},


### PR DESCRIPTION
## Summary
- Fixes incorrect comment in devcontainer.json that stated CI uses Python 3.11 when it now uses Python 3.12

## Context
This was identified during the post-merge review of PR #1677 (https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1677#issuecomment-3578528209).

## Changes
| File | Change |
|------|--------|
| `.devcontainer/devcontainer.json` | Updated comment from "Python 3.11" to "Python 3.12" |

## Test plan
- [x] Verified CI uses Python 3.12 in `.github/workflows/ci.yml`
- [x] Verified change is documentation-only (comment)
- [x] Pre-commit hooks pass

## Follow-up to PR #1677
This is a minor cleanup identified during workflow compliance review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)