### PR TITLE
fix: Recipe condition syntax errors

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -320,7 +320,7 @@ steps:
 
   - id: "step-05b-api-design"
     agent: "amplihack:api-designer"
-    condition: "{{architecture_design}} contains 'API' or {{architecture_design}} contains 'endpoint'"
+    condition: "'API' in {{architecture_design}} or 'endpoint' in {{architecture_design}}"
     prompt: |
       # Step 5b: API Design (if applicable)
       
@@ -338,7 +338,7 @@ steps:
 
   - id: "step-05c-database-design"
     agent: "amplihack:database"
-    condition: "{{architecture_design}} contains 'database' or {{architecture_design}} contains 'model' or {{architecture_design}} contains 'schema'"
+    condition: "'database' in {{architecture_design}} or 'model' in {{architecture_design}} or 'schema' in {{architecture_design}}"
     prompt: |
       # Step 5c: Database Design (if applicable)
       
@@ -514,7 +514,7 @@ steps:
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"
-    condition: "{{design_spec}} contains 'external' or {{design_spec}} contains 'integration' or {{design_spec}} contains 'service'"
+    condition: "'external' in {{design_spec}} or 'integration' in {{design_spec}} or 'service' in {{design_spec}}"
     prompt: |
       # Step 8b: External Service Integration
       
@@ -978,7 +978,7 @@ steps:
 
   - id: "step-19b-push-cleanup"
     type: "bash"
-    condition: "{{final_cleanup}} contains 'changes made' or {{final_cleanup}} contains 'updated'"
+    condition: "'changes made' in {{final_cleanup}} or 'updated' in {{final_cleanup}}"
     command: |
       cd "{{repo_path}}" && \
       echo "=== Pushing Cleanup Changes ===" && \


### PR DESCRIPTION
## Problem
Recipe engine doesn't support 'contains' operator, causing execution failures in default-workflow.yaml.

## Solution  
Changed all 4 conditions to use Python 'in' operator:
- step-05b-api-design
- step-05c-database-design
- step-08b-integration  
- step-19b-push-cleanup

## Testing
✅ Recipe executes without syntax errors

This unblocks default-workflow for fixing circular dependencies.