### PR TITLE
[CLEANUP] Remove 28 backup directories consuming 430MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ htmlcov/
 *.bak
 *.backup
 *.backup.*
+.claude.backup.*
 **/.metadata/versions.json
 
 # Project specific


### PR DESCRIPTION
## Summary
Philosophy compliance fix: Remove .claude.backup.* directories that violate ruthless simplicity principle, freeing 430MB disk space.

## Problem
- **28 backup directories** (.claude.backup.*) consuming **430MB**
- **9,370 duplicate files** polluting codebase
- **Philosophy Grade: D** - violation of "ruthless simplicity"

## Solution
- Deleted all 28 .claude.backup.* directories
- Added `.claude.backup.*` pattern to .gitignore

## Testing
- ✅ All 28 directories removed
- ✅ 430MB disk space reclaimed
- ✅ Git ignore pattern working

Fixes #2191

🤖 Generated with [Claude Code](https://claude.com/claude-code)