### PR TITLE
fix: Add _ensure_amplihack_staged() call to launch_command()

### DIFF
--- a/src/amplihack/cli.py
+++ b/src/amplihack/cli.py
@@ -101,6 +101,9 @@ def launch_command(args: argparse.Namespace, claude_args: list[str] | None = Non
         os.chdir(staging_result.temp_root)
         print(f"   📂 CWD changed to: {staging_result.temp_root}\n")
 
+    # Ensure amplihack framework is staged to ~/.amplihack/.claude/
+    _ensure_amplihack_staged()
+
     # Start session tracking
     tracker = SessionTracker()
     is_auto_mode = getattr(args, "auto", False)


### PR DESCRIPTION
Fixes #2145

## Summary

When running `amplihack launch` from a different directory, the command failed to stage framework files to `~/.amplihack/.claude/`, causing skills like `ultrathink-orchestrator` to fail when referencing files in that location.

## Root Cause

The `launch_command()` function didn't call `_ensure_amplihack_staged()`, unlike other commands:
- ✅ `cmd_copilot()` calls it (line 1091)
- ✅ `cmd_amplifier()` calls it (line 1137)
- ✅ `cmd_rustyclawd()` calls it (line 1066)
- ✅ `cmd_codex()` calls it (line 1114)
- ❌ `launch_command()` was MISSING the call

## Solution

Added `_ensure_amplihack_staged()` call to `launch_command()`:
- Placed after nesting detection (line 105)
- Before session tracking starts
- Matches pattern used in all other commands
- Added integration test to prevent regression

## Changes

- `src/amplihack/cli.py`: Added `_ensure_amplihack_staged()` call (3 lines)
- `tests/integration/test_cli_unified_staging.py`: Added test for launch command (30 lines)

## Step 13: Local Testing Results

**Test Environment**: feat/issue-2145-launch-staging branch, local worktree

**Tests Executed**:
1. Simple: Integration test verification → ✅ PASSED
   - All 10 unified staging tests pass (1 skipped)
   - Confirms `_ensure_amplihack_staged()` called during launch_command()

2. Complex: Source code verification → ✅ PASSED  
   - Verified function call present in source
   - Pattern matches other commands

**Regressions**: ✅ None detected

**Issues Found**: None

## Test Plan

✅ **Integration Tests**:
- All staging tests pass (10 passed, 1 skipped)
- New test specifically for launch command

✅ **Code Quality**:
- Pre-commit hooks pass
- Pattern consistent with existing commands
- No TODOs, stubs, or placeholders

## Verification

To verify the fix:

\`\`\`bash
# Run integration tests
uv run pytest tests/integration/test_cli_unified_staging.py -v

# Verify staging occurs with launch command
uvx --from "git+https://github.com/rysweet/amplihack@feat/issue-2145-launch-staging" amplihack launch --help
ls -la ~/.amplihack/.claude/  # Should show staged files
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)