### PR TITLE
fix: Ensure GitHub header link visible at tablet breakpoint (Issue #2215)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -84,3 +84,21 @@ code {
     background-color: #4caf50;
     color: white;
 }
+
+/* Ensure GitHub header link is visible at tablet breakpoint and above (Issue #2215)
+   Material for MkDocs default shows at 60em (960px), lowering to 45em (720px) */
+@media screen and (min-width: 45em) {
+    .md-header__source {
+        display: block;
+        max-width: 11.7rem;
+        width: 11.7rem;
+    }
+    
+    [dir=ltr] .md-header__source {
+        margin-left: 1rem;
+    }
+    
+    [dir=rtl] .md-header__source {
+        margin-right: 1rem;
+    }
+}


### PR DESCRIPTION
## Problem
The GitHub repo link in the docs header was reported as missing (#2215). Investigation showed the link IS present in HTML, but Material for MkDocs default CSS hides it on screens below 960px (60em breakpoint).

## Investigation Summary
- Fetched live site HTML - GitHub link IS present in `.md-header__source`
- `mkdocs.yml` config is correct: `repo_url`, `repo_name`, `icon.repo` all set
- No custom CSS hiding the link
- Material for MkDocs default: `.md-header__source{display:none}` at < 960px

## Solution
Add custom CSS to show the header source link at 720px (45em) and above, making it visible on tablets and small laptops where it was previously hidden.

## Changes
- `docs/stylesheets/extra.css`: Add media query to display GitHub header link at smaller breakpoint

## Testing
- `mkdocs build`: SUCCESS ✅
- CSS follows Material for MkDocs conventions (separate `[dir=ltr]` and `[dir=rtl]` selectors)

Closes #2215