### PR TITLE
Fix typos in Microsoft Amplifier secxtion of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ amplihack copilot
 
 and then use **/model**
 
-### Other models with Microosft Amplifier
+### Other models with Microsoft Amplifier
 
-Amplifier wil walk you through model configuration on first startup:
+Amplifier will walk you through model configuration on first startup:
 
 ```sh
 amplihack amplfier


### PR DESCRIPTION
This PR fixes typos in Microsoft Amplifier section of README.md as reported in issue #2375.

Changes made:-
- Line 253: Corrected "Microosft Amplifier" → "Microsoft Amplifier"
- Line 256: Corrected "amlpfier" →  "amplifier"

No code logic was changed, this is purely a documentation improvement.