### PR TITLE
fix: Restore ToC sidebar and remove First Docs Site Tutorial link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,6 @@ amplihack is a development framework for popular coding agent systems (Claude Co
 - [Get Started](#-get-started) - Installation and first steps
 - [Core Concepts](#-core-concepts) - Philosophy and principles
 - [Amplihack Tutorial](tutorials/amplihack-tutorial.md) - Comprehensive 60-90 minute tutorial
-- [First Docs Site Tutorial](tutorials/first-docs-site.md) - Create your first documentation site
 
 **Looking for something specific?**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ theme:
     - search.highlight
     - search.share
     - toc.follow
+    - toc.integrate
     - content.code.copy
     - content.code.annotate
     - content.action.edit


### PR DESCRIPTION
## Summary

Fixes #2113

## Problem

The documentation site was missing the Table of Contents (ToC) in the navigation sidebar, and the user requested removal of the 'First Docs Site Tutorial' link from the prominent position on the landing page.

## Changes

### mkdocs.yml
- Added `toc.integrate` feature to Material theme configuration
- This integrates the ToC into the left navigation sidebar

### docs/index.md  
- Removed 'First Docs Site Tutorial' link from Quick Navigation section

## Step 13: Local Testing Results

**Test Environment**: fix/issue-2113-docs-toc-sidebar branch, local mkdocs build

**Tests Executed**:
1. Simple: Tutorial link removal → PASS ✅ (grep confirms 0 matches in built site)
2. Complex: Homepage renders correctly → PASS ✅ (Amplihack Tutorial still present)
3. Build: mkdocs build succeeded → PASS ✅ (site/index.html generated)

**Regressions**: ✅ None detected - other navigation still works

## Verification

After merge and GitHub Pages deploy:
- [ ] ToC visible in left navigation sidebar on docs pages
- [ ] 'First Docs Site Tutorial' link removed from landing page
- [ ] No other navigation broken