### PR TITLE
fix: Restore ToC sidebar and remove First Docs Site Tutorial from landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,6 @@ amplihack is a development framework for popular coding agent systems (Claude Co
 - [Get Started](#-get-started) - Installation and first steps
 - [Core Concepts](#-core-concepts) - Philosophy and principles
 - [Amplihack Tutorial](tutorials/amplihack-tutorial.md) - Comprehensive 60-90 minute tutorial
-- [First Docs Site Tutorial](tutorials/first-docs-site.md) - Create your first documentation site
 
 **Looking for something specific?**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ theme:
     - search.highlight
     - search.share
     - toc.follow
+    - toc.integrate
     - content.code.copy
     - content.code.annotate
     - content.action.edit


### PR DESCRIPTION
## Summary

Fixes issues with the docs site landing page:

1. **Restores ToC sidebar** - Added `toc.integrate` feature to mkdocs.yml which integrates the table of contents into the left navigation sidebar
2. **Removes First Docs Site Tutorial** - Removed the prominent link to the First Docs Site Tutorial from the landing page as requested

## Changes

- `mkdocs.yml`: Added `toc.integrate` feature to restore sidebar ToC
- `docs/index.md`: Removed "First Docs Site Tutorial" link from Quick Navigation

## Testing

- Local `mkdocs build` succeeded
- ToC will now appear integrated in the left sidebar

## Before/After

**Before**: ToC only visible on right side of page (or not at all on mobile)
**After**: ToC integrated into left navigation sidebar for easier access

Fixes user-reported issue with docs site.