### PR TITLE
fix(recipe-runner): add retry with exponential backoff for API 529/429/503 errors (#2463)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "amplihack"
-version = "0.5.47"
+version = "0.5.48"
 description = "Amplifier bundle for agentic coding with comprehensive skills, recipes, and workflows"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Add exponential backoff retry (up to 3 retries with 2s, 4s, 8s delays) to `CLISubprocessAdapter.execute_agent_step()` for transient API errors (HTTP 429, 503, 529)
- Detect transient errors via regex matching on CLI output for status codes and keywords like "overloaded", "too many requests", "service unavailable"
- Non-transient errors (auth failures, syntax errors, etc.) fail immediately without retry

## Changes
- `src/amplihack/recipes/adapters/cli_subprocess.py`: Added `is_transient_api_error()` helper, refactored subprocess execution into `_run_agent_subprocess()`, added retry loop with exponential backoff
- `tests/unit/recipes/test_cli_subprocess_retry.py`: 30 new unit tests covering all retry scenarios (transient detection, backoff delays, max retries, non-transient passthrough, progress output)

## Test plan
- [x] All 30 new retry tests pass
- [x] All 15 existing adapter tests pass (no regressions)
- [x] Pre-commit hooks pass (ruff, pyright, etc.)
- [ ] Manual verification with actual API overload scenario

Closes #2463

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>