### PR TITLE
fix(copilot): Stage skills to ~/.copilot/skills/ for Copilot CLI

### DIFF
--- a/src/amplihack/launcher/copilot.py
+++ b/src/amplihack/launcher/copilot.py
@@ -211,6 +211,31 @@ def launch_copilot(args: list[str] | None = None, interactive: bool = True) -> i
             if copied > 0:
                 print(f"✓ Prepared {copied} amplihack agents")
 
+        # Stage skills to ~/.copilot/skills/ for Copilot CLI discovery
+        # Copilot CLI looks in ~/.copilot/skills/ and ~/.claude/skills/
+        # We use ~/.copilot/skills/ to avoid conflicts with Claude Code plugin model
+        source_skills = package_dir / ".claude/skills"
+        copilot_skills_dest = Path.home() / ".copilot" / "skills"
+        if source_skills.exists():
+            copilot_skills_dest.mkdir(parents=True, exist_ok=True)
+
+            skills_copied = 0
+            for skill_dir in source_skills.iterdir():
+                if skill_dir.is_dir():
+                    dest_skill = copilot_skills_dest / skill_dir.name
+                    # Only copy if dest doesn't exist (first time setup)
+                    if not dest_skill.exists():
+                        shutil.copytree(skill_dir, dest_skill, dirs_exist_ok=True)
+                        skills_copied += 1
+                    else:
+                        # Update existing skill (overwrite)
+                        shutil.copytree(skill_dir, dest_skill, dirs_exist_ok=True)
+
+            if skills_copied > 0:
+                print(f"✓ Staged {skills_copied} new skills to ~/.copilot/skills/")
+            else:
+                print("✓ Skills up-to-date in ~/.copilot/skills/")
+
         # Load preferences - try LOCAL first, fallback to PACKAGE
         # This allows users to customize preferences per-project
         prefs_file = user_dir / ".claude/context/USER_PREFERENCES.md"


### PR DESCRIPTION
## Problem

Copilot CLI users on WSL (and potentially other platforms) were not getting amplihack skills, even though they had the correct subagents.

**Root Cause**: The `amplihack copilot` launcher was only staging:
- ✅ Agents to `.github/agents/`
- ✅ Preferences to `AGENTS.md`
- ❌ **Skills were NOT being staged**

Copilot CLI looks for personal skills in:
- `~/.copilot/skills/`
- `~/.claude/skills/`

If a user only ran `amplihack copilot` (not `amplihack install`), neither location would have skills.

## Solution

Added skill staging to `launch_copilot()` that copies all skills from the package's `.claude/skills/` to `~/.copilot/skills/`.

- Uses `~/.copilot/skills/` to avoid conflicts with Claude Code plugin model
- Skills are updated on each launch (`dirs_exist_ok=True`)
- Reports number of new skills staged vs updated

## Step 13: Local Testing Results

**Test Environment**: fix/copilot-skills-staging branch, macOS, 2026-01-28

**Tests Executed**:
1. Simple: Fresh skill staging → 88 skills staged to `~/.copilot/skills/` ✅
2. Complex: Subsequent run → 'Skills up-to-date' message ✅

**Regressions**: Verified agents still staged, preferences still injected → ✅ None detected

**Issues Found**: Ruff fixed f-string without placeholders (cosmetic)

## Reference

- [GitHub Docs: About Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
