### PR TITLE
fix(ci): Configure Copilot tokens and skip-ci

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,26 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install gh-aw extension
+        uses: github/gh-aw/actions/setup-cli@v0.44.0
+        with:
+          version: v0.44.0

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Commit and push version bump
         run: |
           git add pyproject.toml
-          git commit -m "chore: Auto-bump patch version"
+          git commit -m "[skip ci] chore: Auto-bump patch version"
           git push
 
       - name: Comment on PR


### PR DESCRIPTION
Fixes CI workflow issues:

1. Adds copilot-setup-steps.yml with COPILOT_GITHUB_TOKEN and GH_TOKEN env vars
2. Adds [skip ci] to version-check auto-bump commits

This fixes:
- gh-aw workflows failing secret verification
- Auto-bump commits blocking other CI checks  

Note: You need to add COPILOT_GITHUB_TOKEN secret with a PAT that has Copilot Requests scope.

🤖 Generated with Claude Code