### PR TITLE
docs: Update landing page to reflect multi-tool support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # amplihack
 
-**Agentic coding framework that uses specialized AI agents to accelerate software development through intelligent automation and collaborative problem-solving.**
+**Agentic coding framework for Claude Code, Microsoft Amplifier, GitHub Copilot CLI, and Codex that uses specialized AI agents to accelerate software development through intelligent automation and collaborative problem-solving.**
 
 ## What is amplihack?
 
-amplihack is a development tool built on Claude Code that leverages multiple specialized AI agents working together to handle complex software development tasks. It combines ruthless simplicity with powerful capabilities to make AI-assisted development more effective and maintainable.
+amplihack is a development framework for popular coding agent systems (Claude Code, Microsoft Amplifier, GitHub Copilot CLI, and Codex) that leverages multiple specialized AI agents working together to handle complex software development tasks. It combines ruthless simplicity with powerful capabilities to make AI-assisted development more effective and maintainable.
 
 ## Quick Navigation
 
@@ -28,6 +28,41 @@ amplihack is a development tool built on Claude Code that leverages multiple spe
 
 Everything you need to install and configure amplihack.
 
+### Choose Your Tool
+
+amplihack works with multiple agentic coding tools. Choose the one that fits your workflow:
+
+```sh
+# Launch with Claude Code (default)
+uvx --from git+https://github.com/rysweet/amplihack amplihack claude
+
+# Launch with Microsoft Amplifier
+uvx --from git+https://github.com/rysweet/amplihack amplihack amplifier
+
+# Launch with GitHub Copilot CLI
+uvx --from git+https://github.com/rysweet/amplihack amplihack copilot
+```
+
+**Tool Compatibility Matrix:**
+
+| Feature             | Claude Code | Amplifier | Copilot CLI | Codex      |
+| ------------------- | ----------- | --------- | ----------- | ---------- |
+| Plugin Architecture | ✅ Yes      | ❌ No     | ❌ No       | ❌ No      |
+| Per-Project Staging | ✅ Yes      | ✅ Yes    | ✅ Yes      | ✅ Yes     |
+| All Agents (38)     | ✅ Yes      | ✅ Yes    | ✅ Yes      | ⚠️ Limited |
+| All Skills (73)     | ✅ Yes      | ✅ Yes    | ✅ Yes      | ⚠️ Limited |
+| All Commands (24)   | ✅ Yes      | ✅ Yes    | ✅ Yes      | ⚠️ Limited |
+| Workflows           | ✅ All      | ✅ All    | ✅ All      | ⚠️ Limited |
+| Auto Mode           | ✅ Yes      | ✅ Yes    | ✅ Yes      | ⚠️ Limited |
+
+**New to amplihack?** After launching, try the interactive tutorial:
+
+```
+Task(subagent_type='guide', prompt='I am new to amplihack. Teach me the basics.')
+```
+
+The guide agent will walk you through workflows, prompting strategies, and hands-on exercises (60-90 minutes).
+
 ### Plugin Architecture ⭐ NEW
 
 Centralized plugin system that works across all your projects:
@@ -36,7 +71,8 @@ Centralized plugin system that works across all your projects:
 - [Plugin Architecture Overview](plugin/ARCHITECTURE.md) - How the plugin system works
 - [Migration Guide](plugin/MIGRATION.md) - Migrate from per-project to plugin mode
 - [CLI Reference](plugin/CLI_REFERENCE.md) - Complete command-line reference
-- **Note**: Copilot and Codex use per-project `.claude/` staging, not plugin architecture
+
+**Note**: Plugin architecture is **Claude Code only**. Microsoft Amplifier, GitHub Copilot CLI, and Codex use per-project `.claude/` staging instead.
 
 ### Installation
 
@@ -46,8 +82,44 @@ Centralized plugin system that works across all your projects:
 
 ### Configuration
 
+#### Tool-Specific Setup
+
+**Claude Code (Default)**
+
+- Requires: `$ANTHROPIC_API_KEY` environment variable for Anthropic models
+- Plugin mode: Install globally with [Plugin Installation Guide](plugin/INSTALLATION.md)
+- Per-project mode: Copy `.claude/` directory to your project
+- Azure OpenAI: Use proxy configuration (see [Proxy Configuration](PROXY_CONFIG_GUIDE.md))
+
+**Microsoft Amplifier**
+
+```sh
+amplihack amplifier
+```
+
+Amplifier walks you through model configuration on first startup. Supports all Amplifier-compatible models including Claude, GPT-4, and local models.
+
+**GitHub Copilot CLI**
+
+```sh
+amplihack copilot
+```
+
+- Uses GitHub Copilot models (switch with `/model` command)
+- Adaptive hooks enable preference injection and context loading
+- All 38 agents available via `--agent <name>` flag
+- See [GitHub Copilot Integration](github-copilot-litellm-integration.md) for complete guide
+
+**Codex**
+
+- Limited support via per-project `.claude/` staging
+- Most features work but may require adaptation
+- Tested primarily with Claude models
+
+#### General Configuration
+
 - [Profile Management](PROFILE_MANAGEMENT.md) - Multiple environment configurations
-- [Proxy Configuration](PROXY_CONFIG_GUIDE.md) - Network proxy setup
+- [Proxy Configuration](PROXY_CONFIG_GUIDE.md) - Network proxy setup (Azure OpenAI, custom endpoints)
 - [Hook Configuration](HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior
 - [Memory Configuration Consent](features/memory-consent-prompt.md) - Intelligent memory settings with timeout protection
 


### PR DESCRIPTION
## Summary

Updates the GitHub Pages landing page (docs/index.md) to accurately reflect that amplihack works with multiple coding agent systems: Claude Code, Microsoft Amplifier, GitHub Copilot CLI, and Codex.

## Problem

The landing page incorrectly described amplihack as "built on Claude Code" only, while the README correctly states it works with multiple tools. This created confusion for users about which tools are supported.

**Investigation Report**: `.claude/runtime/logs/20260120/docs-index-investigation.md`

## Changes Made

### 1. Opening Description (Lines 3, 7)
**Before:**
```markdown
**Agentic coding framework that uses specialized AI agents...**

amplihack is a development tool built on Claude Code...
```

**After:**
```markdown
**Agentic coding framework for Claude Code, Microsoft Amplifier, GitHub Copilot CLI, and Codex...**

amplihack is a development framework for popular coding agent systems (Claude Code, Microsoft Amplifier, GitHub Copilot CLI, and Codex)...
```

### 2. New Section: Choose Your Tool
Added clear launch commands for each tool:
```sh
# Launch with Claude Code (default)
uvx --from git+https://github.com/rysweet/amplihack amplihack claude

# Launch with Microsoft Amplifier
uvx --from git+https://github.com/rysweet/amplihack amplihack amplifier

# Launch with GitHub Copilot CLI
uvx --from git+https://github.com/rysweet/amplihack amplihack copilot
```

### 3. Tool Compatibility Matrix
Added table showing feature support across all tools:

| Feature | Claude Code | Amplifier | Copilot CLI | Codex |
|---------|-------------|-----------|-------------|-------|
| Plugin Architecture | ✅ Yes | ❌ No | ❌ No | ❌ No |
| Per-Project Staging | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
| All Agents (38) | ✅ Yes | ✅ Yes | ✅ Yes | ⚠️ Limited |
| All Skills (73) | ✅ Yes | ✅ Yes | ✅ Yes | ⚠️ Limited |
| Workflows | ✅ All | ✅ All | ✅ All | ⚠️ Limited |

### 4. Tool-Specific Configuration
Added dedicated configuration sections for:
- **Claude Code**: API key, plugin/per-project modes, Azure OpenAI
- **Microsoft Amplifier**: Model configuration walkthrough
- **GitHub Copilot CLI**: Model switching, agent usage, adaptive hooks
- **Codex**: Limited support disclaimer

### 5. Fixed Plugin Architecture Note
**Before:**
```markdown
**Note**: Copilot and Codex use per-project `.claude/` staging, not plugin architecture
```

**After:**
```markdown
**Note**: Plugin architecture is **Claude Code only**. Microsoft Amplifier, GitHub Copilot CLI, 
and Codex use per-project `.claude/` staging instead.
```

## Alignment Achieved

| Aspect | Before | After | Status |
|--------|--------|-------|--------|
| Multi-tool support mentioned | ❌ Claude Code only | ✅ All 4 tools | ✅ |
| Launch commands | ❌ Missing | ✅ Added | ✅ |
| Tool comparison | ❌ Missing | ✅ Added | ✅ |
| Configuration sections | ⚠️ Incomplete | ✅ Complete | ✅ |
| README alignment | ❌ Misaligned | ✅ 100% Aligned | ✅ |

## Step 13: Local Testing Results ✅

**All tests PASS** - See: `.claude/runtime/logs/20260120/step-13-local-testing.md`

### Test Summary
- ✅ **Markdown Syntax**: All syntax valid
- ✅ **MkDocs Build**: Builds successfully with strict mode (`mkdocs build --strict`)
- ✅ **Content Verification**: All changes present and correct
- ✅ **Link Verification**: All links valid (plugin/, PROXY_CONFIG_GUIDE.md, github-copilot-litellm-integration.md)
- ✅ **README Alignment**: 100% aligned with README.md

### Test Scenarios Verified
1. ✅ New user visits landing page → Sees multi-tool support
2. ✅ User wants to launch with Amplifier → Finds clear launch command
3. ✅ User compares tool features → Tool Compatibility Matrix shows all
4. ✅ User needs Copilot config → Finds dedicated configuration section

### Regression Testing
- ✅ No unintended changes
- ✅ No changes to other pages
- ✅ No broken links
- ✅ Only docs/index.md modified

## Impact

- **Users now understand** amplihack works with 4 tools, not just Claude Code
- **Clear launch commands** available for each tool at the top of the page
- **Tool-specific configuration** guidance provided for all supported tools
- **Feature compatibility** clearly documented in comparison table
- **Landing page** now 100% aligned with README.md

## Files Changed

- `docs/index.md`: +76 lines, -4 lines

## Related

- Fixes #2026
- Investigation workflow completed (6 phases)
- Changes summary: `.claude/runtime/logs/20260120/docs-index-changes-summary.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)