### PR TITLE
feat(string_utils): Add titlecase() function for Title Case conversion

### DIFF
--- a/src/amplihack/utils/string_utils.py
+++ b/src/amplihack/utils/string_utils.py
@@ -1,6 +1,7 @@
 """String utility functions for text processing.
 
-This module provides utilities for converting strings to URL-safe formats.
+This module provides utilities for string transformation including
+slug generation and case conversion.
 
 Philosophy:
 - Ruthless simplicity (stdlib only)

--- a/tests/unit/test_string_utils.py
+++ b/tests/unit/test_string_utils.py
@@ -15,6 +15,8 @@ Test Coverage:
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
@@ -528,8 +530,6 @@ class TestTitlecase:
         - titlecase(None) should raise TypeError
         - Non-string inputs rejected
         """
-        import pytest
-
         with pytest.raises(TypeError):
             titlecase(None)
 
@@ -540,7 +540,5 @@ class TestTitlecase:
         - titlecase(123) should raise TypeError
         - Non-string inputs rejected
         """
-        import pytest
-
         with pytest.raises(TypeError):
             titlecase(123)


### PR DESCRIPTION
## Summary

- Implements new `titlecase()` string utility function
- Converts text to Title Case by capitalizing the first letter of each word
- Word boundaries include whitespace, punctuation, and numbers
- Follows ruthless simplicity philosophy (10 lines of functional code)

## Changes

### New Function: `titlecase(text: str) -> str`

```python
from amplihack.utils.string_utils import titlecase

titlecase("hello world")      # "Hello World"
titlecase("hello-world")      # "Hello-World"
titlecase("it's")             # "It'S"
titlecase("hello123world")    # "Hello123World"
```

### Files Modified
- `src/amplihack/utils/string_utils.py` - Added titlecase function
- `tests/unit/test_string_utils.py` - Added 13 test cases

## Test Plan

- [x] Unit tests: 13 test cases covering all edge cases
- [x] All 44 string_utils tests pass
- [x] Pre-commit hooks pass
- [x] Local interactive testing verified:
  - Simple use cases (hello world, uppercase normalization)
  - Complex use cases (hyphens, apostrophes, numbers)
  - Edge cases (empty, single char, numbers only)
  - Whitespace preservation
  - Type error handling
  - Integration with existing slugify function

## Philosophy Compliance

- ✅ Ruthless simplicity - 10 lines of core logic
- ✅ Standard library only (re module)
- ✅ Zero-BS implementation - fully working, no stubs
- ✅ Clear public API via `__all__`

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)