### PR TITLE
fix: Power-steering infinite loop on success (Issue #1744)

### DIFF
--- a/.claude/tools/amplihack/hooks/power_steering_checker.py
+++ b/.claude/tools/amplihack/hooks/power_steering_checker.py
@@ -775,7 +775,7 @@ class PowerSteeringChecker:
                     continuation_prompt=f"All power-steering checks passed! Please present these results to the user:\n{results_text}",
                     summary=None,
                     analysis=analysis,
-                    is_first_stop=True,
+                    is_first_stop=is_first_stop,  # FIX (Issue #1744): Pass through is_first_stop to prevent infinite loop
                 )
 
             # SUBSEQUENT STOP: All checks passed, approve
@@ -2030,6 +2030,8 @@ class PowerSteeringChecker:
         if total_failed == 0:
             lines.append(f"✅ ALL CHECKS PASSED ({total_passed} passed, {total_skipped} skipped)")
             lines.append("\n📌 This was your first stop. Next stop will proceed without blocking.")
+            lines.append("\n💡 To disable power-steering: export AMPLIHACK_SKIP_POWER_STEERING=1")
+            lines.append("   Or create: .claude/runtime/power-steering/.disabled")
         else:
             lines.append(f"❌ CHECKS FAILED ({total_passed} passed, {total_failed} failed)")
             lines.append("\n📌 Address the failed checks above before stopping.")


### PR DESCRIPTION
## Problem

Power steering caused infinite loop when ALL checks PASSED. The stop hook blocked correctly on first stop but then blocked every subsequent stop indefinitely with the same "all checks passed" message, repeating until interrupted or Node crashed.

## Root Cause

**Line 778** hardcoded `is_first_stop=True` instead of using the calculated variable from line 691. Even though the semaphore file was created to track "results shown" state, the hardcoded value ignored this state.

## Solution

### 1. Fix Line 778 ✅
Changed from:
```python
is_first_stop=True,  # BUG
```

To:
```python
is_first_stop=is_first_stop,  # FIX (Issue #1744): Pass through is_first_stop to prevent infinite loop
```

### 2. Add Disable Instructions ✅
Added to success output (lines 2033-2034):
```
💡 To disable power-steering: export AMPLIHACK_SKIP_POWER_STEERING=1
   Or create: .claude/runtime/power-steering/.disabled
```

## Test Coverage

Comprehensive regression test exists:
- `test_second_stop_proceeds_after_first_displays_results()`
- Verifies first stop blocks, second stop approves
- Tests semaphore file state management

## Manual Testing Plan

1. Start session with task that passes all checks
2. First `/stop` → blocks with formatted results ✅
3. Second `/stop` → proceeds without blocking ✅
4. No infinite loop ✅

## Changes

- 1 file changed
- 3 insertions, 1 deletion
- Philosophy compliant (minimal, targeted fix)

## Fixes

Closes #1744

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)