### PR TITLE
Fix power-steering false positives on INFORMATIONAL Q&A sessions

### DIFF
--- a/.claude/tools/amplihack/considerations.yaml
+++ b/.claude/tools/amplihack/considerations.yaml
@@ -56,7 +56,7 @@
   severity: warning
   checker: _check_agent_unnecessary_questions
   enabled: true
-  applicable_session_types: ["*"]
+  applicable_session_types: ["DEVELOPMENT"]
 
 - id: objective_completion
   category: Session Completion & Progress

--- a/test_fix_locally.py
+++ b/test_fix_locally.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Local test to verify Issue #2012 fix works correctly.
+
+Tests that INFORMATIONAL Q&A sessions do not trigger the
+"agent_unnecessary_questions" consideration.
+"""
+import sys
+from pathlib import Path
+
+# Add hooks to path
+sys.path.insert(0, str(Path(__file__).parent / ".claude" / "tools" / "amplihack" / "hooks"))
+
+from power_steering_checker import PowerSteeringChecker
+
+
+def test_informational_session_filtering():
+    """Test that INFORMATIONAL sessions skip agent_unnecessary_questions check."""
+
+    # Create checker instance
+    project_root = Path(__file__).parent
+    checker = PowerSteeringChecker(project_root)
+
+    # Get applicable considerations for INFORMATIONAL session
+    applicable = checker.get_applicable_considerations("INFORMATIONAL")
+    consideration_ids = {c["id"] for c in applicable}
+
+    print("=" * 70)
+    print("INFORMATIONAL Session - Applicable Considerations:")
+    print("=" * 70)
+    for c_id in sorted(consideration_ids):
+        print(f"  ✓ {c_id}")
+
+    print("\n" + "=" * 70)
+    print("Verification Results:")
+    print("=" * 70)
+
+    # TEST 1: agent_unnecessary_questions should NOT be in the list
+    if "agent_unnecessary_questions" in consideration_ids:
+        print("❌ FAILED: agent_unnecessary_questions IS in INFORMATIONAL considerations")
+        print("   This means the fix did NOT work!")
+        return False
+    else:
+        print("✅ PASSED: agent_unnecessary_questions NOT in INFORMATIONAL considerations")
+        print("   This is correct - Q&A sessions can have follow-up questions")
+
+    # TEST 2: objective_completion SHOULD still be checked
+    if "objective_completion" in consideration_ids:
+        print("✅ PASSED: objective_completion IS in INFORMATIONAL considerations")
+        print("   This is correct - we still check if the question was answered")
+    else:
+        print("❌ FAILED: objective_completion NOT in INFORMATIONAL considerations")
+        return False
+
+    print("\n" + "=" * 70)
+    print("DEVELOPMENT Session - Applicable Considerations (for comparison):")
+    print("=" * 70)
+
+    # Get applicable considerations for DEVELOPMENT session
+    dev_applicable = checker.get_applicable_considerations("DEVELOPMENT")
+    dev_consideration_ids = {c["id"] for c in dev_applicable}
+
+    # TEST 3: agent_unnecessary_questions SHOULD be in DEVELOPMENT
+    if "agent_unnecessary_questions" in dev_consideration_ids:
+        print("✅ PASSED: agent_unnecessary_questions IS in DEVELOPMENT considerations")
+        print("   This is correct - dev sessions should avoid unnecessary questions")
+    else:
+        print("❌ FAILED: agent_unnecessary_questions NOT in DEVELOPMENT considerations")
+        return False
+
+    print("\n" + "=" * 70)
+    print("✅ ALL TESTS PASSED - Fix working correctly!")
+    print("=" * 70)
+
+    return True
+
+
+if __name__ == "__main__":
+    success = test_informational_session_filtering()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

Fixes #2012 - Power-steering hook no longer triggers unnecessary workflow validation checks for simple Q&A sessions.

## Problem

When users asked informational questions like "What agents are available?", the agent would answer correctly but power-steering would flag conversational follow-up questions as "unnecessary questions", creating false-positive warnings.

## Solution

**Single-line configuration change** in `considerations.yaml`:

```yaml
# Line 59: agent_unnecessary_questions consideration
- applicable_session_types: ["*"]
+ applicable_session_types: ["DEVELOPMENT"]
```

This prevents the `agent_unnecessary_questions` check from running on INFORMATIONAL sessions while preserving it for DEVELOPMENT sessions.

## Impact

**INFORMATIONAL Sessions (Q&A)**:
- ✅ No more false-positive warnings about follow-up questions
- ✅ Follow-up questions treated as natural conversation
- ✅ Still validates that the user's question was answered

**DEVELOPMENT Sessions**:
- ✅ No regression - all existing checks still run
- ✅ Still flags unnecessary questions during development work

## Testing

**Unit Tests**: 81/81 passed ✅
- 50 session classification tests
- 31 power-steering checker tests

**Step 13: Local Testing Results** (MANDATORY)

Created `test_fix_locally.py` with 3 verification scenarios:

1. **Simple Test**: INFORMATIONAL sessions skip `agent_unnecessary_questions` ✅
   - Result: Check correctly excluded from INFORMATIONAL sessions
   
2. **Complex Test**: INFORMATIONAL sessions still check `objective_completion` ✅
   - Result: Question answering validation preserved
   
3. **Regression Test**: DEVELOPMENT sessions still check `agent_unnecessary_questions` ✅
   - Result: No regression in development workflow validation

**Regressions**: ✅ None detected - all existing tests pass

## Files Changed

- `.claude/tools/amplihack/considerations.yaml` (1 line)
- `test_fix_locally.py` (new verification test)

## Review Checklist

- [x] Philosophy compliance (ruthless simplicity - 1 line change)
- [x] Zero-BS implementation (pure configuration, no TODOs/stubs)
- [x] All tests passing (81/81)
- [x] Local testing complete (3/3 scenarios)
- [x] No unrelated changes
- [x] Clear commit message with issue reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)