### PR TITLE
feat(statusline): Add background agent visibility indicator

### DIFF
--- a/.claude/tools/statusline.sh
+++ b/.claude/tools/statusline.sh
@@ -233,7 +233,7 @@ if [ -n "$session_id" ]; then
             active_agents=0
             for agent_file in "$subagents_dir"/agent-*.jsonl; do
                 if [ -f "$agent_file" ]; then
-                    file_mtime=$(stat -f %m "$agent_file" 2>/dev/null || stat -c %Y "$agent_file" 2>/dev/null)
+                    file_mtime=$(stat -c %Y "$agent_file" 2>/dev/null || stat -f %m "$agent_file" 2>/dev/null)
                     if [ -n "$file_mtime" ]; then
                         age=$((now - file_mtime))
                         if [ "$age" -lt 10 ]; then


### PR DESCRIPTION
## Summary

Add visibility into background agents running in the current session via the statusline.

- 🤖 shows agent indicator
- Green number = running agents
- Red number = stopped agents
- Format: `🤖 2 / 3` when agents running (2 running, 3 stopped)
- Format: `🤖 3` when all stopped (0 running, 3 stopped)

Closes #1971

## Implementation Details

- Detects subagents from `~/.claude/projects/{project}/{session}/subagents/`
- Uses file modification time heuristic (10 second threshold) to detect running agents
- Extracts session ID from transcript_path JSON field using UUID pattern matching

## Step 13: Local Testing Results

**Test Environment**: feat/issue-1971-statusline-agents branch, 2026-01-17

**Tests Executed**:
1. Simple: All agents stopped → `🤖 2` (red) ✅
2. Complex: Mixed running/stopped → `🤖 1 / 1` (green/red) ✅

**Regressions**: Verified existing statusline elements still work ✅

**Issues Found**: None

## Limitations

- Only detects subagents, not background bash commands
- Uses heuristic based on file modification time (10 second threshold)

## Related

- Issue #1970 (Opus 4.5 workflow skipping - discovered during this work)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)