### PR TITLE
Restore Blarify ON by default (revert PR #2120)

### DIFF
--- a/docs/blarify_integration.md
+++ b/docs/blarify_integration.md
@@ -64,12 +64,12 @@ Code schema extends existing memory schema:
 
 ### Configuration
 
-#### Enabling Blarify Indexing
+#### Disabling Blarify Indexing
 
-Blarify is disabled by default. To enable Blarify code indexing:
+To disable Blarify if unavailable or causing issues:
 
 ```bash
-AMPLIHACK_ENABLE_BLARIFY=1 amplihack launch
+AMPLIHACK_DISABLE_BLARIFY=1 amplihack launch
 ```
 
 ### Supported Languages

--- a/docs/blarify_quickstart.md
+++ b/docs/blarify_quickstart.md
@@ -19,12 +19,12 @@ Get started with blarify code graph integration in 5 minutes.
 
 ## Configuration
 
-### Enabling Blarify (Optional)
+### Disabling Blarify (Optional)
 
-Blarify is disabled by default. To enable Blarify code indexing:
+To disable Blarify if it's unavailable or causing issues:
 
 ```bash
-AMPLIHACK_ENABLE_BLARIFY=1 amplihack launch
+AMPLIHACK_DISABLE_BLARIFY=1 amplihack launch
 ```
 
 ## Option 1: Test Without Blarify (Recommended First)

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -1055,11 +1055,9 @@ class ClaudeLauncher:
         Returns:
             True if indexing completed or skipped, False on error
         """
-        # Blarify is disabled by default - only run if explicitly enabled
-        if os.getenv("AMPLIHACK_ENABLE_BLARIFY") != "1":
-            logger.debug(
-                "Blarify indexing disabled by default (set AMPLIHACK_ENABLE_BLARIFY=1 to enable)"
-            )
+        # Early exit if disabled via AMPLIHACK_DISABLE_BLARIFY environment variable
+        if os.getenv("AMPLIHACK_DISABLE_BLARIFY") == "1":
+            logger.debug("Blarify indexing disabled via AMPLIHACK_DISABLE_BLARIFY")
             return True
 
         # Get project directory (current working directory)


### PR DESCRIPTION
## Summary

Fixes #2174 by restoring the original PR #2117 behavior. Blarify is now **enabled by default** with opt-out capability.

## Problem

PR #2120 made Blarify disabled by default, but user actually wants it **enabled by default**:
- ❌ **After PR #2120**: Blarify disabled by default, set `AMPLIHACK_ENABLE_BLARIFY=1` to enable (opt-in)
- ✅ **After this PR**: Blarify enabled by default, set `AMPLIHACK_DISABLE_BLARIFY=1` to disable (opt-out)

## Changes

### Code Changes
**File**: `src/amplihack/launcher/core.py` (lines 1058-1063)

**Before (PR #2120)**:
```python
# Blarify is disabled by default - only run if explicitly enabled
if os.getenv("AMPLIHACK_ENABLE_BLARIFY") != "1":
    logger.debug("Blarify indexing disabled by default (set AMPLIHACK_ENABLE_BLARIFY=1 to enable)")
    return True
```

**After (this PR - restores PR #2117)**:
```python
# Early exit if disabled via AMPLIHACK_DISABLE_BLARIFY environment variable
if os.getenv("AMPLIHACK_DISABLE_BLARIFY") == "1":
    logger.debug("Blarify indexing disabled via AMPLIHACK_DISABLE_BLARIFY")
    return True
```

### Documentation Changes
- `docs/blarify_quickstart.md`: Changed "Enabling Blarify" → "Disabling Blarify"
- `docs/blarify_integration.md`: Changed "Enabling Blarify Indexing" → "Disabling Blarify Indexing"
- Updated command examples to show `AMPLIHACK_DISABLE_BLARIFY=1` instead of `AMPLIHACK_ENABLE_BLARIFY=1`

## Behavior

**Default (env var not set)**:
- Blarify indexing: ✅ **ENABLED**
- Prompts for consent, runs indexing if consented

**Explicitly disabled (`AMPLIHACK_DISABLE_BLARIFY=1`)**:
- Blarify indexing: ❌ **DISABLED**
- No prompt, no indexing, launches immediately

## Testing

Verified logic restoration:
- Unset env var → Blarify enabled (prompts) ✅
- Set to "0" → Blarify enabled ✅
- Set to "1" → Blarify disabled ✅
- Set to "true" → Blarify enabled ✅ (strict "1" check)

## Breaking Change

**Yes** - This reverts PR #2120:
- Users who set `AMPLIHACK_ENABLE_BLARIFY=1` will need to remove it (enabled is now the default)
- Users who want to disable Blarify will need to set `AMPLIHACK_DISABLE_BLARIFY=1`

**Justification**: User changed requirement - wants Blarify enabled by default.

## Complexity

**TRIVIAL** - Reverting PR #2120 back to PR #2117 behavior

Closes #2174

🤖 Generated with [Claude Code](https://claude.com/claude-code)