### PR TITLE
fix: Register amplihack slash commands with proper namespace prefix

### DIFF
--- a/.claude/commands/amplihack/analyze.md
+++ b/.claude/commands/amplihack/analyze.md
@@ -1,5 +1,5 @@
 ---
-name: analyze
+name: amplihack:analyze
 version: 1.0.0
 description: Comprehensive code analysis and philosophy compliance review
 triggers:

--- a/.claude/commands/amplihack/auto.md
+++ b/.claude/commands/amplihack/auto.md
@@ -1,5 +1,5 @@
 ---
-name: auto
+name: amplihack:auto
 version: 1.0.0
 description: Autonomous multi-turn agentic loop for complex implementations
 triggers:

--- a/.claude/commands/amplihack/cascade.md
+++ b/.claude/commands/amplihack/cascade.md
@@ -1,5 +1,5 @@
 ---
-name: cascade
+name: amplihack:cascade
 version: 1.0.0
 description: Fallback cascade pattern for resilient operations
 triggers:

--- a/.claude/commands/amplihack/customize.md
+++ b/.claude/commands/amplihack/customize.md
@@ -1,5 +1,5 @@
 ---
-name: customize
+name: amplihack:customize
 version: 1.0.0
 description: Manage user-specific preferences and customizations
 argument-hint: <action> [preference] [value]

--- a/.claude/commands/amplihack/debate.md
+++ b/.claude/commands/amplihack/debate.md
@@ -1,5 +1,5 @@
 ---
-name: debate
+name: amplihack:debate
 version: 1.0.0
 description: Multi-agent debate for complex decisions and trade-offs
 triggers:

--- a/.claude/commands/amplihack/expert-panel.md
+++ b/.claude/commands/amplihack/expert-panel.md
@@ -1,5 +1,5 @@
 ---
-name: expert-panel
+name: amplihack:expert-panel
 version: 1.0.0
 description: Expert panel review with voting and consensus decision-making
 triggers:

--- a/.claude/commands/amplihack/fix.md
+++ b/.claude/commands/amplihack/fix.md
@@ -1,5 +1,5 @@
 ---
-name: fix
+name: amplihack:fix
 version: 1.0.0
 description: Rapid diagnosis and fix for common issues
 triggers:

--- a/.claude/commands/amplihack/improve.md
+++ b/.claude/commands/amplihack/improve.md
@@ -1,5 +1,5 @@
 ---
-name: improve
+name: amplihack:improve
 version: 2.0.0
 description: Continuous self-improvement with simplicity validation
 triggers:

--- a/.claude/commands/amplihack/ingest-code.md
+++ b/.claude/commands/amplihack/ingest-code.md
@@ -1,5 +1,5 @@
 ---
-name: ingest-code
+name: amplihack:ingest-code
 version: 1.0.0
 description: Ingest and analyze external codebases into Neo4j
 triggers:

--- a/.claude/commands/amplihack/install.md
+++ b/.claude/commands/amplihack/install.md
@@ -1,5 +1,5 @@
 ---
-name: install
+name: amplihack:install
 version: 1.0.0
 description: Install amplihack framework and tools
 triggers:

--- a/.claude/commands/amplihack/knowledge-builder.md
+++ b/.claude/commands/amplihack/knowledge-builder.md
@@ -1,5 +1,5 @@
 ---
-name: knowledge-builder
+name: amplihack:knowledge-builder
 version: 1.0.0
 description: Build comprehensive knowledge base using Socratic method and web search
 triggers:

--- a/.claude/commands/amplihack/lock.md
+++ b/.claude/commands/amplihack/lock.md
@@ -1,5 +1,5 @@
 ---
-name: lock
+name: amplihack:lock
 version: 1.0.0
 description: Enable continuous work mode without stopping
 triggers:

--- a/.claude/commands/amplihack/modular-build.md
+++ b/.claude/commands/amplihack/modular-build.md
@@ -1,5 +1,5 @@
 ---
-name: modular-build
+name: amplihack:modular-build
 version: 1.0.0
 description: Build modular code following brick philosophy
 triggers:

--- a/.claude/commands/amplihack/n-version.md
+++ b/.claude/commands/amplihack/n-version.md
@@ -1,5 +1,5 @@
 ---
-name: n-version
+name: amplihack:n-version
 version: 1.0.0
 description: N-version programming for Byzantine-robust critical implementations
 triggers:

--- a/.claude/commands/amplihack/reflect.md
+++ b/.claude/commands/amplihack/reflect.md
@@ -1,5 +1,5 @@
 ---
-name: reflect
+name: amplihack:reflect
 version: 1.0.0
 description: Reflection and meta-cognitive analysis of sessions
 triggers:

--- a/.claude/commands/amplihack/remote.md
+++ b/.claude/commands/amplihack/remote.md
@@ -1,3 +1,13 @@
+---
+name: amplihack:remote
+version: 1.0.0
+description: Execute amplihack commands on remote Azure VMs using azlin
+triggers:
+  - "Run on remote VM"
+  - "Execute remotely"
+  - "Use Azure VM"
+---
+
 # Remote Execution Command
 
 Execute amplihack commands on remote Azure VMs using azlin for provisioning.

--- a/.claude/commands/amplihack/skill-builder.md
+++ b/.claude/commands/amplihack/skill-builder.md
@@ -1,5 +1,5 @@
 ---
-name: skill-builder
+name: amplihack:skill-builder
 version: 1.0.0
 description: Build new Claude Code skills with guided workflow and agent orchestration
 argument-hint: <skill-name> <skill-type> <description>

--- a/.claude/commands/amplihack/socratic.md
+++ b/.claude/commands/amplihack/socratic.md
@@ -1,5 +1,5 @@
 ---
-name: socratic
+name: amplihack:socratic
 version: 1.0.0
 description: Generate Socratic questions for requirements clarification
 triggers:

--- a/.claude/commands/amplihack/transcripts.md
+++ b/.claude/commands/amplihack/transcripts.md
@@ -1,5 +1,5 @@
 ---
-name: transcripts
+name: amplihack:transcripts
 version: 1.0.0
 description: Manage and analyze conversation transcripts
 triggers:

--- a/.claude/commands/amplihack/ultrathink.md
+++ b/.claude/commands/amplihack/ultrathink.md
@@ -1,5 +1,5 @@
 ---
-name: ultrathink
+name: amplihack:ultrathink
 version: 1.0.0
 description: Deep analysis mode with multi-agent orchestration
 DEPRECATED: true

--- a/.claude/commands/amplihack/uninstall.md
+++ b/.claude/commands/amplihack/uninstall.md
@@ -1,5 +1,5 @@
 ---
-name: uninstall
+name: amplihack:uninstall
 version: 1.0.0
 description: Uninstall amplihack framework and tools
 triggers:

--- a/.claude/commands/amplihack/unlock.md
+++ b/.claude/commands/amplihack/unlock.md
@@ -1,5 +1,5 @@
 ---
-name: unlock
+name: amplihack:unlock
 version: 1.0.0
 description: Disable continuous work mode and resume normal behavior
 triggers:

--- a/.claude/commands/amplihack/xpia.md
+++ b/.claude/commands/amplihack/xpia.md
@@ -1,5 +1,5 @@
 ---
-name: xpia
+name: amplihack:xpia
 version: 1.0.0
 description: Cross-Prompt Injection Attack defense and security management
 triggers:


### PR DESCRIPTION
## Summary

Fixed slash command registration for all 23 amplihack commands by adding the `amplihack:` prefix to frontmatter `name` fields.

## Problem

Commands in `.claude/commands/amplihack/` were not discoverable via slash command syntax (e.g., `/amplihack:ultrathink`) because their frontmatter `name` fields lacked the subdirectory prefix.

## Solution

Updated all 23 command files to include `amplihack:` prefix in the `name` field:
- 22 existing files: Updated `name:` field (e.g., `name: ultrathink` → `name: amplihack:ultrathink`)
- 1 file (`remote.md`): Added missing frontmatter with proper prefix

This matches the pattern used by working DDD commands (e.g., `name: ddd:prime`).

## Changes

### Files Modified (23 total)
All `.md` files in `.claude/commands/amplihack/`:
- analyze.md, auto.md, cascade.md, customize.md, debate.md
- expert-panel.md, fix.md, improve.md, ingest-code.md, install.md
- knowledge-builder.md, lock.md, modular-build.md, n-version.md
- reflect.md, remote.md, skill-builder.md, socratic.md
- transcripts.md, ultrathink.md, unlock.md, uninstall.md, xpia.md

### Pattern Applied
```yaml
# BEFORE
name: ultrathink

# AFTER  
name: amplihack:ultrathink
```

## Testing Plan

Commands should now be discoverable and executable:
- [ ] Test `/amplihack:ultrathink` - Deep analysis mode
- [ ] Test `/amplihack:analyze` - Code analysis  
- [ ] Test `/amplihack:fix` - Fix workflow
- [ ] Verify DDD commands still work (regression check)

## Philosophy Compliance

✅ **Ruthless Simplicity**: Minimal change (frontmatter only)
✅ **Zero-BS**: No stubs, all changes functional  
✅ **Explicit User Requirements**: All 23 files updated as requested

Fixes #1742

🤖 Generated with [Claude Code](https://claude.com/claude-code)