### PR TITLE
feat(utils): Add slugify_safe() wrapper with type coercion and None handling

### DIFF
--- a/src/amplihack/utils/string_utils.py
+++ b/src/amplihack/utils/string_utils.py
@@ -10,6 +10,7 @@ Philosophy:
 
 Public API:
     slugify: Convert text to URL-safe slug format
+    slugify_safe: Type-safe wrapper with None/type coercion handling
 """
 
 import re
@@ -61,4 +62,37 @@ def slugify(text: str) -> str:
     return text.strip("-")
 
 
-__all__ = ["slugify"]
+def slugify_safe(text: str | None | float | bool) -> str:
+    """Type-safe wrapper around slugify() with None and type coercion handling.
+
+    Converts input to string, handles None → "", then delegates to slugify().
+    This is useful when dealing with user input or data that may be None or
+    non-string types.
+
+    Args:
+        text: Any type that can be coerced to string, or None.
+            - None returns empty string
+            - Integers, floats, booleans converted via str()
+            - Strings processed normally
+
+    Returns:
+        URL-safe slug. Empty string for None input.
+
+    Examples:
+        >>> slugify_safe(None)
+        ''
+        >>> slugify_safe(42)
+        '42'
+        >>> slugify_safe("Hello World")
+        'hello-world'
+        >>> slugify_safe(True)
+        'true'
+        >>> slugify_safe(12.5)
+        '12-5'
+    """
+    if text is None:
+        return ""
+    return slugify(str(text))
+
+
+__all__ = ["slugify", "slugify_safe"]


### PR DESCRIPTION
## Summary

Adds a type-safe wrapper around `slugify()` that handles edge cases the core function doesn't:

- **None handling**: `slugify_safe(None)` returns `""`
- **Type coercion**: Integers, floats, and booleans are converted via `str()`
- **Delegation**: Uses existing `slugify()` for actual transformation
- **Idempotency**: `slugify_safe(slugify_safe(x)) == slugify_safe(x)`

## Changes

- Added `slugify_safe()` function to `src/amplihack/utils/string_utils.py`
- Added 13 comprehensive tests for all edge cases
- Updated `__all__` exports
- Cleaned up TDD placeholder code from test file

## Implementation

The implementation follows ruthless simplicity - just 3 lines of core logic:

```python
def slugify_safe(text: str | None | float | bool) -> str:
    if text is None:
        return ""
    return slugify(str(text))
```

## Test Plan

- [x] 44 unit tests pass (31 slugify + 13 slugify_safe)
- [x] All pre-commit hooks pass
- [x] Manual testing of all input types
- [x] Idempotency verified
- [x] Edge cases tested (negative numbers, scientific notation)

## Local Test Results

```
slugify_safe(None) = ''           ✓
slugify_safe(42) = '42'           ✓
slugify_safe(3.14) = '3-14'       ✓
slugify_safe(True) = 'true'       ✓
slugify_safe("Hello World!") = 'hello-world'  ✓
slugify_safe(-999) = '999'        ✓
```

Closes #1835

🤖 Generated with [Claude Code](https://claude.com/claude-code)