### PR TITLE
docs: Update outside-in-testing skill for npm package installation

### DIFF
--- a/.claude/skills/outside-in-testing/SKILL.md
+++ b/.claude/skills/outside-in-testing/SKILL.md
@@ -122,12 +122,29 @@ Each example is marked with its level. Start at Level 1 and progress as needed.
 
 ### Installation
 
+**Prerequisites (for native module compilation):**
+
 ```bash
-# Install gadugi-agentic-test framework
-pip install gadugi-agentic-test
+# macOS
+xcode-select --install
+
+# Ubuntu/Debian
+sudo apt-get install -y build-essential python3
+
+# Windows: Install Visual Studio Build Tools with "Desktop development with C++"
+```
+
+**Install the framework:**
+
+```bash
+# Install globally for CLI access
+npm install -g @gadugi/agentic-test
+
+# Or install locally in your project
+npm install @gadugi/agentic-test
 
 # Verify installation
-gadugi-agentic-test --version
+gadugi-test --version
 ```
 
 ### Your First Test (CLI Example)
@@ -157,7 +174,7 @@ scenario:
 Run the test:
 
 ```bash
-gadugi-agentic-test run test-hello.yaml
+gadugi-test run test-hello.yaml
 ```
 
 Output:
@@ -888,19 +905,19 @@ scenario:
 **Single test**:
 
 ```bash
-gadugi-agentic-test run test-scenario.yaml
+gadugi-test run test-scenario.yaml
 ```
 
 **Multiple tests**:
 
 ```bash
-gadugi-agentic-test run tests/*.yaml
+gadugi-test run tests/*.yaml
 ```
 
 **With options**:
 
 ```bash
-gadugi-agentic-test run test.yaml \
+gadugi-test run test.yaml \
   --verbose \
   --evidence-dir ./test-evidence \
   --retry 2 \
@@ -923,10 +940,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install gadugi-agentic-test
-        run: pip install gadugi-agentic-test
+        run: npm install -g @gadugi/agentic-test
 
       - name: Run tests
-        run: gadugi-agentic-test run tests/agentic/*.yaml
+        run: gadugi-test run tests/agentic/*.yaml
 
       - name: Upload evidence
         if: always()
@@ -1079,7 +1096,7 @@ scenario:
 scenario:
   name: "Critical Payment Flow"
   tags: [smoke, critical, payment, e2e]
-  # Run with: gadugi-agentic-test run --tags critical
+  # Run with: gadugi-test run --tags critical
 ```
 
 ### 7. Add Timeouts Strategically
@@ -1121,7 +1138,7 @@ scenario:
       timeout: 5s
 ```
 
-Run before every commit: `gadugi-agentic-test run --tags smoke`
+Run before every commit: `gadugi-test run --tags smoke`
 
 ### Happy Path Tests
 
@@ -1386,7 +1403,7 @@ python scripts/check-freshness.py
 # - Video recording for all test types
 # - Parallel test execution
 #
-# Update with: pip install --upgrade gadugi-agentic-test
+# Update with: npm update -g @gadugi/agentic-test
 ```
 
 The script checks the GitHub repository for releases and compares against the embedded version. This ensures you're aware of new features and improvements.
@@ -1755,7 +1772,7 @@ scenario:
       description: "Save screenshot of logged-in state"
 # To run this test:
 # 1. Save as test-login-valid.yaml
-# 2. Run: gadugi-agentic-test run test-login-valid.yaml
+# 2. Run: gadugi-test run test-login-valid.yaml
 # 3. Check evidence in ./evidence/user-login-valid-credentials-TIMESTAMP/
 ```
 
@@ -1789,7 +1806,7 @@ For complete shadow environment documentation, see the **shadow-testing** skill.
 shadow.create(local_sources=["~/repos/my-lib:org/my-lib"])
 
 # Run outside-in test scenarios inside shadow
-shadow.exec(shadow_id, "gadugi-agentic-test run test-scenario.yaml")
+shadow.exec(shadow_id, "gadugi-test run test-scenario.yaml")
 
 # Extract evidence
 shadow.extract(shadow_id, "/evidence", "./test-evidence")
@@ -1805,7 +1822,7 @@ shadow.destroy(shadow_id)
 amplifier-shadow create --local ~/repos/my-lib:org/my-lib --name test
 
 # Run your test scenarios
-amplifier-shadow exec test "gadugi-agentic-test run test-scenario.yaml"
+amplifier-shadow exec test "gadugi-test run test-scenario.yaml"
 
 # Extract results
 amplifier-shadow extract test /evidence ./test-evidence
@@ -1844,7 +1861,7 @@ amplifier-shadow create \
   --name multi-test
 
 # Run test that exercises both
-amplifier-shadow exec multi-test "gadugi-agentic-test run test-multi-repo.yaml"
+amplifier-shadow exec multi-test "gadugi-test run test-multi-repo.yaml"
 ```
 
 #### Pattern 4: Web App Testing in Shadow
@@ -1881,7 +1898,7 @@ amplifier-shadow exec web-test "
 "
 
 # Wait for app to start, then run tests
-amplifier-shadow exec web-test "sleep 5 && gadugi-agentic-test run test-web-app.yaml"
+amplifier-shadow exec web-test "sleep 5 && gadugi-test run test-web-app.yaml"
 ```
 
 ### Verification Best Practices
@@ -1936,7 +1953,7 @@ amplifier-shadow exec breaking-test "
 "
 
 # 3. Run outside-in test
-amplifier-shadow exec breaking-test "gadugi-agentic-test run test-library-change.yaml"
+amplifier-shadow exec breaking-test "gadugi-test run test-library-change.yaml"
 
 # If test passes, your breaking change is compatible!
 # If test fails, you've caught the issue before pushing


### PR DESCRIPTION
## Summary

Updates the outside-in-testing skill to reflect the new npm-based installation workflow for gadugi-agentic-test.

## Changes

### Installation Instructions
- Changed from `pip install gadugi-agentic-test` to `npm install -g @gadugi/agentic-test`
- Added prerequisites for native module compilation (node-pty requires build tools)
- Documented platform-specific requirements (macOS, Ubuntu/Debian, Windows)

### CLI Command Updates
- Updated all references from `gadugi-agentic-test` CLI to `gadugi-test`
- Updated CI/CD examples to use npm install
- Updated version checking and upgrade commands

### Files Changed
- `.claude/skills/outside-in-testing/SKILL.md` - Main skill documentation

## Related

- rysweet/gadugi-agentic-test#15 - NPM packaging improvements PR

## Testing

The skill documentation now accurately reflects the npm installation workflow:

```bash
# Install globally
npm install -g @gadugi/agentic-test

# Verify
gadugi-test --version

# Run tests
gadugi-test run test-scenario.yaml
```
