### PR TITLE
feat: Add timeout tracking to stop hook to prevent operation starvation (#2158)

### DIFF
--- a/.claude/tools/amplihack/hooks/timeout_tracker.py
+++ b/.claude/tools/amplihack/hooks/timeout_tracker.py
@@ -1,0 +1,159 @@
+"""
+Timeout tracking for stop hook operations.
+
+Provides TimeoutTracker class to help stop hook gracefully skip operations
+when insufficient time remains in the 30-second hook budget.
+
+Security considerations:
+- Uses time.monotonic() to prevent clock manipulation attacks
+- Fails open on all errors (returns True from has_time())
+- Validates configuration at module load
+- Logs all timeout-based decisions for audit trail
+
+Constants:
+    HOOK_TIMEOUT_BUDGET: Total time budget (25s, leaving 5s buffer)
+    MIN_TIME_POWER_STEERING: Minimum time needed for power-steering (15s)
+    MIN_TIME_REFLECTION: Minimum time needed for reflection (12s)
+"""
+
+import time
+
+# Configuration constants
+HOOK_TIMEOUT_BUDGET = 25.0  # Leave 5s buffer before Claude Code's 30s timeout
+MIN_TIME_POWER_STEERING = 15.0  # Power-steering needs meaningful time
+MIN_TIME_REFLECTION = 12.0  # Reflection needs meaningful time
+
+# Validate configuration at module load (SECURITY REQUIREMENT)
+assert HOOK_TIMEOUT_BUDGET > 0, "Timeout budget must be positive"
+assert MIN_TIME_POWER_STEERING > 0, "Power-steering minimum must be positive"
+assert MIN_TIME_REFLECTION > 0, "Reflection minimum must be positive"
+assert MIN_TIME_POWER_STEERING < HOOK_TIMEOUT_BUDGET, (
+    f"Power-steering minimum ({MIN_TIME_POWER_STEERING}s) exceeds budget ({HOOK_TIMEOUT_BUDGET}s)"
+)
+assert MIN_TIME_REFLECTION < HOOK_TIMEOUT_BUDGET, (
+    f"Reflection minimum ({MIN_TIME_REFLECTION}s) exceeds budget ({HOOK_TIMEOUT_BUDGET}s)"
+)
+
+
+class TimeoutTracker:
+    """
+    Thread-safe timeout tracking using monotonic time.
+
+    Tracks elapsed time and remaining budget to help decide whether
+    to start expensive operations that may not complete in time.
+
+    Security considerations:
+    - Uses time.monotonic() to prevent clock manipulation attacks
+    - Fails open on all errors (returns True from has_time())
+    - Validates inputs and provides defensive bounds checking
+
+    Example:
+        >>> tracker = TimeoutTracker(budget_seconds=25.0)
+        >>> if tracker.has_time(operation_min=15.0):
+        ...     run_expensive_operation()
+        >>> print(f"Elapsed: {tracker.elapsed():.1f}s")
+        Elapsed: 5.2s
+    """
+
+    def __init__(self, budget_seconds: float = HOOK_TIMEOUT_BUDGET):
+        """
+        Initialize timeout tracker.
+
+        Args:
+            budget_seconds: Total time budget in seconds (default: HOOK_TIMEOUT_BUDGET)
+
+        Raises:
+            ValueError: If budget_seconds is not positive
+        """
+        if budget_seconds <= 0:
+            raise ValueError(f"budget_seconds must be positive, got {budget_seconds}")
+
+        # SECURITY: Use monotonic time to prevent clock manipulation
+        self.start_time = time.monotonic()
+        self.budget_seconds = budget_seconds
+
+    def elapsed(self) -> float:
+        """
+        Get elapsed time since tracker creation.
+
+        Returns:
+            Elapsed seconds as float
+
+        Security:
+            Uses time.monotonic() which is immune to system clock changes
+        """
+        # SECURITY: Use monotonic time (immune to clock changes)
+        elapsed = time.monotonic() - self.start_time
+
+        # Defensive: Check for negative values (should be impossible with monotonic)
+        if elapsed < 0:
+            # This should never happen with monotonic time, but check anyway
+            import sys
+
+            print(
+                f"WARNING: Negative elapsed time detected "
+                f"(start={self.start_time}, now={time.monotonic()})",
+                file=sys.stderr,
+            )
+            return 0.0  # Fail-safe: return 0 instead of negative
+
+        return elapsed
+
+    def remaining(self) -> float:
+        """
+        Get remaining time in budget.
+
+        Returns:
+            Remaining seconds as float (may be negative if over budget)
+        """
+        return self.budget_seconds - self.elapsed()
+
+    def has_time(self, operation_min: float) -> bool:
+        """
+        Check if sufficient time remains for an operation.
+
+        Args:
+            operation_min: Minimum time required in seconds (must be non-negative)
+
+        Returns:
+            True if sufficient time remains (remaining >= operation_min),
+            False otherwise. Always returns True for operation_min=0.
+
+        Raises:
+            ValueError: If operation_min is negative
+
+        Security:
+            Returns True (fail-open) on all errors except validation errors.
+            This ensures that timeout tracking failures don't block operations.
+        """
+        if operation_min < 0:
+            raise ValueError(f"operation_min must be non-negative, got {operation_min}")
+
+        # Special case: If operation needs 0 time, always allow it
+        if operation_min == 0.0:
+            return True
+
+        try:
+            remaining = self.remaining()
+            return remaining >= operation_min
+        except Exception:
+            # SECURITY: Fail-open on any unexpected error
+            # This is critical - timeout tracking should never block operations
+            return True
+
+    def __repr__(self) -> str:
+        """
+        Return string representation for debugging.
+
+        Returns:
+            String showing elapsed and remaining time
+        """
+        try:
+            elapsed = self.elapsed()
+            remaining = self.remaining()
+            return f"TimeoutTracker(elapsed={elapsed:.1f}s, remaining={remaining:.1f}s, budget={self.budget_seconds:.1f}s)"
+        except Exception:
+            # Fail-safe: return basic info if calculation fails
+            return f"TimeoutTracker(budget={self.budget_seconds:.1f}s)"
+
+    __str__ = __repr__


### PR DESCRIPTION
## Summary

Fixes #2158

Adds `TimeoutTracker` class that gracefully skips power-steering and reflection operations when insufficient time remains in the 30-second hook budget.

## Problem

Power-steering and reflection can each take significant time (15s+, 12-60s), but the stop hook has only a 30s timeout. Without tracking, these operations could exceed the budget and cause hook timeout, starving operations and confusing users.

## Solution

- **New Module**: `timeout_tracker.py` with `TimeoutTracker` class
- **Time Tracking**: Uses `time.monotonic()` (clock manipulation resistant)
- **Preemptive Skipping**: Skips operations if insufficient time (15s for power-steering, 12s for reflection)
- **Safe Budget**: 25s budget (leaving 5s safety buffer before 30s timeout)
- **Fail-Open**: All errors allow operations to proceed (never blocks hook)

## User Experience

**When Operations Run Normally:**
- No change from current behavior
- Operations complete successfully

**When Time Budget Low:**
```
⏱️  Power-Steering Skipped
Insufficient time remaining (6.7s) to run power-steering analysis (requires 15.0s minimum).
Hook has been running for 18.3s of 25.0s budget.
```

## Technical Details

**Implementation:**
- 159 lines `timeout_tracker.py` (includes comprehensive documentation)
- 133 lines stop.py integration
- Backward compatible (graceful degradation if tracker unavailable)
- Zero breaking changes

**Security:**
- Uses `time.monotonic()` (not `time.time()`) to prevent clock manipulation
- Configuration validation at module load
- Defensive bounds checking
- Fail-open error handling throughout

**Metrics:**
- `power_steering_timeout_skips`: Counter for PS skipped due to timeout
- `reflection_timeout_skips`: Counter for reflection skipped due to timeout

## Testing

**Code Review:**
- ✅ Reviewer agent: APPROVED (zero issues)
- ✅ Security agent: APPROVED (all security requirements met)
- ✅ Philosophy guardian: A grade (exemplary implementation)
- ✅ Pre-commit checks: All passed (ruff, pyright, prettier)

**Step 13: Local Testing Results**

**Test Environment**: feat-issue-2158-neo4j-timeout-tracking branch, 2026-01-27

**Tests Executed:**

1. **Simple**: Module Import and Instantiation → ✅ PASSED
   - TimeoutTracker imports successfully
   - Constants correctly set (25s, 15s, 12s)
   - Instantiation working
   - Time tracking accurate (0.1s sleep measured correctly)
   - Input validation working (rejects negative budget)

2. **Complex**: Stop Hook Simulation → ✅ PASSED
   - Normal execution: Both operations run with full budget ✅
   - Low time (7s remaining): Both operations correctly skipped ✅
   - Edge case: Floating-point precision handled correctly ✅
   - Fail-open: Errors handled gracefully, returns True ✅

**Regressions:** ✅ None detected  
**Issues Found:** None

**Step 19: Outside-In Testing Results**

**Test Environment**: Real hook context with subprocess isolation, 2026-01-27

**User Flows Tested:**

1. **Hook Context Import** → ✅ PASSED
   - Commands/Actions: Import timeout_tracker from hook sys.path
   - Expected: Module imports with constants available
   - Actual: Successfully imported HOOK_TIMEOUT_BUDGET=25s, MIN_TIME_POWER_STEERING=15s, MIN_TIME_REFLECTION=12s
   - Evidence: All constants validated and accessible

2. **TimeoutTracker Instantiation in Hook Context** → ✅ PASSED
   - Commands/Actions: Create TimeoutTracker(25.0) in hook environment
   - Expected: Tracker initialized with elapsed=0s, remaining=25s
   - Actual: Tracker created successfully, time tracking accurate
   - Evidence: elapsed()=0.000s, remaining()=25.000s

3. **Decision Logic in Normal Scenario** → ✅ PASSED
   - Commands/Actions: Check has_time() with full 25s budget
   - Expected: Both operations (PS 15s, reflection 12s) should run
   - Actual: has_time(15.0)=True, has_time(12.0)=True
   - Evidence: Correct decision to allow both operations

4. **Decision Logic in Low-Time Scenario** → ✅ PASSED
   - Commands/Actions: Simulate 7s remaining (low-time condition)
   - Expected: Both operations should be skipped
   - Actual: has_time(15.0)=False, has_time(12.0)=False
   - Evidence: Correct decision to skip both operations

5. **stop.py Integration** → ✅ PASSED
   - Commands/Actions: Verify stop.py can import and use timeout_tracker
   - Expected: TIMEOUT_TRACKING_AVAILABLE=True
   - Actual: stop.py successfully imported timeout_tracker
   - Evidence: Integration flag set correctly

**Edge Cases Tested:** Floating-point precision, zero budget, exact threshold → ✅ All passed

**Integration Points Verified:** Hook sys.path, module import, stop.py integration → ✅ All working

**Observability Check:** Logs track elapsed/remaining/required times → ✅ Confirmed

**Issues Found:** None

## Philosophy Compliance

- **Ruthless Simplicity**: ✅ Minimal code, maximum clarity
- **Zero-BS**: ✅ No placeholders, stubs, or TODOs
- **Fail-Safe**: ✅ Fail-open design, graceful degradation
- **User-First**: ✅ Clear notifications, helpful messages
- **Philosophy Guardian Score**: A (Excellent)

## Files Changed

- `.claude/tools/amplihack/hooks/timeout_tracker.py` (159 lines, new)
- `.claude/tools/amplihack/hooks/stop.py` (+133 lines)

## Checklist

- [x] Code follows project style guide
- [x] All tests pass locally (Step 13)
- [x] Outside-in testing completed (Step 19)
- [x] Pre-commit hooks pass
- [x] Security requirements met
- [x] Backward compatible
- [x] Documentation comprehensive
- [x] User notifications clear
- [x] Philosophy compliance verified (A grade)