### PR TITLE
hotfix(docs): Fix site_url causing broken theme and 404 links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,9 @@
 site_name: amplihack
 site_description: Agentic coding framework that uses specialized AI agents to accelerate software development
 site_author: amplihack contributors
-site_url: https://amplihack.github.io/amplihack/
-repo_name: amplihack/amplihack
-repo_url: https://github.com/amplihack/amplihack
+site_url: https://rysweet.github.io/MicrosoftHackathon2025-AgenticCoding/
+repo_name: rysweet/MicrosoftHackathon2025-AgenticCoding
+repo_url: https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding
 edit_uri: edit/main/docs/
 
 # Theme Configuration


### PR DESCRIPTION
CRITICAL: The mkdocs.yml site_url was pointing to amplihack.github.io instead of rysweet.github.io causing broken CSS/theme and wrong repository links. This fixes the broken rendering reported by user. Resolves #1827 (final fix).