### PR TITLE
fix: Use recipes behavior bundle to resolve circular dependencies (Issue #2051)

### DIFF
--- a/amplifier-bundle/bundle.md
+++ b/amplifier-bundle/bundle.md
@@ -5,15 +5,11 @@ bundle:
   description: "A set of recipes, agents, tools, hooks, and skills from the amplihack toolset which are designed to provide a more complete engineering system on top of Amplifier."
 
 includes:
-  # Note: foundation is NOT explicitly included here because:
-  # 1. Amplifier CLI already loads foundation as the default bundle
-  # 2. amplifier-bundle-recipes includes foundation transitively
-  # Including it again causes a "circular dependency" warning
-  
-  # Core recipes bundle (includes foundation transitively)
-  # Foundation already includes: python-dev, ts-dev, shadow, sessions
-  # So we don't include those bundles directly to avoid circular dependencies
-  - bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main
+  # Note: We include the recipes BEHAVIOR bundle, not the main bundle
+  # The main bundle includes foundation, which would create a circular dependency
+  # since foundation already includes recipes:behaviors/recipes
+  # This matches the pattern foundation uses (line 36 of foundation/bundle.md)
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main#subdirectory=behaviors/recipes.yaml
   
   # GitHub issues integration (NOT in foundation, safe to include directly)
   - bundle: git+https://github.com/microsoft/amplifier-bundle-issues@main


### PR DESCRIPTION
## Problem

Circular dependency errors when loading amplihack bundle:
- python-dev: Circular dependency detected
- shadow: Circular dependency detected  
- sessions.yaml: Circular dependency detected

Previous fix attempt (PR #2047, commit c699b0a1) removed direct includes of python-dev/shadow/ts-dev but the errors persisted.

## Root Cause

The circular dependency occurred because amplihack included the recipes **MAIN bundle**, which includes foundation, which also includes recipes:behaviors/recipes, creating a cycle:

```
amplihack → recipes (main) → foundation → recipes:behaviors/recipes
                            ↓
                          recipes:behaviors/recipes (DUPLICATE)
```

This caused python-dev, shadow, and sessions.yaml to be flagged as circular (they are in foundation, which was part of the circular path).

## Solution

Changed amplihack to include recipes **BEHAVIOR bundle** directly instead of the main bundle:

**BEFORE:**
```yaml
- bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main
```

**AFTER:**
```yaml
- bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main#subdirectory=behaviors/recipes.yaml
```

This matches the pattern foundation uses (line 36 of foundation/bundle.md) and breaks the circular dependency.

## Testing

✅ No circular dependency warnings when running `amplihack amplifier`
✅ Bundle loads cleanly
✅ All functionality preserved (recipes tool, agents, skills all work)

## Analysis

Credit to `amplihack:analyzer` agent for identifying the root cause through dependency chain analysis.

Fixes #2051