### PR TITLE
feat: Add slash commands for all recipes with hybrid workflow

### DIFF
--- a/.claude/commands/amplihack/consensus.md
+++ b/.claude/commands/amplihack/consensus.md
@@ -1,0 +1,83 @@
+---
+name: amplihack:consensus
+version: 1.0.0
+description: Run the consensus workflow with multi-agent validation gates
+triggers:
+  - "critical implementation"
+  - "need consensus"
+  - "high-stakes code"
+  - "multi-agent validation"
+invokes:
+  - type: recipe
+    name: consensus-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/consensus-workflow.yaml
+examples:
+  - "/amplihack:consensus Implement JWT token validation for public API"
+  - "/amplihack:consensus Design database migration strategy"
+---
+
+# Consensus Workflow Command
+
+## Usage
+
+`/amplihack:consensus <TASK_DESCRIPTION>`
+
+## Purpose
+
+Directly invoke the consensus workflow recipe with multi-agent validation at 7 critical gates. Use for complex features with architectural implications, mission-critical code, security-sensitive implementations, or public APIs.
+
+This is slower but produces significantly higher quality output than the default workflow.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "consensus-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "task_description": "{TASK_DESCRIPTION}",
+           "repo_path": ".",
+           "consensus_depth": "balanced"
+       }
+   )
+   ```
+
+2. **Fallback to Skill** (if Recipe Runner unavailable):
+   - Read workflow directly and execute with multi-agent debate at each gate
+
+3. **Create TodoWrite entries** for all 15 steps including 7 consensus gates.
+
+## Consensus Gates
+
+1. Requirements: Multi-Agent Debate (if ambiguous)
+2. Design: Architecture debate (5 agents, 3 rounds)
+3. Implementation: N-Version programming (2-3 builders)
+4. Refactoring: Expert Panel (4 agents)
+5. PR Review: Expert Panel (5 agents)
+6. Philosophy: Compliance Panel (3 agents)
+7. Final: Quality Panel (3 agents)
+
+## When to Use
+
+- Complex features with architectural implications
+- Mission-critical code requiring high reliability
+- Security-sensitive implementations
+- Public APIs with long-term commitments
+
+## Cost-Benefit
+
+- **Cost:** 3-5x execution time vs default-workflow
+- **Benefit:** Significantly higher quality through consensus validation
+
+## Task Description
+
+```
+{TASK_DESCRIPTION}
+```

--- a/.claude/commands/amplihack/default-workflow.md
+++ b/.claude/commands/amplihack/default-workflow.md
@@ -1,0 +1,80 @@
+---
+name: amplihack:default-workflow
+version: 1.0.0
+description: Run the full 23-step development workflow via Recipe Runner
+aliases: [amplihack:dev]
+triggers:
+  - "full development workflow"
+  - "complete workflow"
+  - "23-step workflow"
+invokes:
+  - type: recipe
+    name: default-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/default-workflow.yaml
+examples:
+  - "/amplihack:default-workflow Add JWT authentication to REST API"
+  - "/amplihack:dev Fix null pointer in UserService"
+---
+
+# Default Workflow Command
+
+## Usage
+
+`/amplihack:default-workflow <TASK_DESCRIPTION>`
+`/amplihack:dev <TASK_DESCRIPTION>`
+
+## Purpose
+
+Directly invoke the full 23-step development workflow recipe. This is the standard workflow for features, bug fixes, and refactoring.
+
+Unlike `/ultrathink` which auto-detects the workflow type, this command always runs `default-workflow` without classification overhead.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "default-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "task_description": "{TASK_DESCRIPTION}",
+           "repo_path": "."
+       }
+   )
+   ```
+
+2. **Fallback to Skill** (if Recipe Runner unavailable):
+
+   ```
+   Skill(skill="default-workflow")
+   ```
+
+3. **Final fallback to Markdown** (if skill unavailable):
+
+   ```
+   Read(file_path="~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md")
+   ```
+
+4. **Create TodoWrite entries** for all 23 steps and execute systematically.
+
+## Phases
+
+1. Requirements Clarification (Steps 0-3)
+2. Design (Steps 4-6)
+3. Implementation (Steps 7-9)
+4. Testing & Review (Steps 10-13)
+5. Version & PR (Steps 14-16)
+6. PR Review (Steps 17-18)
+7. Merge (Steps 19-22)
+
+## Task Description
+
+```
+{TASK_DESCRIPTION}
+```

--- a/.claude/commands/amplihack/dev.md
+++ b/.claude/commands/amplihack/dev.md
@@ -1,0 +1,64 @@
+---
+name: amplihack:dev
+version: 1.0.0
+description: Alias for /amplihack:default-workflow - Run the full 23-step development workflow
+aliases_for: amplihack:default-workflow
+triggers:
+  - "dev workflow"
+  - "start development"
+invokes:
+  - type: recipe
+    name: default-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/default-workflow.yaml
+examples:
+  - "/amplihack:dev Add user authentication"
+  - "/amplihack:dev Fix login timeout bug"
+---
+
+# Dev Command (Alias)
+
+## Usage
+
+`/amplihack:dev <TASK_DESCRIPTION>`
+
+This is an alias for `/amplihack:default-workflow`. See that command for full documentation.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, execute exactly as `/amplihack:default-workflow`:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "default-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "task_description": "{TASK_DESCRIPTION}",
+           "repo_path": "."
+       }
+   )
+   ```
+
+2. **Fallback to Skill** (if Recipe Runner unavailable):
+
+   ```
+   Skill(skill="default-workflow")
+   ```
+
+3. **Final fallback to Markdown** (if skill unavailable):
+
+   ```
+   Read(file_path="~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md")
+   ```
+
+4. **Create TodoWrite entries** for all 23 steps and execute systematically.
+
+## Task Description
+
+```
+{TASK_DESCRIPTION}
+```

--- a/.claude/commands/amplihack/guide.md
+++ b/.claude/commands/amplihack/guide.md
@@ -1,0 +1,67 @@
+---
+name: amplihack:guide
+version: 1.0.0
+description: Interactive guide to amplihack features and workflows
+triggers:
+  - "help with amplihack"
+  - "how to use amplihack"
+  - "amplihack guide"
+  - "onboarding"
+invokes:
+  - type: recipe
+    name: guide
+dependencies:
+  required:
+    - amplifier-bundle/recipes/guide.yaml
+examples:
+  - "/amplihack:guide How do workflows work?"
+  - "/amplihack:guide What agents are available?"
+---
+
+# Amplihack Guide Command
+
+## Usage
+
+`/amplihack:guide <TOPIC>`
+
+## Purpose
+
+Interactive guide to amplihack features. Ask about workflows, agents, skills, hooks, recipes, or any amplihack concept and get a friendly, knowledgeable explanation.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "guide",
+       adapter=sdk_adapter,
+       user_context={
+           "topic": "{TOPIC}",
+           "detail_level": "standard"
+       }
+   )
+   ```
+
+2. **Fallback to direct response**:
+   - Use knowledge of amplihack to answer the question
+   - Reference relevant files and documentation
+   - Point to commands, skills, and agents as appropriate
+
+## Topics
+
+- **Workflows**: How the 9 workflow recipes work
+- **Agents**: What agents are available and when to use them
+- **Skills**: How skills auto-activate and extend capabilities
+- **Commands**: Slash commands and their purposes
+- **Recipes**: Recipe Runner and YAML recipe format
+- **Philosophy**: Ruthless simplicity, bricks & studs, zero-BS
+
+## Topic
+
+```
+{TOPIC}
+```

--- a/.claude/commands/amplihack/hybrid.md
+++ b/.claude/commands/amplihack/hybrid.md
@@ -1,0 +1,128 @@
+---
+name: amplihack:hybrid
+version: 1.0.0
+description: Hybrid workflow - investigation first, then development
+aliases: [amplihack:run]
+triggers:
+  - "investigate then implement"
+  - "understand then build"
+  - "research then develop"
+  - "hybrid workflow"
+invokes:
+  - type: recipe
+    name: investigation-workflow
+  - type: recipe
+    name: default-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/investigation-workflow.yaml
+    - amplifier-bundle/recipes/default-workflow.yaml
+examples:
+  - "/amplihack:hybrid Understand the auth system then add OAuth support"
+  - "/amplihack:run Investigate rate limiting, then implement it"
+---
+
+# Hybrid Workflow Command
+
+## Usage
+
+`/amplihack:hybrid <TASK_DESCRIPTION>`
+`/amplihack:run <TASK_DESCRIPTION>`
+
+## Purpose
+
+Execute a two-phase hybrid workflow: investigate first, then develop. The investigation phase builds understanding that feeds directly into the development phase, producing better-informed implementations.
+
+This is the recommended approach when working in unfamiliar code areas or when the task requires understanding existing systems before making changes.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST execute two phases sequentially:
+
+### Phase 1: Investigation
+
+1. **Extract the investigation aspect** from the task description.
+   Parse the task to identify what needs to be understood before building.
+
+2. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+
+   # Phase 1: Investigation
+   investigation_result = run_recipe_by_name(
+       "investigation-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "investigation_question": "[investigation aspect of TASK_DESCRIPTION]",
+           "codebase_path": ".",
+           "investigation_type": "code",
+           "depth": "deep"
+       }
+   )
+   ```
+
+3. **Fallback to Skill** (if Recipe Runner unavailable):
+   ```
+   Skill(skill="investigation-workflow")
+   ```
+
+### Phase 2: Development (with investigation context)
+
+4. **Extract the development aspect** from the task description.
+
+5. **Execute development workflow with investigation findings**:
+
+   ```python
+   # Phase 2: Development with investigation context
+   dev_result = run_recipe_by_name(
+       "default-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "task_description": "[development aspect of TASK_DESCRIPTION]",
+           "repo_path": ".",
+           "investigation_findings": investigation_result.context,
+           "architecture_insights": investigation_result.context.get("insights", {})
+       }
+   )
+   ```
+
+6. **Fallback to Skill** (if Recipe Runner unavailable):
+   ```
+   Skill(skill="default-workflow")
+   ```
+
+### Parsing the Task
+
+The task description typically follows one of these patterns:
+
+- "Investigate X, then implement Y"
+- "Understand X and add Y"
+- "Research X, then build Y"
+- Single task that implicitly needs both (e.g., "Add OAuth to auth system" implies investigating auth first)
+
+If no explicit investigation/development split, use the full task as both:
+
+- Investigation: "How does [relevant system] work?"
+- Development: The full task description
+
+### Context Flow
+
+Investigation findings flow into development:
+
+- Architecture insights inform design decisions (Step 5)
+- Code patterns discovered guide implementation style (Step 8)
+- Identified risks shape testing strategy (Step 7)
+- Integration points inform module boundaries (Step 9)
+
+## Cost-Benefit
+
+- **Cost:** ~1.5x execution time vs development alone
+- **Benefit:** Better-informed implementation, fewer rework cycles
+- **ROI Positive when:** Working in unfamiliar code or complex systems
+
+## Task Description
+
+```
+{TASK_DESCRIPTION}
+```

--- a/.claude/commands/amplihack/investigation.md
+++ b/.claude/commands/amplihack/investigation.md
@@ -1,0 +1,80 @@
+---
+name: amplihack:investigation
+version: 1.0.0
+description: Run the 6-phase investigation workflow via Recipe Runner
+triggers:
+  - "investigate code"
+  - "understand system"
+  - "deep analysis"
+  - "explore codebase"
+invokes:
+  - type: recipe
+    name: investigation-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/investigation-workflow.yaml
+examples:
+  - "/amplihack:investigation How does the authentication system work?"
+  - "/amplihack:investigation Analyze the recipe runner architecture"
+---
+
+# Investigation Workflow Command
+
+## Usage
+
+`/amplihack:investigation <INVESTIGATION_QUESTION>`
+
+## Purpose
+
+Directly invoke the 6-phase investigation workflow recipe. Use for understanding existing code, systems, and architecture without making changes.
+
+Unlike `/ultrathink` which auto-detects the workflow type, this command always runs `investigation-workflow` without classification overhead.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "investigation-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "investigation_question": "{INVESTIGATION_QUESTION}",
+           "codebase_path": ".",
+           "investigation_type": "code",
+           "depth": "deep"
+       }
+   )
+   ```
+
+2. **Fallback to Skill** (if Recipe Runner unavailable):
+
+   ```
+   Skill(skill="investigation-workflow")
+   ```
+
+3. **Final fallback to Markdown** (if skill unavailable):
+
+   ```
+   Read(file_path="~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md")
+   ```
+
+4. **Create TodoWrite entries** for all 6 phases and execute systematically.
+
+## Phases
+
+1. Scope Definition - Define boundaries and success criteria
+2. Exploration Strategy - Plan agent deployment
+3. Parallel Deep Dives - Deploy multiple agents simultaneously
+4. Verification - Hypothesis-based testing
+5. Synthesis - Generate comprehensive findings
+6. Knowledge Capture - Update DISCOVERIES.md and PATTERNS.md
+
+## Investigation Question
+
+```
+{INVESTIGATION_QUESTION}
+```

--- a/.claude/commands/amplihack/qa.md
+++ b/.claude/commands/amplihack/qa.md
@@ -1,0 +1,59 @@
+---
+name: amplihack:qa
+version: 1.0.0
+description: Run the minimal Q&A workflow for simple questions
+triggers:
+  - "quick question"
+  - "simple question"
+  - "what is"
+invokes:
+  - type: recipe
+    name: qa-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/qa-workflow.yaml
+examples:
+  - "/amplihack:qa What does the cleanup agent do?"
+  - "/amplihack:qa How do I run tests?"
+---
+
+# Q&A Workflow Command
+
+## Usage
+
+`/amplihack:qa <QUESTION>`
+
+## Purpose
+
+Directly invoke the minimal 3-step Q&A workflow recipe. Use for simple questions that can be answered in a single turn without code changes or deep exploration.
+
+If the question turns out to be complex, the workflow will auto-escalate to investigation-workflow.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "qa-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "question": "{QUESTION}",
+           "context_info": ""
+       }
+   )
+   ```
+
+2. **Fallback to Skill** (if Recipe Runner unavailable):
+   - Read `~/.amplihack/.claude/workflow/Q&A_WORKFLOW.md` directly
+
+3. **Answer concisely** - Q&A workflow is intentionally minimal.
+
+## Question
+
+```
+{QUESTION}
+```

--- a/.claude/commands/amplihack/run.md
+++ b/.claude/commands/amplihack/run.md
@@ -1,0 +1,72 @@
+---
+name: amplihack:run
+version: 1.0.0
+description: Alias for /amplihack:hybrid - Investigation then development workflow
+aliases_for: amplihack:hybrid
+triggers:
+  - "run workflow"
+  - "investigate and build"
+invokes:
+  - type: recipe
+    name: investigation-workflow
+  - type: recipe
+    name: default-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/investigation-workflow.yaml
+    - amplifier-bundle/recipes/default-workflow.yaml
+examples:
+  - "/amplihack:run Understand the auth system then add OAuth support"
+  - "/amplihack:run Add rate limiting to the API"
+---
+
+# Run Command (Alias)
+
+## Usage
+
+`/amplihack:run <TASK_DESCRIPTION>`
+
+This is an alias for `/amplihack:hybrid`. See that command for full documentation.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, execute exactly as `/amplihack:hybrid`:
+
+### Phase 1: Investigation
+
+```python
+from amplihack.recipes import run_recipe_by_name
+
+investigation_result = run_recipe_by_name(
+    "investigation-workflow",
+    adapter=sdk_adapter,
+    user_context={
+        "investigation_question": "[investigation aspect of TASK_DESCRIPTION]",
+        "codebase_path": ".",
+        "investigation_type": "code",
+        "depth": "deep"
+    }
+)
+```
+
+### Phase 2: Development (with investigation context)
+
+```python
+dev_result = run_recipe_by_name(
+    "default-workflow",
+    adapter=sdk_adapter,
+    user_context={
+        "task_description": "[development aspect of TASK_DESCRIPTION]",
+        "repo_path": ".",
+        "investigation_findings": investigation_result.context
+    }
+)
+```
+
+Fallback: Use workflow skills or markdown workflows if Recipe Runner unavailable.
+
+## Task Description
+
+```
+{TASK_DESCRIPTION}
+```

--- a/.claude/commands/amplihack/verification.md
+++ b/.claude/commands/amplihack/verification.md
@@ -1,0 +1,70 @@
+---
+name: amplihack:verification
+version: 1.0.0
+description: Run the 5-step verification workflow for trivial changes
+triggers:
+  - "trivial change"
+  - "config update"
+  - "doc update"
+  - "simple fix"
+invokes:
+  - type: recipe
+    name: verification-workflow
+dependencies:
+  required:
+    - amplifier-bundle/recipes/verification-workflow.yaml
+examples:
+  - "/amplihack:verification Update config.yaml timeout value"
+  - "/amplihack:verification Fix typo in README"
+---
+
+# Verification Workflow Command
+
+## Usage
+
+`/amplihack:verification <CHANGE_DESCRIPTION>`
+
+## Purpose
+
+Directly invoke the 5-step verification workflow recipe. Use for trivial changes: config edits, documentation updates, presentational changes, and simple fixes under 10 lines.
+
+If the change is more complex, escalate to `/amplihack:default-workflow` or `/amplihack:dev`.
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+
+When this command is invoked, you MUST:
+
+1. **Attempt Recipe Runner execution** (preferred):
+
+   ```python
+   from amplihack.recipes import run_recipe_by_name
+   result = run_recipe_by_name(
+       "verification-workflow",
+       adapter=sdk_adapter,
+       user_context={
+           "change_description": "{CHANGE_DESCRIPTION}",
+           "repo_path": "."
+       }
+   )
+   ```
+
+2. **Fallback to manual execution**:
+   - Make the change
+   - Verify it builds/passes
+   - Commit and push
+   - Create PR
+   - Verify CI
+
+## Steps
+
+1. Make Change - Edit file(s) and verify syntax
+2. Verify - Run tests and checks
+3. Commit - Stage and commit changes
+4. PR - Create pull request
+5. CI - Verify CI passes
+
+## Change Description
+
+```
+{CHANGE_DESCRIPTION}
+```


### PR DESCRIPTION
## Summary
- Adds direct slash commands for every recipe that previously lacked one
- Creates a new hybrid investigation+development workflow command
- Adds convenience aliases `/amplihack:dev` and `/amplihack:run`

## New Commands

| Command | Alias | Recipe | Description |
|---------|-------|--------|-------------|
| `/amplihack:default-workflow` | `/amplihack:dev` | `default-workflow` | 23-step development workflow |
| `/amplihack:investigation` | - | `investigation-workflow` | 6-phase investigation |
| `/amplihack:qa` | - | `qa-workflow` | Minimal Q&A workflow |
| `/amplihack:verification` | - | `verification-workflow` | 5-step trivial changes |
| `/amplihack:consensus` | - | `consensus-workflow` | Multi-agent consensus gates |
| `/amplihack:guide` | - | `guide` | Interactive amplihack guide |
| `/amplihack:hybrid` | `/amplihack:run` | investigation + default | Investigation then development |

## Existing Commands (unchanged)
- `/amplihack:auto` -> `auto-workflow`
- `/amplihack:debate` -> `debate-workflow`
- `/amplihack:n-version` -> `n-version-workflow`
- `/amplihack:cascade` -> `cascade-workflow`

## Hybrid Workflow
The hybrid command (`/amplihack:hybrid` or `/amplihack:run`) chains the investigation-workflow into the default-workflow. It:
1. Runs the 6-phase investigation first to build understanding
2. Feeds investigation findings as context into the 23-step development workflow
3. Produces better-informed implementations when working in unfamiliar code

## Test plan
- [x] Pre-commit hooks pass (prettier, trailing whitespace, merge conflicts)
- [ ] Verify commands appear in Claude Code skill list (confirmed locally)
- [ ] Test `/amplihack:dev` invokes default-workflow recipe
- [ ] Test `/amplihack:run` chains investigation then development
- [ ] Test `/amplihack:qa` handles simple questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)