### PR TITLE
feat: Enable GitHub header actions in MkDocs documentation

### DIFF
--- a/docs/development/case-studies/issue-1931-proportionality.md
+++ b/docs/development/case-studies/issue-1931-proportionality.md
@@ -1,0 +1,1146 @@
+# Root Cause Analysis: 58 Tests for 2-Line Config Change
+
+**Issue**: Issue #1931 "Add GitHub link to docs header" resulted in 58 tests, 3 documentation files, and elaborate architecture for a trivial 2-line mkdocs.yml config change.
+
+**What Was Needed**:
+
+- 2 lines added to mkdocs.yml (lines 45-46: `content.action.edit` + `content.action.view`)
+- Verification: `mkdocs build` succeeds
+- Total effort: 5-10 minutes
+
+**What Was Created**:
+
+- 58 test files (29,257 lines of test code)
+- Multiple architecture documents
+- Elaborate TDD process
+- Full DEFAULT_WORKFLOW execution (Steps 0-21)
+
+---
+
+## Root Cause Analysis
+
+### 1. Task Classification Failure
+
+**Finding**: No task classification mechanism exists for "trivial config changes"
+
+**Evidence**:
+
+- DEFAULT_WORKFLOW.md line 63: "Any non-trivial code changes"
+- But there's NO definition of what constitutes "trivial"
+- No workflow skip conditions for simple config edits
+- prompt-writer agent (Step 2) classifies EXECUTABLE vs DOCUMENTATION, but not TRIVIAL vs NON-TRIVIAL
+
+**Missing Classification Categories**:
+
+```
+Current: EXECUTABLE, DOCUMENTATION, AMBIGUOUS
+Needed: TRIVIAL_CONFIG, SIMPLE_EDIT, VERIFICATION_ONLY
+```
+
+**Warning Signs Missed**:
+
+- User request: "Add GitHub link" (no complexity indicators)
+- File type: `.yml` config file (declarative, not imperative)
+- Change scope: Header visibility (purely presentational)
+- Implementation size: 2 lines
+- No logic, no algorithms, no data structures
+
+**What Should Have Happened**:
+
+```
+WORKFLOW: TRIVIAL_CONFIG
+Reason: Single config file, presentational change, < 5 lines
+Following: Quick verification workflow (no TDD, no architecture)
+
+Steps:
+1. Make config change
+2. Run mkdocs build
+3. Verify output
+4. Commit and PR
+Total time: 5-10 minutes
+```
+
+---
+
+### 2. Workflow Blindness (Mechanical Execution)
+
+**Finding**: Workflow steps executed mechanically without proportionality checks
+
+**Evidence from DEFAULT_WORKFLOW.md**:
+
+**Step 7 (Line 233-235)**:
+
+```markdown
+### Step 7: Test Driven Development - Writing Tests First
+
+- [ ] Following the Test Driven Development methodology - use the tester
+      agent to write failing tests (TDD approach) based upon the work done so far.
+```
+
+**NO EXCEPTIONS CLAUSE**. No "skip if trivial" guidance. No proportionality principle.
+
+**Step 5 (Line 203-226)**: Research and Design
+
+- Architect agent invoked for 2-line config change
+- API designer considered (not applicable)
+- Database agent considered (not applicable)
+- Security agent invoked (for CSS visibility?)
+
+**The Workflow Problem**:
+
+```
+Step 5: Research and Design
+→ Invokes architect agent
+→ Architect creates elaborate design for "GitHub link feature"
+→ Design includes testing strategy, architecture diagrams, etc.
+
+Step 7: TDD
+→ Invokes tester agent
+→ Tester sees "design" and creates comprehensive test suite
+→ 58 tests generated
+
+Step 8: Implementation
+→ Builder implements from design
+→ 2 lines added to mkdocs.yml
+→ Massive mismatch between tests and implementation
+```
+
+**Root Issue**: Each agent operates in isolation, seeing only their step's context, not the FULL PICTURE of "this is just 2 config lines."
+
+---
+
+### 3. Agent Context Loss
+
+**Finding**: Agents lose sight of implementation simplicity during workflow execution
+
+**Context Decay Pattern**:
+
+```
+User Request: "Add GitHub link to docs header"
+  ↓
+Step 2 (prompt-writer): Clarifies to "Add GitHub icon link visibility"
+  ↓
+Step 5 (architect): Designs "GitHub Integration Feature"
+  ↓ (Context amplification, not preservation)
+Step 7 (tester): Tests "Complete GitHub Link System"
+  ↓ (Context further amplified)
+Step 8 (builder): Implements 2 lines
+  ↓ (Reality check - but tests already written)
+Result: 58 tests for 2 lines
+```
+
+**Why This Happens**:
+
+1. **Agent handoff loses simplicity signal**: Each agent receives "design a feature" not "this is trivial"
+2. **No shared context about implementation size**: Tester doesn't know implementation is 2 lines
+3. **Design-first workflow**: Design created BEFORE knowing implementation complexity
+4. **No feedback loop**: Builder realizes it's trivial AFTER tester creates 58 tests
+
+**Missing Mechanism**: Shared context artifact tracking "this is a trivial change"
+
+---
+
+### 4. Missing Proportionality Checks
+
+**Finding**: No workflow stage validates "effort matches change size"
+
+**Philosophy Reference** (PHILOSOPHY.md line 141):
+
+```markdown
+5. **Value**: "Does the complexity add proportional value?"
+```
+
+**Philosophy EXISTS but NOT ENFORCED in workflow.**
+
+**Where Checks Should Exist**:
+
+**Check Point 1: After Step 5 (Design)**
+
+```markdown
+### Proportionality Gate
+
+Before proceeding to TDD, verify:
+
+- [ ] Design complexity matches implementation size
+- [ ] If implementation < 10 lines, skip to simplified testing
+- [ ] If config-only change, use verification workflow instead
+```
+
+**Check Point 2: After Step 7 (TDD)**
+
+```markdown
+### Test Coverage Proportionality
+
+Verify test suite proportional to implementation:
+
+- [ ] Test count < 5x implementation complexity
+- [ ] Tests focus on critical paths, not exhaustive coverage
+- [ ] Config changes have verification tests, not unit tests
+```
+
+**Check Point 3: Step 9 (Refactor)**
+
+```markdown
+### Ruthless Simplification - Test Edition
+
+- [ ] Remove tests that don't add value
+- [ ] Consolidate redundant test cases
+- [ ] Verify test suite matches implementation complexity
+```
+
+**Current State**: Step 9 exists (line 246-249) but focuses on CODE simplification, not TEST simplification.
+
+---
+
+### 5. TDD Misapplication
+
+**Finding**: TDD applied universally without considering change type
+
+**TDD Appropriateness Matrix** (MISSING from workflow):
+
+| Change Type    | TDD Appropriate? | Testing Approach                    |
+| -------------- | ---------------- | ----------------------------------- |
+| New Algorithm  | ✅ YES           | Write failing tests first, iterate  |
+| Business Logic | ✅ YES           | Test edge cases, validations        |
+| API Endpoint   | ✅ YES           | Contract tests, integration tests   |
+| Config Change  | ❌ NO            | Verification: does it build/deploy? |
+| CSS Styling    | ❌ NO            | Visual regression tests (manual)    |
+| Documentation  | ❌ NO            | Link checker, spell check           |
+
+**Issue #1931 Classification**: Config Change → TDD NOT appropriate
+
+**What Was Needed**:
+
+```yaml
+Testing Strategy: VERIFICATION
+- Run: mkdocs build (does it succeed?)
+- Check: generated site includes GitHub link
+- Verify: link points to correct URL
+Total tests: 1 build verification test
+```
+
+**What Was Created**:
+
+```yaml
+Testing Strategy: COMPREHENSIVE TDD
+- Unit tests: 58 files
+- Integration tests: included
+- Architecture tests: included
+Total tests: 29,257 lines
+```
+
+**The TDD Trap**:
+
+> "When you have a hammer (TDD), everything looks like a nail."
+
+Step 7 says "use TDD" without qualifying WHEN TDD adds value vs when it's overkill.
+
+---
+
+## Warning Signs We Missed
+
+### Signal 1: Issue Description
+
+Issue #1931 body (from `gh issue view 1931`):
+
+```markdown
+## Current State
+
+The mkdocs.yml configuration already includes:
+
+- repo_url: https://github.com/rysweet/amplihack (line 9)
+- repo_name: rysweet/amplihack (line 8)
+- theme.icon.repo: fontawesome/brands/github (line 46)
+
+## Requirements
+
+- Verify GitHub link appears in header on all documentation pages
+```
+
+**RED FLAG**: Issue says "verify" and "current state already includes config" - this is NOT a new feature, it's VERIFICATION of existing feature visibility.
+
+**Should Have Triggered**: VERIFICATION workflow, not DEVELOPMENT workflow
+
+### Signal 2: File Type
+
+**Change File**: `mkdocs.yml` (YAML configuration)
+
+**Characteristics**:
+
+- Declarative (not imperative)
+- No logic, no algorithms
+- No data transformations
+- Pure configuration
+
+**Should Have Triggered**: Config change workflow (simplified testing)
+
+### Signal 3: User Language
+
+User request keywords:
+
+- "Add GitHub link" (not "implement GitHub integration")
+- "to docs header" (presentational change)
+- No mention of: logic, validation, error handling, edge cases
+
+**Complexity Indicators ABSENT**:
+
+- No "when X then Y" (conditional logic)
+- No "handle errors" (error handling)
+- No "validate input" (validation)
+- No "integrate with" (external dependencies)
+
+**Should Have Triggered**: Trivial change classification
+
+### Signal 4: Step 8 Reality Check
+
+When builder agent implemented in Step 8, they added **2 lines** to mkdocs.yml.
+
+**This Should Have Triggered**:
+
+```markdown
+⚠️ PROPORTIONALITY ALERT
+
+Implementation: 2 lines
+Tests written: 58 files (29,257 lines)
+Ratio: 14,628:1 (tests:code)
+
+RECOMMENDED ACTION:
+
+1. Delete 95% of tests
+2. Keep 1-2 verification tests
+3. Flag workflow for proportionality issue
+```
+
+**But NO mechanism exists to surface this alert.**
+
+---
+
+## Prevention Mechanisms
+
+### Mechanism 1: Task Classification Enhancement
+
+**Location**: `.claude/agents/amplihack/specialized/prompt-writer.md`
+
+**Add Classification Category**:
+
+```markdown
+### 1. Task Classification (MANDATORY FIRST STEP)
+
+**Classification Logic (keyword-based, < 5 seconds):**
+
+1. **TRIVIAL** - Simple changes requiring no architecture:
+   - Config file edits (_.yml, _.json, \*.toml)
+   - Single-line fixes
+   - Presentational changes (CSS, styling)
+   - Documentation updates
+   - **Keywords**: "add to config", "change setting", "update value"
+   - **Workflow**: VERIFICATION_WORKFLOW (5-10 min)
+
+2. **SIMPLE** - Straightforward changes with minimal testing:
+   - < 50 lines of code
+   - No new dependencies
+   - No architecture changes
+   - **Keywords**: "add function", "update logic", "fix bug"
+   - **Workflow**: SIMPLIFIED_WORKFLOW (30-60 min)
+
+3. **COMPLEX** - Full workflow required:
+   - New features with architecture
+   - Multiple file changes
+   - Integration with external systems
+   - **Keywords**: "implement", "integrate", "design"
+   - **Workflow**: DEFAULT_WORKFLOW (2-8 hours)
+```
+
+**Classification Actions**:
+
+```markdown
+**For TRIVIAL requests:**
+
+Task Classification: TRIVIAL
+
+WARNING: This is a simple config/doc change. Do NOT use full workflow.
+
+- Skip: Architecture design (Step 5)
+- Skip: Comprehensive TDD (Step 7)
+- Use: Verification testing only
+- Estimated time: 5-10 minutes
+- Workflow: VERIFICATION_WORKFLOW
+
+Steps:
+
+1. Make change
+2. Verify (build succeeds, visual check)
+3. Commit and PR
+```
+
+### Mechanism 2: Proportionality Gates in Workflow
+
+**Location**: `.claude/workflow/DEFAULT_WORKFLOW.md`
+
+**Add After Step 5 (Design)**:
+
+````markdown
+### Step 5.5: Proportionality Check (MANDATORY)
+
+Before proceeding to TDD, verify design matches implementation size:
+
+**Implementation Size Estimate**:
+
+- [ ] Count estimated lines of code to be changed
+- [ ] Classify: TRIVIAL (< 10 lines), SIMPLE (10-50 lines), COMPLEX (50+ lines)
+
+**Proportionality Decision**:
+
+```yaml
+If TRIVIAL:
+  - Skip comprehensive TDD (Step 7)
+  - Use verification testing only
+  - Reason: "Config change - verify it works"
+
+If SIMPLE:
+  - Simplified TDD (1-2 test files max)
+  - Focus on critical path only
+
+If COMPLEX:
+  - Proceed with full TDD (Step 7)
+```
+````
+
+**Anti-Pattern Prevention**:
+
+- ❌ DO NOT create elaborate test suites for config changes
+- ❌ DO NOT write 50+ tests for < 10 lines of code
+- ✅ DO match test effort to implementation complexity
+
+````
+
+**Add After Step 7 (TDD)**:
+```markdown
+### Step 7.5: Test Proportionality Validation
+
+Verify test suite size is proportional to implementation:
+
+**Proportionality Formula**:
+````
+
+Test Ratio = (Test Lines) / (Implementation Lines)
+
+Target Ratios:
+
+- Config changes: 1:1 to 2:1 (verification only)
+- Business logic: 3:1 to 5:1 (comprehensive tests)
+- Critical paths: 5:1 to 10:1 (exhaustive tests)
+
+```
+
+**Validation Checklist**:
+- [ ] Test ratio within target range for change type
+- [ ] If ratio > 10:1, review for over-testing
+- [ ] Remove redundant or low-value tests
+- [ ] Consolidate similar test cases
+
+**Escalation**: If ratio > 15:1, pause and consult prompt-writer agent to re-classify task complexity.
+```
+
+### Mechanism 3: Agent Handoff Context Preservation
+
+**Problem**: Context about "this is trivial" lost during agent handoffs
+
+**Solution**: Shared context artifact
+
+**Create**: `.claude/runtime/current_task_context.json`
+
+```json
+{
+  "task_id": "issue-1931",
+  "classification": "TRIVIAL",
+  "complexity_estimate": "< 10 lines",
+  "change_type": "config",
+  "workflow_mode": "VERIFICATION",
+  "skip_steps": [5, 7],
+  "reasoning": "Single config file change for presentational feature",
+  "created_by": "prompt-writer",
+  "created_at": "2024-01-14T10:00:00Z"
+}
+```
+
+**Usage**: Every agent reads this file FIRST before executing their step.
+
+**Agent Behavior**:
+
+```python
+# In each agent's initialization
+task_context = read_task_context()
+
+if task_context.classification == "TRIVIAL":
+    log("Task classified as TRIVIAL - using simplified approach")
+    if current_step in task_context.skip_steps:
+        log(f"Step {current_step} skipped for TRIVIAL tasks")
+        return SkipStep(reason=task_context.reasoning)
+```
+
+### Mechanism 4: Step-Specific Proportionality Checks
+
+**Step 5 (architect)**: Add complexity reality check
+
+```markdown
+### Before Designing
+
+- [ ] Check task classification (from task_context.json)
+- [ ] If TRIVIAL: Do NOT create elaborate architecture
+- [ ] If config change: Design is "change config value X to Y"
+```
+
+**Step 7 (tester)**: Add test count guidelines
+
+```markdown
+### Before Writing Tests
+
+- [ ] Check implementation size estimate (from architect or context)
+- [ ] Calculate target test count using proportionality formula
+- [ ] If config change: Write 1-2 verification tests ONLY
+- [ ] NO unit tests for declarative config files
+```
+
+**Step 9 (cleanup)**: Add test simplification
+
+```markdown
+### Cleanup - Test Suite Edition
+
+- [ ] Review test suite for proportionality
+- [ ] Delete redundant tests (similar test cases)
+- [ ] Delete low-value tests (trivial assertions)
+- [ ] Consolidate integration tests
+- [ ] Target: Test ratio < 10:1 for most changes
+```
+
+### Mechanism 5: Sanity Check Agent
+
+**New Agent**: `.claude/agents/amplihack/specialized/sanity-checker.md`
+
+**Invoked**: After Step 7 (TDD), before Step 8 (Implementation)
+
+**Responsibilities**:
+
+```markdown
+## Sanity Checker Agent
+
+You prevent over-engineering by validating proportionality before implementation.
+
+### Validation Checks
+
+1. **Test Count Sanity**:
+   - Count test files created in Step 7
+   - If > 10 test files: FLAG for review
+   - If > 1000 lines of tests: FLAG for review
+
+2. **Architecture-Implementation Mismatch**:
+   - Compare design complexity (Step 5) to implementation estimate
+   - If mismatch (complex design, simple impl): FLAG for review
+
+3. **Change Type Validation**:
+   - Check file types being changed
+   - If config files only: Validate no business logic tests exist
+
+4. **Proportionality Formula**:
+   - Estimated test lines / estimated implementation lines
+   - If ratio > 15:1: FLAG for review
+   - If ratio > 50:1: AUTO-REJECT, escalate to human
+
+### Output
+
+Return one of:
+
+- PASS: Proportional, proceed to implementation
+- REVIEW: Potential over-engineering, recommend simplification
+- REJECT: Obvious over-engineering, require redesign
+```
+
+---
+
+## Workflow Improvements Needed
+
+### Improvement 1: Create VERIFICATION_WORKFLOW.md
+
+**Location**: `.claude/workflow/VERIFICATION_WORKFLOW.md`
+
+```markdown
+# Verification Workflow
+
+For TRIVIAL changes: config edits, doc updates, single-line fixes
+
+## When to Use
+
+- Config file changes (_.yml, _.json, \*.toml)
+- Documentation updates
+- Presentational changes (CSS, styling)
+- Simple fixes < 10 lines
+
+## Workflow Steps (5 total)
+
+### Step 1: Make Change
+
+- [ ] Edit the file(s)
+- [ ] Verify syntax (linter, formatter)
+
+### Step 2: Verify Locally
+
+- [ ] Run build command (if applicable)
+- [ ] Visual check (if UI change)
+- [ ] Test command succeeds (if CLI change)
+
+### Step 3: Commit
+
+- [ ] Commit with descriptive message
+- [ ] Push to branch
+
+### Step 4: Create PR
+
+- [ ] Create PR with brief description
+- [ ] Link to issue (if exists)
+
+### Step 5: Verify CI
+
+- [ ] CI passes
+- [ ] Request review
+- [ ] Merge when approved
+
+**Total Time**: 5-10 minutes
+**Tests Required**: Verification only (does it build?)
+```
+
+### Improvement 2: Update DEFAULT_WORKFLOW.md Classification Section
+
+**Add at Top** (after frontmatter):
+
+```markdown
+## ⚠️ WORKFLOW SELECTION (Read This First)
+
+**This workflow is for NON-TRIVIAL changes only.**
+
+### Quick Classification
+
+Before starting, classify your task:
+
+| Classification | Description                                         | Use Workflow          |
+| -------------- | --------------------------------------------------- | --------------------- |
+| **TRIVIAL**    | Config edit, doc update, < 10 lines                 | VERIFICATION_WORKFLOW |
+| **SIMPLE**     | Straightforward change, < 50 lines, no architecture | SIMPLIFIED_WORKFLOW   |
+| **COMPLEX**    | New feature, architecture needed, 50+ lines         | DEFAULT_WORKFLOW      |
+
+### Classification Questions
+
+Ask yourself:
+
+1. Is this a config file edit only? → **TRIVIAL**
+2. Is this < 10 lines with no architecture needed? → **TRIVIAL**
+3. Is this < 50 lines with clear implementation? → **SIMPLE**
+4. Does this need design, architecture, or complex logic? → **COMPLEX**
+
+**If TRIVIAL or SIMPLE**: STOP. Use the appropriate simplified workflow.
+
+**If COMPLEX**: Continue with this workflow.
+```
+
+### Improvement 3: Add Proportionality Principle to PHILOSOPHY.md
+
+**Location**: `.claude/context/PHILOSOPHY.md`
+
+**Add Section**:
+
+```markdown
+## Proportionality Principle
+
+### Effort Must Match Complexity
+
+**Core Tenet**: The effort invested in any aspect of development (design, testing, documentation) must be proportional to the complexity and criticality of the change.
+
+### Proportionality in Practice
+
+**Testing Proportionality**:
+```
+
+Test Ratio = (Lines of Test Code) / (Lines of Implementation Code)
+
+Target Ratios by Change Type:
+
+- Config changes: 1:1 to 2:1 (verification only)
+- Simple functions: 2:1 to 4:1 (basic coverage)
+- Business logic: 3:1 to 8:1 (comprehensive)
+- Critical paths: 5:1 to 15:1 (exhaustive)
+
+RED FLAG: Ratio > 20:1 indicates likely over-testing
+
+```
+
+**Design Proportionality**:
+- 2-line config change → No architecture document needed
+- 50-line feature → Brief design outline
+- 500-line system → Comprehensive architecture
+
+**Documentation Proportionality**:
+- Internal function → Docstring only
+- Public API → API docs + examples
+- Major feature → Guide + reference + examples
+
+### Proportionality Anti-Patterns
+
+❌ **Over-Engineering Indicators**:
+1. Writing 58 tests for 2 lines of code (ratio 14,628:1)
+2. Creating architecture diagrams for config changes
+3. Writing more test code than implementation code for simple utilities
+4. Elaborate abstractions for one-time operations
+
+✅ **Proportional Engineering**:
+1. Match test coverage to criticality and complexity
+2. Design depth matches implementation scope
+3. Documentation matches audience needs (internal vs external)
+4. Abstractions justify their own complexity (3:1 benefit-to-cost minimum)
+
+### When to Question Proportionality
+
+Stop and reassess if:
+- Test code > 10x implementation code (for non-critical paths)
+- Architecture doc > 5 pages for < 100 lines of code
+- Spent > 1 hour on a "simple fix"
+- Created > 5 abstraction layers for a single feature
+
+**Remember**: Complexity must always justify itself. Default to simplicity.
+```
+
+---
+
+## Agent Behavior Changes Needed
+
+### Change 1: prompt-writer Agent Enhancement
+
+**Add to prompt-writer.md** (after line 100):
+
+````markdown
+### 2. Complexity Assessment (MANDATORY SECOND STEP)
+
+After classification, estimate implementation complexity:
+
+**Complexity Indicators**:
+
+```yaml
+TRIVIAL (< 10 lines):
+  - Single config value change
+  - Documentation update
+  - CSS/styling tweak
+  - Flag: "add to config", "change setting"
+
+SIMPLE (10-50 lines):
+  - Single function addition
+  - Straightforward bug fix
+  - Simple API endpoint
+  - Flag: "add function", "fix bug"
+
+COMPLEX (50+ lines):
+  - New feature with architecture
+  - Multiple file changes
+  - External integrations
+  - Flag: "implement", "integrate", "design"
+```
+````
+
+**Output Format**:
+
+```markdown
+## Complexity Assessment
+
+**Classification**: TRIVIAL
+**Estimated Lines**: < 10
+**Recommended Workflow**: VERIFICATION_WORKFLOW
+**Estimated Time**: 5-10 minutes
+
+**Justification**:
+
+- Change Type: Config file edit
+- Files Affected: 1 (mkdocs.yml)
+- No logic changes
+- No new dependencies
+- Verification: Run mkdocs build
+
+**Testing Strategy**:
+
+- Verification only
+- No unit tests needed (config has no logic)
+- Test: `mkdocs build` succeeds
+- Manual: Verify GitHub link visible in header
+```
+
+**This assessment is passed to ALL subsequent agents.**
+
+````
+
+### Change 2: architect Agent Constraint
+
+**Add to architect.md**:
+
+```markdown
+## Before Designing
+
+**MANDATORY: Read task_context.json first**
+
+```python
+task_context = read_task_context()
+
+if task_context.classification == "TRIVIAL":
+    return SimpleDesign(
+        change="Add X to config file",
+        verification="Run build command",
+        skip_architecture=True,
+        reason="Trivial config change - no architecture needed"
+    )
+````
+
+**Design Proportionality**:
+
+- TRIVIAL tasks: 2-3 sentence design ("Change X in file Y")
+- SIMPLE tasks: 1-paragraph design with bullet points
+- COMPLEX tasks: Multi-section design with diagrams
+
+**RED FLAG**: If writing > 1 page of design for TRIVIAL task, STOP and re-classify.
+
+````
+
+### Change 3: tester Agent Constraint
+
+**Add to tester.md**:
+
+```markdown
+## Before Writing Tests
+
+**MANDATORY: Check implementation complexity**
+
+```python
+task_context = read_task_context()
+implementation_estimate = get_implementation_size_estimate()
+
+if task_context.classification == "TRIVIAL":
+    return VerificationTests(
+        test_count=1,
+        test_type="Build verification",
+        reason="Config change - verify build succeeds",
+        skip_unit_tests=True
+    )
+
+if task_context.change_type == "config":
+    return ConfigTests(
+        test_count=2,
+        tests=["build succeeds", "config value set correctly"],
+        reason="Config files have no logic - verification only"
+    )
+````
+
+**Test Proportionality Guidelines**:
+
+```yaml
+Config Changes:
+  - Test count: 1-2
+  - Test type: Verification (does it build/deploy?)
+  - NO unit tests (config has no logic)
+
+Simple Functions:
+  - Test count: 2-5
+  - Test type: Basic coverage + edge cases
+  - Focus: Happy path + 1-2 edge cases
+
+Complex Logic:
+  - Test count: 5-15
+  - Test type: Comprehensive coverage
+  - Focus: All paths + edge cases + error handling
+```
+
+**RED FLAG**: If writing > 10 tests for TRIVIAL task, STOP and re-classify.
+
+````
+
+### Change 4: cleanup Agent Enhancement
+
+**Add to cleanup.md**:
+
+```markdown
+## Test Suite Simplification (NEW)
+
+After code simplification, simplify test suite:
+
+### Test Proportionality Audit
+
+1. **Count Tests**:
+   - Total test files
+   - Total test lines
+   - Calculate ratio: test_lines / implementation_lines
+
+2. **Proportionality Check**:
+   ```python
+   ratio = test_lines / implementation_lines
+
+   if ratio > 20:
+       flag_for_cleanup("Severe over-testing")
+   elif ratio > 10:
+       flag_for_review("Potential over-testing")
+````
+
+3. **Test Consolidation**:
+   - Remove redundant tests (similar test cases)
+   - Remove trivial tests (assert True, basic getters)
+   - Consolidate integration tests
+   - Keep critical path tests only
+
+4. **Config Change Special Case**:
+   - If all changes are config files: Keep 1-2 verification tests ONLY
+   - Delete all unit tests for config values
+   - Rationale: Config files have no logic to test
+
+### Output
+
+```markdown
+## Test Simplification Results
+
+**Before**: 58 test files, 29,257 lines
+**After**: 2 test files, 45 lines
+**Ratio**: 14,628:1 → 22:1 (within target for verification)
+
+**Deleted**:
+
+- 56 redundant unit tests (config has no logic)
+- Kept: build verification + visual check
+
+**Reasoning**: Config change requires verification only, not unit testing.
+```
+
+```
+
+---
+
+## Specific Prevention for Issue #1931
+
+### What Should Have Happened
+
+```
+
+Step 0: Workflow Preparation
+→ Read DEFAULT_WORKFLOW.md
+→ See classification section: "Is this TRIVIAL?"
+→ YES: Config file edit, presentational change
+→ STOP: Use VERIFICATION_WORKFLOW instead
+
+VERIFICATION_WORKFLOW:
+Step 1: Edit mkdocs.yml (add lines 45-46)
+Step 2: Run `mkdocs build` (verify succeeds)
+Step 3: Visual check (GitHub link visible?)
+Step 4: Commit and PR
+Step 5: CI passes, merge
+
+Total time: 5-10 minutes
+Total tests: 1 (build verification)
+
+```
+
+### What Actually Happened
+
+```
+
+Step 0: Workflow Preparation
+→ Read DEFAULT_WORKFLOW.md
+→ No classification section
+→ Assume: Use full workflow
+
+Step 2: prompt-writer clarifies requirements
+→ No complexity assessment
+→ Passes to architect as "feature"
+
+Step 5: architect designs "GitHub link feature"
+→ No proportionality check
+→ Creates architecture for 2-line change
+
+Step 7: tester writes comprehensive tests
+→ No proportionality check
+→ 58 tests created
+
+Step 8: builder implements
+→ Adds 2 lines to mkdocs.yml
+→ No feedback to previous steps
+
+Result: 58 tests for 2 lines (ratio 14,628:1)
+
+```
+
+---
+
+## Summary of Fixes Needed
+
+### Immediate (High Priority)
+
+1. **Add Classification Section to DEFAULT_WORKFLOW.md**
+   - TRIVIAL vs SIMPLE vs COMPLEX
+   - Clear routing to simplified workflows
+
+2. **Create VERIFICATION_WORKFLOW.md**
+   - 5-step simplified workflow for trivial changes
+   - Target time: 5-10 minutes
+
+3. **Add Proportionality Gates**
+   - After Step 5: Design proportionality check
+   - After Step 7: Test proportionality validation
+
+4. **Enhance prompt-writer Agent**
+   - Add complexity assessment (MANDATORY second step)
+   - Output includes estimated lines and recommended workflow
+
+### Medium Priority
+
+5. **Create sanity-checker Agent**
+   - Invoked after Step 7 (TDD)
+   - Validates test proportionality
+   - Flags over-engineering
+
+6. **Add task_context.json Artifact**
+   - Shared context across agent handoffs
+   - Preserves "this is trivial" signal
+   - All agents read before executing
+
+7. **Update Agent Behavior**
+   - architect: Skip elaborate design for TRIVIAL tasks
+   - tester: Skip comprehensive TDD for TRIVIAL tasks
+   - cleanup: Add test suite simplification
+
+### Low Priority
+
+8. **Add Proportionality Principle to PHILOSOPHY.md**
+   - Codify target ratios (test:code)
+   - Document anti-patterns
+   - Provide decision framework
+
+9. **Create Proportionality Audit Tool**
+   - Runs after workflow completion
+   - Reports ratios (test:code, design:code, docs:code)
+   - Flags outliers for review
+
+10. **Add Proportionality Metrics to CI**
+    - Fail PR if test:code ratio > 50:1 (for non-critical paths)
+    - Warning if ratio > 15:1
+    - Force review on outliers
+
+---
+
+## Lessons Learned
+
+### What Went Wrong
+
+1. **No task classification before workflow execution**
+   - Assumed all tasks need full workflow
+   - No routing to simplified workflows
+
+2. **Mechanical workflow execution**
+   - Each step executed in isolation
+   - No proportionality validation
+   - No feedback loop from reality (2 lines) to plan (58 tests)
+
+3. **Agent context loss**
+   - "This is trivial" signal not preserved across handoffs
+   - Each agent amplified complexity instead of questioning it
+
+4. **TDD misapplication**
+   - Applied universally without considering change type
+   - Config changes don't need unit tests (they have no logic)
+
+5. **Missing proportionality principle**
+   - Philosophy mentions it, but not enforced
+   - No gates to catch disproportionate effort
+
+### Key Insights
+
+> **Complexity must always justify itself.**
+
+- 2-line config change does NOT justify 58 tests
+- Config files have no logic → No unit tests needed
+- Verification (does it build?) is sufficient
+
+> **Workflows need escape hatches.**
+
+- Not every change needs full DEFAULT_WORKFLOW
+- Trivial changes need simplified workflows
+- Proportionality checks are mandatory gates, not optional
+
+> **Agent handoffs must preserve context.**
+
+- "This is trivial" signal must travel with task
+- Shared artifacts prevent context loss
+- Each agent should question if they're over-engineering
+
+### Prevention Checklist
+
+Before starting ANY task, answer:
+
+1. **Is this TRIVIAL?** (< 10 lines, config/doc only)
+   - YES → Use VERIFICATION_WORKFLOW
+   - NO → Continue
+
+2. **Is this SIMPLE?** (< 50 lines, no architecture)
+   - YES → Use SIMPLIFIED_WORKFLOW
+   - NO → Continue
+
+3. **Is this COMPLEX?** (50+ lines, architecture needed)
+   - YES → Use DEFAULT_WORKFLOW
+
+After EACH workflow step, validate:
+
+4. **Is design proportional to implementation size?**
+   - Elaborate design for 2 lines → NO, simplify
+
+5. **Is test count proportional to implementation complexity?**
+   - 58 tests for 2 lines → NO, reduce to verification only
+
+6. **Does this feel like over-engineering?**
+   - Trust your instincts → Question complexity
+
+---
+
+## Recommended Next Steps
+
+1. **Immediate Action** (Today):
+   - Add classification section to DEFAULT_WORKFLOW.md (top of file)
+   - Create VERIFICATION_WORKFLOW.md (5 steps, 5-10 min target)
+   - Update prompt-writer agent to include complexity assessment
+
+2. **This Week**:
+   - Add proportionality gates after Steps 5 and 7
+   - Create sanity-checker agent
+   - Implement task_context.json shared artifact
+   - Update architect, tester, cleanup agents with proportionality checks
+
+3. **This Month**:
+   - Add proportionality principle to PHILOSOPHY.md
+   - Create proportionality audit tool
+   - Add proportionality metrics to CI
+   - Document proportionality anti-patterns in PATTERNS.md
+
+4. **Validation**:
+   - Test with Issue #1931: Verify takes 5-10 min with new classification
+   - Test with 5 historical "trivial" issues: Verify routing works
+   - Test with 5 "complex" issues: Verify full workflow still applies
+
+---
+
+## Closing Thoughts
+
+This failure is **embarrassing but instructive**. The system blindly followed a workflow designed for complex features when a trivial config change was requested.
+
+**Root cause**: Lack of proportionality validation at critical gates.
+
+**Fix**: Add task classification + proportionality checks + simplified workflows for trivial changes.
+
+**Philosophy alignment**: This fix embodies "ruthless simplicity" - the workflow itself must be simple and proportional, not just the code it produces.
+
+**User trust**: By catching this, fixing it, and documenting it, we demonstrate commitment to quality and learning from mistakes. This is how systems improve.
+
+---
+
+**Analysis completed**: 2026-01-14
+**Issue**: #1931
+**Root cause**: Workflow blindness + missing proportionality checks
+**Status**: Recommendations ready for implementation
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,8 @@ theme:
     - toc.follow
     - content.code.copy
     - content.code.annotate
+    - content.action.edit
+    - content.action.view
   icon:
     repo: fontawesome/brands/github
 


### PR DESCRIPTION
## Summary

Enables GitHub integration links in the MkDocs documentation header bar by adding Material for MkDocs features.

## Changes

- **mkdocs.yml**: Added `content.action.edit` and `content.action.view` to `theme.features`
- **docs/development/case-studies/issue-1931-proportionality.md**: Root cause analysis documenting initial over-engineering and lessons learned

## What This Does

The Material for MkDocs theme automatically creates GitHub integration links in the blue header bar when these features are enabled:

1. **"Edit this page" button** - Links to GitHub source for editing
2. **"View source" button** - Links to view file on GitHub  
3. **GitHub repository icon** - Already configured via existing `repo_url` setting

## Test Plan

- [x] mkdocs build --clean --strict: SUCCESS (no errors)
- [x] Pre-commit hooks: All passed
- [x] Config validation: Confirmed valid YAML
- [ ] Manual verification: After deployment, verify GitHub icon appears in header at https://rysweet.github.io/amplihack/
- [ ] Manual verification: Click link to confirm it opens https://github.com/rysweet/amplihack
- [ ] Manual verification: Verify "Edit this page" and "View source" buttons appear and work

## Philosophy Note

This PR demonstrates ruthless simplicity. Initial implementation attempted elaborate testing (58 tests for 2-line config change). After user feedback, we applied proportionality principle: just the 2-line config change needed.

The included analysis document (docs/development/case-studies/issue-1931-proportionality.md) captures:
- Why over-engineering happened (workflow blindness, no proportionality checks)
- How to prevent it (task classification, proportionality gates)
- Specific fixes needed (VERIFICATION_WORKFLOW, sanity-checker agent)

## Testing Results

```
mkdocs build --clean --strict
✅ Build succeeded with no errors
✅ Config changes validated
✅ No automated tests needed (config has no logic to test)
✅ Manual verification required post-deployment
```

Closes #1931

🤖 Generated with [Claude Code](https://claude.com/claude-code)