### PR TITLE
Invert Blarify logic - disabled by default (opt-in)

### DIFF
--- a/docs/blarify_integration.md
+++ b/docs/blarify_integration.md
@@ -71,12 +71,12 @@ Code schema extends existing memory schema:
 
 ### Configuration
 
-#### Disabling Blarify Indexing
+#### Enabling Blarify Indexing
 
-To disable Blarify if unavailable or causing issues:
+Blarify is disabled by default. To enable Blarify code indexing:
 
 ```bash
-AMPLIHACK_DISABLE_BLARIFY=1 amplihack launch
+AMPLIHACK_ENABLE_BLARIFY=1 amplihack launch
 ```
 
 ### Supported Languages

--- a/docs/blarify_quickstart.md
+++ b/docs/blarify_quickstart.md
@@ -19,12 +19,12 @@ Get started with blarify code graph integration in 5 minutes.
 
 ## Configuration
 
-### Disabling Blarify (Optional)
+### Enabling Blarify (Optional)
 
-To disable Blarify if it's unavailable or causing issues:
+Blarify is disabled by default. To enable Blarify code indexing:
 
 ```bash
-AMPLIHACK_DISABLE_BLARIFY=1 amplihack launch
+AMPLIHACK_ENABLE_BLARIFY=1 amplihack launch
 ```
 
 ## Option 1: Test Without Blarify (Recommended First)

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -1051,9 +1051,9 @@ class ClaudeLauncher:
         Returns:
             True if indexing completed or skipped, False on error
         """
-        # Early exit if disabled via AMPLIHACK_DISABLE_BLARIFY environment variable
-        if os.getenv("AMPLIHACK_DISABLE_BLARIFY") == "1":
-            logger.debug("Blarify indexing disabled via AMPLIHACK_DISABLE_BLARIFY")
+        # Blarify is disabled by default - only run if explicitly enabled
+        if os.getenv("AMPLIHACK_ENABLE_BLARIFY") != "1":
+            logger.debug("Blarify indexing disabled by default (set AMPLIHACK_ENABLE_BLARIFY=1 to enable)")
             return True
 
         # Get project directory (current working directory)


### PR DESCRIPTION
## Summary

Fixes #2119 by inverting the Blarify environment variable logic. Blarify is now **disabled by default** and requires explicit opt-in to enable.

## Problem

PR #2117 implemented the logic backwards:
- ❌ **Before**: Blarify enabled by default, set `AMPLIHACK_DISABLE_BLARIFY=1` to disable (opt-out)
- ✅ **After**: Blarify disabled by default, set `AMPLIHACK_ENABLE_BLARIFY=1` to enable (opt-in)

User's original request was "disable blarify until fixed" meaning make it OFF by default, not just add a disable switch.

## Changes

### Code Changes
**File**: `src/amplihack/launcher/core.py` (lines 1054-1057)

**Before**:
```python
# Early exit if disabled via AMPLIHACK_DISABLE_BLARIFY environment variable
if os.getenv("AMPLIHACK_DISABLE_BLARIFY") == "1":
    logger.debug("Blarify indexing disabled via AMPLIHACK_DISABLE_BLARIFY")
    return True
```

**After**:
```python
# Blarify is disabled by default - only run if explicitly enabled
if os.getenv("AMPLIHACK_ENABLE_BLARIFY") != "1":
    logger.debug("Blarify indexing disabled by default (set AMPLIHACK_ENABLE_BLARIFY=1 to enable)")
    return True
```

### Documentation Changes
- `docs/blarify_quickstart.md`: Changed "Disabling Blarify" → "Enabling Blarify"
- `docs/blarify_integration.md`: Changed "Disabling Blarify Indexing" → "Enabling Blarify Indexing"
- Updated command examples to show `AMPLIHACK_ENABLE_BLARIFY=1` instead of `AMPLIHACK_DISABLE_BLARIFY=1`

## Behavior

**Default (env var not set)**:
- Blarify indexing: ❌ **DISABLED**
- No prompt, no indexing, launches immediately

**Explicitly enabled (`AMPLIHACK_ENABLE_BLARIFY=1`)**:
- Blarify indexing: ✅ **ENABLED**
- Prompts for consent, runs indexing if consented

## Testing

Verified logic inversion:
- Unset env var → Blarify disabled ✅
- Set to "0" → Blarify disabled ✅
- Set to "1" → Blarify enabled ✅
- Set to "true" → Blarify disabled ✅ (strict "1" check)

## Breaking Change

**Yes** - This changes default behavior:
- Users who relied on Blarify running by default will need to set `AMPLIHACK_ENABLE_BLARIFY=1`
- Users who set `AMPLIHACK_DISABLE_BLARIFY=1` will need to remove it (disabled is now the default)

**Justification**: This aligns with the original user requirement and makes Blarify opt-in, which is safer for users experiencing issues.

## Complexity

**TRIVIAL** - 4 lines changed (logic inversion + log message)

Closes #2119

🤖 Generated with [Claude Code](https://claude.com/claude-code)