### PR TITLE
fix(ci): Add [skip ci] to version-check auto-bump commits

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Commit and push version bump
         run: |
           git add pyproject.toml
-          git commit -m "chore: Auto-bump patch version"
+          git commit -m "[skip ci] chore: Auto-bump patch version"
           git push
 
       - name: Comment on PR


### PR DESCRIPTION
Fixes CI workflows not running after version-check auto-bumps version.

The version-check workflow pushes commits as github-actions[bot], which don't trigger other workflows. Adding `[skip ci]` to these commits prevents blocking other CI checks.

🤖 Generated with Claude Code