### PR TITLE
feat(memory): Migrate DISCOVERIES.md references to Kuzu memory backend

### DIFF
--- a/.claude/agents/amplihack/core/reviewer.md
+++ b/.claude/agents/amplihack/core/reviewer.md
@@ -146,7 +146,7 @@ Fix: [Minimal solution]
 - Implement minimal solution
 - Add regression test
 - Document the issue
-- Update DISCOVERIES.md if novel
+- Store discovery in memory if novel
 
 ## Review Output Format
 
@@ -324,7 +324,7 @@ gh pr comment 123 --body "LGTM! All issues addressed"
 - **Minimal changes**: Fix only what's broken
 - **Root cause**: Address the cause, not symptoms
 - **Add tests**: Prevent regression
-- **Document**: Update DISCOVERIES.md for novel issues
+- **Document**: Store discoveries in memory for novel issues
 - **Simplify**: Can the fix make things simpler?
 
 ## Remember

--- a/.claude/agents/amplihack/specialized/amplifier-cli-architect.md
+++ b/.claude/agents/amplihack/specialized/amplifier-cli-architect.md
@@ -440,7 +440,7 @@ async def coordinate_agents(task: str) -> Dict:
 - **Workflow**: Map decisions to multi-step workflow
 - **Priorities**: Explicit requirements > implicit preferences > philosophy > defaults
 - **Execution**: Support parallel execution where decisions are independent
-- **Knowledge**: Update DISCOVERIES.md with learnings
+- **Knowledge**: Store learnings in memory via discoveries adapter
 
 ## Success Metrics
 

--- a/.claude/agents/amplihack/specialized/fix-agent.md
+++ b/.claude/agents/amplihack/specialized/fix-agent.md
@@ -200,7 +200,7 @@ Execute all 22 steps of DEFAULT_WORKFLOW:
 
 **Step 21: Documentation Updates**
 
-- Update DISCOVERIES.md if needed
+- Store discovery in memory if needed
 - Document fix pattern for future reference
 - Update related documentation
 

--- a/.claude/agents/amplihack/workflows/amplihack-improvement-workflow.md
+++ b/.claude/agents/amplihack/workflows/amplihack-improvement-workflow.md
@@ -145,7 +145,7 @@ Redundancy Check:
 - [ ] No security warnings
 - [ ] No philosophy violations
 - [ ] Documentation updated
-- [ ] DISCOVERIES.md updated if novel
+- [ ] Discoveries stored in memory if novel
 
 ## Complexity Justification
 
@@ -301,9 +301,9 @@ security_issues: [count]
 time_to_complete: [duration]
 ```
 
-### Update DISCOVERIES.md
+### Store Discoveries in Memory
 
-When patterns emerge:
+When patterns emerge, use `store_discovery()` from `amplihack.memory.discoveries`:
 
 ```markdown
 ## Improvement Pattern Discovered

--- a/.claude/skills/cascade-workflow/SKILL.md
+++ b/.claude/skills/cascade-workflow/SKILL.md
@@ -261,7 +261,7 @@ What's Missing:
 - Adjust timeouts based on success rates
 - Improve secondary approaches if frequently used
 - Update tertiary if inadequate
-- Document learnings in `.claude/context/DISCOVERIES.md`
+- Store learnings in memory using `store_discovery()` from `amplihack.memory.discoveries`
 
 **Optimization Criteria:**
 

--- a/.claude/skills/debate-workflow/SKILL.md
+++ b/.claude/skills/debate-workflow/SKILL.md
@@ -349,7 +349,7 @@ Counter: [Additional evidence or reasoning]
 - Document full debate transcript
 - Include all perspective arguments
 - Record synthesis and final decision
-- Add to `.claude/context/DISCOVERIES.md`
+- Store in memory using `store_discovery()` from `amplihack.memory.discoveries`
 - Update relevant architecture docs
 
 **Decision Record Template:**

--- a/.claude/skills/investigation-workflow/SKILL.md
+++ b/.claude/skills/investigation-workflow/SKILL.md
@@ -250,7 +250,7 @@ Verification: Examine reflection logs, trace message processing
 
 **Tasks**:
 
-- **Update .claude/context/DISCOVERIES.md** with key insights
+- **Store discoveries in memory** using `store_discovery()` from `amplihack.memory.discoveries`
 - **Update .claude/context/PATTERNS.md** if reusable patterns found
 - Create or update relevant documentation files
 - Add inline code comments for critical understanding
@@ -275,14 +275,14 @@ Verification: Examine reflection logs, trace message processing
 
 **Success Criteria**:
 
-- DISCOVERIES.md updated with investigation results
+- Discoveries stored in memory for future reference
 - Relevant documentation files updated
 - Knowledge is discoverable by future investigators
 - No information loss
 
 **Deliverables**:
 
-- Updated DISCOVERIES.md
+- Discoveries stored in memory
 - Updated PATTERNS.md (if applicable)
 - Updated project documentation
 - Optional: GitHub issues for improvements
@@ -294,7 +294,7 @@ Verification: Examine reflection logs, trace message processing
 
 1. **Resume at Step 4** (Research and Design) with the knowledge gained from investigation
 2. **Or resume at Step 5** (Implement the Solution) if the investigation already provided clear design guidance
-3. **Use investigation findings** from DISCOVERIES.md and session logs to inform design decisions
+3. **Use investigation findings** from memory (via `get_recent_discoveries()`) and session logs to inform design decisions
 
 **Example Hybrid Workflow**:
 
@@ -304,7 +304,7 @@ User: "/ultrathink investigate how authentication works, then add OAuth support"
 Phase 1: Investigation
 → Run INVESTIGATION_WORKFLOW.md (6 phases)
 → Complete understanding of existing auth system
-→ Document findings in DISCOVERIES.md
+→ Store findings in memory via discoveries adapter
 
 Phase 2: Development
 → Transition to DEFAULT_WORKFLOW.md
@@ -407,7 +407,7 @@ Track these metrics to validate workflow effectiveness:
 
 - **Message Count**: Target 30-40% reduction vs. ad-hoc (to be validated)
 - **Investigation Time**: Track time to completion
-- **Knowledge Reuse**: How often DISCOVERIES.md prevents repeat work
+- **Knowledge Reuse**: How often memory retrieval prevents repeat work
 - **Completeness**: Percentage of investigations with full documentation
 - **User Satisfaction**: Clear understanding achieved
 
@@ -416,7 +416,7 @@ Track these metrics to validate workflow effectiveness:
 - **Scope first, explore second** - Define boundaries before diving in
 - **Parallel exploration is key** - Deploy multiple agents simultaneously in Phase 3
 - **Verify understanding** - Test your hypotheses in Phase 4
-- **Capture knowledge** - Always update DISCOVERIES.md in Phase 6
+- **Capture knowledge** - Always store discoveries in memory in Phase 6
 - **This workflow optimizes for understanding, not implementation**
 
 When in doubt about investigation vs. development:

--- a/.claude/skills/knowledge-extractor/SKILL.md
+++ b/.claude/skills/knowledge-extractor/SKILL.md
@@ -4,8 +4,8 @@ version: 1.0.0
 description: |
   Extracts key learnings from conversations, debugging sessions, and failed attempts.
   Use at session end or after solving complex problems to capture insights.
-  Automatically suggests updates to: DISCOVERIES.md (learnings), PATTERNS.md (reusable solutions), new agent creation (repeated workflows).
-  Ensures knowledge persists across sessions.
+  Stores discoveries in memory (via amplihack.memory.discoveries), suggests PATTERNS.md updates, and recommends new agent creation.
+  Ensures knowledge persists across sessions via Kuzu memory backend.
 ---
 
 # Knowledge Extractor Skill
@@ -251,7 +251,7 @@ Extract and structure knowledge:
 Place knowledge in correct locations:
 
 ```
-DISCOVERIES.md → New discovery at end of file
+Memory → Store discovery using store_discovery() from amplihack.memory.discoveries
 PATTERNS.md → New pattern in appropriate section
 Agent → Create in .claude/agents/amplihack/specialized/
 ```
@@ -426,12 +426,12 @@ Before finalizing an extraction, verify:
 
 ## Integration with System
 
-### DISCOVERIES.md Lifecycle
+### Discovery Memory Lifecycle
 
-1. **Extraction**: Added to DISCOVERIES.md during session
-2. **Visibility**: Immediately available to all agents
-3. **Action**: Agents can reference when solving similar problems
-4. **Prevention**: Prevents repeating same mistakes
+1. **Extraction**: Stored in memory via `store_discovery()` during session
+2. **Visibility**: Retrieved by `get_recent_discoveries()` at session start
+3. **Action**: Agents can query memory when solving similar problems
+4. **Prevention**: Prevents repeating same mistakes across sessions
 5. **Evolution**: Updated when better solution found
 
 ### PATTERNS.md Lifecycle
@@ -455,7 +455,7 @@ Before finalizing an extraction, verify:
 ### Impact 1: Prevent Wasted Debugging Time
 
 **Without knowledge extraction**: Repeat same 45-minute debugging process
-**With extraction**: Reference DISCOVERIES.md, fix in 10 minutes
+**With extraction**: Retrieve from memory, fix in 10 minutes
 
 ### Impact 2: Faster Solution Discovery
 

--- a/.claude/skills/n-version-workflow/SKILL.md
+++ b/.claude/skills/n-version-workflow/SKILL.md
@@ -195,7 +195,7 @@ Selection Criteria Applied:
 - Document all N implementations generated
 - Explain selection rationale in detail
 - Capture insights from rejected versions
-- Update `.claude/context/DISCOVERIES.md` with patterns learned
+- Store patterns learned in memory using `store_discovery()` from `amplihack.memory.discoveries`
 - Include comparison matrix for future reference
 
 ## Trade-Offs

--- a/.claude/skills/philosophy-compliance-workflow/SKILL.md
+++ b/.claude/skills/philosophy-compliance-workflow/SKILL.md
@@ -396,7 +396,7 @@ A successful philosophy review:
 
 - `.claude/runtime/logs/<session>/philosophy_review_<timestamp>.md`
 - Link in commit message if fixes applied
-- Update `.claude/context/DISCOVERIES.md` with patterns learned
+- Store patterns learned in memory using `store_discovery()` from `amplihack.memory.discoveries`
 
 ## Remember
 

--- a/.claude/tools/amplihack/hooks/session_start.py
+++ b/.claude/tools/amplihack/hooks/session_start.py
@@ -196,10 +196,24 @@ class SessionStartHook(HookProcessor):
         context_parts.append("This is the Microsoft Hackathon 2025 Agentic Coding project.")
         context_parts.append("Focus on building AI-powered development tools.")
 
-        # Check for recent discoveries
-        discoveries_file = self.project_root / ".claude" / "context" / "DISCOVERIES.md"
-        if discoveries_file.exists():
-            context_parts.append("\n## Recent Learnings")
+        # Check for recent discoveries from memory
+        context_parts.append("\n## Recent Learnings")
+        try:
+            from amplihack.memory.discoveries import get_recent_discoveries
+
+            recent_discoveries = get_recent_discoveries(days=30, limit=5)
+            if recent_discoveries:
+                context_parts.append(
+                    f"Found {len(recent_discoveries)} recent discoveries in memory:"
+                )
+                for disc in recent_discoveries:
+                    summary = disc.get("summary", "No summary")
+                    category = disc.get("category", "uncategorized")
+                    context_parts.append(f"- [{category}] {summary}")
+            else:
+                context_parts.append("Check .claude/context/DISCOVERIES.md for recent insights.")
+        except ImportError:
+            # Fallback if memory module not available
             context_parts.append("Check .claude/context/DISCOVERIES.md for recent insights.")
 
         # Simplified preference file resolution
@@ -318,8 +332,7 @@ class SessionStartHook(HookProcessor):
 
         if launcher_type == "copilot":
             return CopilotStrategy(self.project_root, self.log)
-        else:
-            return ClaudeStrategy(self.project_root, self.log)
+        return ClaudeStrategy(self.project_root, self.log)
 
     def _check_version_mismatch(self) -> None:
         """Check for version mismatch and offer to update.

--- a/.claude/workflow/INVESTIGATION_WORKFLOW.md
+++ b/.claude/workflow/INVESTIGATION_WORKFLOW.md
@@ -290,7 +290,7 @@ Verification: Examine reflection logs, trace message processing
 
 **Tasks:**
 
-- [ ] **Update .claude/context/DISCOVERIES.md** with key insights
+- [ ] **Store discoveries in memory** using `store_discovery()` from `amplihack.memory.discoveries`
 - [ ] **Update .claude/context/PATTERNS.md** if reusable patterns found
 - [ ] Create or update relevant documentation files
 - [ ] Add inline code comments for critical understanding
@@ -315,14 +315,14 @@ Verification: Examine reflection logs, trace message processing
 
 **Success Criteria:**
 
-- DISCOVERIES.md updated with investigation results
+- Discoveries stored in memory for future reference
 - Relevant documentation files updated
 - Knowledge is discoverable by future investigators
 - No information loss
 
 **Deliverables:**
 
-- Updated DISCOVERIES.md
+- Discoveries stored in memory
 - Updated PATTERNS.md (if applicable)
 - Updated project documentation
 - Optional: GitHub issues for improvements
@@ -334,7 +334,7 @@ Verification: Examine reflection logs, trace message processing
 
 1. **Resume at Step 4** (Research and Design) with the knowledge gained from investigation
 2. **Or resume at Step 5** (Implement the Solution) if the investigation already provided clear design guidance
-3. **Use investigation findings** from DISCOVERIES.md and session logs to inform design decisions
+3. **Use investigation findings** from memory (via `get_recent_discoveries()`) and session logs to inform design decisions
 
 **Example Hybrid Workflow:**
 
@@ -344,7 +344,7 @@ User: "/ultrathink investigate how authentication works, then add OAuth support"
 Phase 1: Investigation
 → Run INVESTIGATION_WORKFLOW.md (6 phases)
 → Complete understanding of existing auth system
-→ Document findings in DISCOVERIES.md
+→ Store findings in memory via discoveries adapter
 
 Phase 2: Development
 → Transition to DEFAULT_WORKFLOW.md
@@ -451,7 +451,7 @@ Track these metrics to validate workflow effectiveness:
 
 - **Message Count**: Target 30-40% reduction vs. ad-hoc (to be validated)
 - **Investigation Time**: Track time to completion
-- **Knowledge Reuse**: How often DISCOVERIES.md prevents repeat work
+- **Knowledge Reuse**: How often memory retrieval prevents repeat work
 - **Completeness**: Percentage of investigations with full documentation
 - **User Satisfaction**: Clear understanding achieved
 
@@ -460,7 +460,7 @@ Track these metrics to validate workflow effectiveness:
 - **Scope first, explore second** - Define boundaries before diving in
 - **Parallel exploration is key** - Deploy multiple agents simultaneously in Phase 3
 - **Verify understanding** - Test your hypotheses in Phase 4
-- **Capture knowledge** - Always update DISCOVERIES.md in Phase 6
+- **Capture knowledge** - Always store discoveries in memory in Phase 6
 - **This workflow optimizes for understanding, not implementation**
 
 When in doubt about investigation vs. development:

--- a/.claude/workflow/N_VERSION_WORKFLOW.md
+++ b/.claude/workflow/N_VERSION_WORKFLOW.md
@@ -271,7 +271,7 @@ See: n_version_analysis.md for full comparison matrix
 - [ ] Document all N implementations generated
 - [ ] Explain selection rationale in detail
 - [ ] Capture insights from rejected versions
-- [ ] Update `.claude/context/DISCOVERIES.md` with patterns learned
+- [ ] Store patterns learned in memory using `store_discovery()` from `amplihack.memory.discoveries`
 - [ ] Include comparison matrix for future reference
 
 **Analysis Document Structure:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,8 @@ Following: .claude/workflow/[WORKFLOW_NAME].md
   judgement, and only stop to ask if really necessary or explicitly instructed
   to do so.
 - **Check discoveries before problem-solving**: Before solving complex problems,
-  check `@docs/DISCOVERIES.md` for known issues and solutions
-- **Document learnings**: Update .claude/context/DISCOVERIES.md with new
-  insights
+  retrieve recent discoveries from memory using `get_recent_discoveries()` from `amplihack.memory.discoveries`
+- **Document learnings**: Store discoveries in memory using `store_discovery()` from `amplihack.memory.discoveries`
 - **Session Logs**: All interactions MUST be logged in
   .claude/runtime/logs/<session_id> where <session_id> is a unique identifier
   for the session based on the timestamp.
@@ -843,14 +842,14 @@ After code changes:
 1. Run tests if available
 2. Check philosophy compliance
 3. Verify module boundaries
-4. Update .claude/context/DISCOVERIES.md with learnings
+4. Store learnings in memory via discoveries adapter
 
 ## Self-Improvement
 
 The system should continuously improve:
 
 - Track patterns in `.claude/context/PATTERNS.md`
-- Document discoveries in `.claude/context/DISCOVERIES.md`
+- Store discoveries in memory for cross-session persistence
 - Update agent definitions as needed
 - Create new agents for repeated tasks
 

--- a/src/amplihack/memory/discoveries.py
+++ b/src/amplihack/memory/discoveries.py
@@ -1,0 +1,114 @@
+"""Discovery memory adapter - sync interface fer session hooks.
+
+Provides simple sync functions to store/retrieve discoveries
+from the memory system. Used by session_start.py hook.
+
+Philosophy:
+- Thin adapter, not an abstraction layer
+- Sync wrappers fer async MemoryCoordinator
+- Discovery-specific metadata structure
+- Graceful fallback when memory unavailable
+
+Public API:
+    store_discovery: Store a discovery in memory
+    get_recent_discoveries: Retrieve recent discoveries fer context
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from .coordinator import MemoryCoordinator, RetrievalQuery, StorageRequest
+from .types import MemoryType
+
+logger = logging.getLogger(__name__)
+
+
+def store_discovery(
+    content: str,
+    *,
+    category: str | None = None,
+    date: datetime | None = None,
+    summary: str | None = None,
+    session_id: str | None = None,
+) -> str | None:
+    """Store a discovery in memory (sync wrapper).
+
+    Args:
+        content: Full discovery content
+        category: Optional category (e.g., "bug-fix", "pattern", "architecture")
+        date: Discovery date (defaults to now)
+        summary: Brief summary (first 100 chars of content if not provided)
+        session_id: Session ID fer coordinator
+
+    Returns:
+        Memory ID if stored, None if rejected or failed
+    """
+    coordinator = MemoryCoordinator(session_id=session_id)
+
+    # Build metadata with discovery-specific fields
+    metadata = {
+        "source": "discovery",
+        "category": category or "uncategorized",
+        "timestamp": (date or datetime.now()).isoformat(),
+        "summary": summary or content[:100].strip(),
+    }
+
+    request = StorageRequest(
+        content=content,
+        memory_type=MemoryType.SEMANTIC,  # Discoveries are long-term learnings
+        metadata=metadata,
+    )
+
+    try:
+        return asyncio.run(coordinator.store(request))
+    except Exception as e:
+        logger.warning(f"Failed to store discovery: {e}")
+        return None  # Graceful failure
+
+
+def get_recent_discoveries(
+    days: int = 30,
+    limit: int = 10,
+    session_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve recent discoveries fer session context.
+
+    Args:
+        days: How far back to look (default 30)
+        limit: Maximum discoveries to return
+        session_id: Session ID fer coordinator
+
+    Returns:
+        List of discovery dicts with content and metadata
+    """
+    coordinator = MemoryCoordinator(session_id=session_id)
+
+    end_time = datetime.now()
+    start_time = end_time - timedelta(days=days)
+
+    query = RetrievalQuery(
+        query_text="discovery learning pattern solution",  # Semantic search terms
+        memory_types=[MemoryType.SEMANTIC],
+        time_range=(start_time, end_time),
+        token_budget=4000,  # Reasonable budget fer context
+    )
+
+    try:
+        memories = asyncio.run(coordinator.retrieve(query))
+        return [
+            {
+                "content": m.content,
+                "date": m.created_at.isoformat() if m.created_at else None,
+                "category": m.metadata.get("category"),
+                "summary": m.metadata.get("summary"),
+            }
+            for m in memories[:limit]
+        ]
+    except Exception as e:
+        logger.warning(f"Failed to retrieve discoveries: {e}")
+        return []  # Graceful failure
+
+
+__all__ = ["store_discovery", "get_recent_discoveries"]

--- a/tests/memory/test_discoveries_adapter.py
+++ b/tests/memory/test_discoveries_adapter.py
@@ -1,0 +1,251 @@
+"""Tests for discovery memory adapter.
+
+TDD tests for the sync adapter that bridges discoveries to memory system.
+Following testing pyramid: focus on unit tests with mocked coordinator.
+
+Test Coverage:
+- store_discovery: Basic storage, metadata structure, error handling
+- get_recent_discoveries: Retrieval, formatting, time filtering
+- Edge cases: Empty results, backend failures
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestStoreDiscovery:
+    """Tests for store_discovery function."""
+
+    def test_store_discovery_basic(self):
+        """Test basic discovery storage."""
+        from amplihack.memory.discoveries import store_discovery
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.store = AsyncMock(return_value="mem-123")
+            mock_coord_cls.return_value = mock_coordinator
+
+            result = store_discovery(
+                content="Discovered that CI failures often caused by Python version mismatch",
+                category="bug-fix",
+            )
+
+            assert result == "mem-123"
+            mock_coordinator.store.assert_called_once()
+
+    def test_store_discovery_metadata_structure(self):
+        """Test that metadata has correct structure."""
+        from amplihack.memory.discoveries import store_discovery
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.store = AsyncMock(return_value="mem-456")
+            mock_coord_cls.return_value = mock_coordinator
+
+            store_discovery(
+                content="Discovery content here",
+                category="pattern",
+                date=datetime(2025, 1, 15, 10, 30),
+                summary="Brief summary",
+            )
+
+            # Get the StorageRequest that was passed
+            call_args = mock_coordinator.store.call_args
+            request = call_args[0][0]
+
+            assert request.metadata["source"] == "discovery"
+            assert request.metadata["category"] == "pattern"
+            assert "2025-01-15" in request.metadata["timestamp"]
+            assert request.metadata["summary"] == "Brief summary"
+
+    def test_store_discovery_default_summary(self):
+        """Test that summary defaults to first 100 chars of content."""
+        from amplihack.memory.discoveries import store_discovery
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.store = AsyncMock(return_value="mem-789")
+            mock_coord_cls.return_value = mock_coordinator
+
+            long_content = "X" * 200  # 200 chars
+            store_discovery(content=long_content)
+
+            call_args = mock_coordinator.store.call_args
+            request = call_args[0][0]
+
+            # Summary should be first 100 chars
+            assert len(request.metadata["summary"]) == 100
+
+    def test_store_discovery_graceful_failure(self):
+        """Test graceful failure when coordinator raises exception."""
+        from amplihack.memory.discoveries import store_discovery
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.store = AsyncMock(side_effect=RuntimeError("Backend unavailable"))
+            mock_coord_cls.return_value = mock_coordinator
+
+            result = store_discovery(content="Test content")
+
+            # Should return None instead of raising
+            assert result is None
+
+    def test_store_discovery_uses_semantic_type(self):
+        """Test that discoveries use SEMANTIC memory type."""
+        from amplihack.memory.discoveries import store_discovery
+        from amplihack.memory.types import MemoryType
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.store = AsyncMock(return_value="mem-abc")
+            mock_coord_cls.return_value = mock_coordinator
+
+            store_discovery(content="Semantic discovery")
+
+            call_args = mock_coordinator.store.call_args
+            request = call_args[0][0]
+
+            assert request.memory_type == MemoryType.SEMANTIC
+
+
+class TestGetRecentDiscoveries:
+    """Tests for get_recent_discoveries function."""
+
+    def test_get_recent_discoveries_basic(self):
+        """Test basic retrieval of recent discoveries."""
+        from amplihack.memory.discoveries import get_recent_discoveries
+
+        mock_memory = MagicMock()
+        mock_memory.content = "Discovery content"
+        mock_memory.created_at = datetime.now()
+        mock_memory.metadata = {"category": "pattern", "summary": "Brief summary"}
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.retrieve = AsyncMock(return_value=[mock_memory])
+            mock_coord_cls.return_value = mock_coordinator
+
+            results = get_recent_discoveries(days=30, limit=10)
+
+            assert len(results) == 1
+            assert results[0]["content"] == "Discovery content"
+            assert results[0]["category"] == "pattern"
+            assert results[0]["summary"] == "Brief summary"
+
+    def test_get_recent_discoveries_empty(self):
+        """Test retrieval when no discoveries exist."""
+        from amplihack.memory.discoveries import get_recent_discoveries
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.retrieve = AsyncMock(return_value=[])
+            mock_coord_cls.return_value = mock_coordinator
+
+            results = get_recent_discoveries()
+
+            assert results == []
+
+    def test_get_recent_discoveries_respects_limit(self):
+        """Test that limit parameter is respected."""
+        from amplihack.memory.discoveries import get_recent_discoveries
+
+        # Create 5 mock memories
+        mock_memories = []
+        for i in range(5):
+            mock_memory = MagicMock()
+            mock_memory.content = f"Discovery {i}"
+            mock_memory.created_at = datetime.now()
+            mock_memory.metadata = {"category": "test", "summary": f"Summary {i}"}
+            mock_memories.append(mock_memory)
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.retrieve = AsyncMock(return_value=mock_memories)
+            mock_coord_cls.return_value = mock_coordinator
+
+            results = get_recent_discoveries(limit=3)
+
+            # Should return only 3 even though 5 available
+            assert len(results) == 3
+
+    def test_get_recent_discoveries_graceful_failure(self):
+        """Test graceful failure when coordinator raises exception."""
+        from amplihack.memory.discoveries import get_recent_discoveries
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.retrieve = AsyncMock(side_effect=RuntimeError("Backend down"))
+            mock_coord_cls.return_value = mock_coordinator
+
+            results = get_recent_discoveries()
+
+            # Should return empty list instead of raising
+            assert results == []
+
+    def test_get_recent_discoveries_uses_semantic_type(self):
+        """Test that retrieval queries SEMANTIC memory type."""
+        from amplihack.memory.discoveries import get_recent_discoveries
+        from amplihack.memory.types import MemoryType
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.retrieve = AsyncMock(return_value=[])
+            mock_coord_cls.return_value = mock_coordinator
+
+            get_recent_discoveries()
+
+            call_args = mock_coordinator.retrieve.call_args
+            query = call_args[0][0]
+
+            assert MemoryType.SEMANTIC in query.memory_types
+
+    def test_get_recent_discoveries_time_range(self):
+        """Test that time range is correctly calculated."""
+        from amplihack.memory.discoveries import get_recent_discoveries
+
+        with patch("amplihack.memory.discoveries.MemoryCoordinator") as mock_coord_cls:
+            mock_coordinator = MagicMock()
+            mock_coordinator.retrieve = AsyncMock(return_value=[])
+            mock_coord_cls.return_value = mock_coordinator
+
+            get_recent_discoveries(days=7)
+
+            call_args = mock_coordinator.retrieve.call_args
+            query = call_args[0][0]
+
+            # Time range should be set
+            assert query.time_range is not None
+            start_time, end_time = query.time_range
+
+            # Start should be ~7 days ago, end should be ~now
+            days_diff = (end_time - start_time).days
+            assert 6 <= days_diff <= 8  # Allow small variance
+
+
+class TestIntegration:
+    """Integration tests with real coordinator (if available)."""
+
+    @pytest.mark.skipif(
+        True,  # Skip by default - enable for integration testing
+        reason="Integration test - requires memory backend",
+    )
+    def test_round_trip_store_retrieve(self):
+        """Test storing and retrieving a discovery."""
+        from amplihack.memory.discoveries import get_recent_discoveries, store_discovery
+
+        # Store a discovery
+        content = f"Integration test discovery at {datetime.now().isoformat()}"
+        memory_id = store_discovery(
+            content=content,
+            category="test",
+            summary="Integration test",
+        )
+
+        assert memory_id is not None
+
+        # Retrieve and verify
+        discoveries = get_recent_discoveries(days=1, limit=10)
+
+        assert any(d["content"] == content for d in discoveries)


### PR DESCRIPTION
## Summary

- Adds thin sync adapter for discovery storage/retrieval via Kuzu memory backend
- Updates session_start.py hook to retrieve discoveries from memory at session start  
- Updates 14 documentation files to reference memory API instead of DISCOVERIES.md file
- Implements graceful fallback when memory unavailable

## Changes

### New Files
- `src/amplihack/memory/discoveries.py` - Thin adapter with `store_discovery()` and `get_recent_discoveries()` (~60 lines)
- `tests/memory/test_discoveries_adapter.py` - 12 tests (11 unit, 1 integration skipped)

### Updated Files
- `.claude/tools/amplihack/hooks/session_start.py` - Now retrieves discoveries from memory
- `CLAUDE.md` - Updated instructions to use memory API
- `.claude/workflow/INVESTIGATION_WORKFLOW.md` - Memory storage instructions
- `.claude/workflow/N_VERSION_WORKFLOW.md` - Memory storage instructions
- `.claude/agents/amplihack/core/reviewer.md` - Memory storage instructions
- `.claude/agents/amplihack/specialized/fix-agent.md` - Memory storage instructions  
- `.claude/agents/amplihack/specialized/amplifier-cli-architect.md` - Memory storage instructions
- `.claude/agents/amplihack/workflows/amplihack-improvement-workflow.md` - Memory storage instructions
- `.claude/skills/investigation-workflow/SKILL.md` - Memory storage instructions
- `.claude/skills/n-version-workflow/SKILL.md` - Memory storage instructions
- `.claude/skills/philosophy-compliance-workflow/SKILL.md` - Memory storage instructions
- `.claude/skills/knowledge-extractor/SKILL.md` - Memory lifecycle description
- `.claude/skills/cascade-workflow/SKILL.md` - Memory storage instructions
- `.claude/skills/debate-workflow/SKILL.md` - Memory storage instructions

## Test plan

- [x] Unit tests pass (11/12 passing, 1 integration skipped)
- [x] Pre-commit hooks pass
- [x] Local integration test: storage returns memory ID
- [x] Local integration test: retrieval gracefully degrades when Kuzu unavailable
- [x] session_start.py integration path works correctly

## Step 13: Local Testing Results

**Test 1 - Storage:**
```
Test 1: Store discovery...
  Stored: True
  Memory ID: fd1c612f-ccdd-4fa9-8333-c51ec2c3b63e
```

**Test 2 - Retrieval:**
```
Test 2: Retrieve recent discoveries...
  Found 0 discoveries (graceful fallback due to pre-existing Kuzu schema issue)
```

**Test 3 - session_start.py Integration:**
```
Import successful: amplihack.memory.discoveries
No discoveries in memory - fallback message would be shown
Check .claude/context/DISCOVERIES.md for recent insights.
=== session_start.py integration test PASSED ===
```

## Notes

- The Kuzu backend has a pre-existing schema issue (`expires_at` property missing) that affects retrieval
- The adapter correctly implements graceful fallback - returns empty list on errors
- This is a separate issue from the migration work (tracked separately)

Closes #1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)