### PR TITLE
fix: quality-audit round 2 — critical double-quoting regression, subprocess consolidation

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -4,7 +4,7 @@ description: |
   Classifies -> formulates goal -> decomposes into workstreams ->
   executes via recipe runner (single or parallel) -> goal-seeking
   reflection loop (3 rounds max, auto-mode pattern) -> summarizes.
-version: "1.2.0"
+version: "1.3.0"
 author: "Amplihack Team"
 tags: ["orchestration", "routing", "parallel", "auto-classify", "goal-seeking"]
 
@@ -74,7 +74,7 @@ steps:
     type: "bash"
     command: |
       HELPER_PATH="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/orch_helper.py"
-      DECOMP_JSON='{{decomposition_json}}'
+      DECOMP_JSON={{decomposition_json}}
       export DECOMP_JSON HELPER_PATH
       python3 - <<'PYEOF'
       import os, sys
@@ -91,13 +91,13 @@ steps:
   - id: "extract-task-type"
     type: "bash"
     command: |
-      echo '{{parse_output}}' | grep '^task_type=' | cut -d= -f2 || echo 'Development'
+      echo {{parse_output}} | grep '^task_type=' | cut -d= -f2 || echo 'Development'
     output: "task_type"
 
   - id: "extract-workstream-count"
     type: "bash"
     command: |
-      echo '{{parse_output}}' | grep '^workstream_count=' | cut -d= -f2 || echo '1'
+      echo {{parse_output}} | grep '^workstream_count=' | cut -d= -f2 || echo '1'
     output: "workstream_count"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -188,7 +188,7 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type"
     command: |
-      SESSION_JSON='{{session_info}}'
+      SESSION_JSON={{session_info}}
       SESSION_STATUS=$(echo "$SESSION_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('status','ok'))")
       if [ "$SESSION_STATUS" = "ok" ] || [ "$SESSION_STATUS" = "no_tree_script" ]; then
         echo "ALLOWED"
@@ -230,7 +230,7 @@ steps:
       ('Development' in task_type or 'Investigation' in task_type) and int(str(workstream_count).strip() or '1') > 1 and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
       HELPER_PATH="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/orch_helper.py"
-      DECOMP_JSON='{{decomposition_json}}'
+      DECOMP_JSON={{decomposition_json}}
       export DECOMP_JSON HELPER_PATH
       python3 - <<'PYEOF'
       import json, os, re, tempfile, sys
@@ -261,11 +261,21 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and int(str(workstream_count).strip() or '1') > 1 and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      REPO_PATH='{{repo_path}}'
-      WS_FILE='{{workstreams_file}}'
-      SESSION_JSON='{{session_info}}'
-      TREE_ID=$(echo "$SESSION_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('tree_id',''))")
-      SESSION_DEPTH=$(echo "$SESSION_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('depth',0))")
+      REPO_PATH={{repo_path}}
+      WS_FILE={{workstreams_file}}
+      SESSION_JSON={{session_info}}
+      # Parse tree_id and depth in one Python subprocess
+      read -r TREE_ID SESSION_DEPTH < <(echo $SESSION_JSON | python3 - <<'PYEOF'
+      import sys, json
+      try:
+          d = json.loads(sys.stdin.read())
+          print(d.get('tree_id',''), d.get('depth',0))
+      except Exception:
+          print('', 0)
+      PYEOF
+      )
+      TREE_ID=${TREE_ID:-}
+      SESSION_DEPTH=${SESSION_DEPTH:-0}
 
       if [ -z "$WS_FILE" ] || [ ! -f "$WS_FILE" ]; then
         echo "ERROR: workstreams_file is missing or empty. create-workstreams-config may have failed." >&2
@@ -299,7 +309,7 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and 'BLOCKED' in recursion_guard and int(str(workstream_count).strip() or '1') > 1
     command: |
-      GUARD_STATE='{{recursion_guard}}'
+      GUARD_STATE={{recursion_guard}}
       echo ""
       echo "WARNING: RECURSION GUARD: Parallel workstream spawning blocked ($GUARD_STATE)"
       echo "  Falling back to single-session execution."
@@ -329,7 +339,7 @@ steps:
   - id: "cleanup-helper"
     type: "bash"
     command: |
-      WS_FILE='{{workstreams_file}}'
+      WS_FILE={{workstreams_file}}
       [ -f "$WS_FILE" ] && rm -f "$WS_FILE"
       echo "ok"
     output: "cleanup_status"
@@ -465,10 +475,20 @@ steps:
   - id: "complete-session"
     type: "bash"
     command: |
-      SESSION_JSON='{{session_info}}'
-      SESSION_ID=$(echo "$SESSION_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('session_id',''))" 2>/dev/null || echo "")
-      TREE_ID=$(echo "$SESSION_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('tree_id',''))" 2>/dev/null || echo "")
-      STATUS=$(echo "$SESSION_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('status',''))" 2>/dev/null || echo "")
+      SESSION_JSON={{session_info}}
+      # Parse all fields in one Python subprocess
+      read -r SESSION_ID TREE_ID STATUS < <(echo $SESSION_JSON | python3 - <<'PYEOF'
+      import sys, json
+      try:
+          d = json.loads(sys.stdin.read())
+          print(d.get('session_id',''), d.get('tree_id',''), d.get('status',''))
+      except Exception:
+          print('', '', '')
+      PYEOF
+      )
+      SESSION_ID=${SESSION_ID:-}
+      TREE_ID=${TREE_ID:-}
+      STATUS=${STATUS:-}
       TREE_SCRIPT="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/session_tree.py"
 
       if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ] && [ -f "$TREE_SCRIPT" ]; then
@@ -493,4 +513,4 @@ output:
     {{summary}}
 
     ---
-    *amplihack smart-orchestrator v1.2.0*
+    *amplihack smart-orchestrator v1.3.0*

--- a/amplifier-bundle/tools/orch_helper.py
+++ b/amplifier-bundle/tools/orch_helper.py
@@ -73,12 +73,10 @@ def normalise_type(raw: str) -> str:
 
 
 if __name__ == "__main__":
-    """CLI for manual testing and debugging.
-
-    Usage:
-        echo '{"task_type": "dev", "workstreams": []}' | python3 orch_helper.py extract
-        echo "dev" | python3 orch_helper.py normalise
-    """
+    # CLI for manual testing and debugging.
+    # Usage:
+    #   echo '{"task_type": "dev", "workstreams": []}' | python3 orch_helper.py extract
+    #   echo "dev" | python3 orch_helper.py normalise
     import sys
     cmd = sys.argv[1] if len(sys.argv) > 1 else "extract"
     text = sys.stdin.read()

--- a/tests/test_orch_helper.py
+++ b/tests/test_orch_helper.py
@@ -5,6 +5,7 @@ Covers: extract_json, normalise_type, and CLI subcommands.
 """
 
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -175,6 +176,23 @@ class TestCLIUnknownSubcommand(unittest.TestCase):
         )
         self.assertEqual(r.returncode, 1, f"Expected rc=1 for unknown command, got {r.returncode}")
         self.assertIn("Unknown", r.stderr)
+
+
+class TestHelperPathImport(unittest.TestCase):
+    """Verify the recipe's HELPER_PATH import pattern works."""
+
+    def test_import_via_helper_path_env_var(self):
+        """Verify the recipe's import pattern works: HELPER_PATH must be importable."""
+        tools_dir = str(Path(__file__).parent.parent / "amplifier-bundle" / "tools")
+        r = subprocess.run(
+            [sys.executable, "-c",
+             "import os,sys; sys.path.insert(0,os.path.dirname(os.environ['HELPER_PATH'])); import orch_helper; print('ok')"],
+            env={**os.environ, "HELPER_PATH": f"{tools_dir}/orch_helper.py"},
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(r.returncode, 0, f"Import via HELPER_PATH failed: {r.stderr}")
+        self.assertEqual(r.stdout.strip(), "ok")
 
 
 if __name__ == "__main__":

--- a/tests/test_smart_orchestrator_decomposition.py
+++ b/tests/test_smart_orchestrator_decomposition.py
@@ -810,22 +810,24 @@ class TestRound1SuccessPath(unittest.TestCase):
             )
         )
 
-    def test_reflect_round1_skips_depth_limited(self):
-        """reflect-round-1 condition includes DEPTH_LIMITED guard (NEW-5 fix)."""
-        round_1_result = (
-            "RECURSION GUARD: session depth limit reached.\nSTATUS: DEPTH_LIMITED"
-        )
-        # reflect-round-1 condition from recipe:
-        # 'Q&A' not in task_type and 'Operations' not in task_type and round_1_result
-        # and 'DEPTH_LIMITED' not in round_1_result
-        should_reflect_round1 = (
+    def test_reflect_round1_skips_when_no_result(self):
+        """reflect-round-1 must not run when round_1_result is empty."""
+        # Actual recipe condition: Q&A/Ops excluded AND round_1_result must be truthy
+        should_reflect = (
             "Q&A" not in "Development"
             and "Operations" not in "Development"
-            and bool(round_1_result)
-            and "DEPTH_LIMITED" not in round_1_result
+            and bool("")  # empty round_1_result -> False
         )
-        self.assertFalse(should_reflect_round1,
-            "reflect-round-1 must NOT run when result is DEPTH_LIMITED")
+        self.assertFalse(should_reflect)
+
+    def test_reflect_round1_runs_with_real_result(self):
+        """reflect-round-1 runs when there is a real round_1_result."""
+        should_reflect = (
+            "Q&A" not in "Development"
+            and "Operations" not in "Development"
+            and bool("PR created at https://github.com/... STATUS: COMPLETE")
+        )
+        self.assertTrue(should_reflect)
 
     def test_reflect_final_runs_when_depth_limited(self):
         """reflect-final does NOT have a DEPTH_LIMITED guard (just Q&A/Ops exclusion).


### PR DESCRIPTION
Fixes #2625 (CRITICAL), #2626 (HIGH), #2627 (HIGH). 130 tests pass.

## CRITICAL: Remove surrounding single-quotes from all {{var}} bash assignments (#2625)

Round-1 changed `VAR={{var}}` to `VAR='{{var}}'`. This was wrong: render_shell() already applies shlex.quote() to produce 'value'. The surrounding single-quotes in the YAML template produced `VAR=''<value>''` — bash assigns empty string silently.

**All bash steps were broken**:
- SESSION_JSON always empty → derive-recursion-guard always returned BLOCKED (silently disabling all parallel execution)
- DECOMP_JSON always empty → workstream count always defaulted to 1
- parse_output echo also broken → workstream_count extraction always returned '1'

Fix: removed ALL surrounding single-quotes from all {{var}} patterns throughout the recipe. render_shell() handles quoting correctly without YAML-level surrounding quotes.

## HIGH: Consolidate multi-subprocess JSON parsing (#2627)

- launch-parallel-round-1: 2 python3 -c processes → 1 subprocess (read -r)
- complete-session: 3 python3 -c processes → 1 subprocess (read -r)

## Other fixes
- Recipe version bumped to 1.3.0
- orch_helper.py: string literal in __main__ converted to #comments
- test_reflect_round1_skips_depth_limited: deleted (tested hypothetical condition); replaced with tests matching actual recipe conditions
- tests/test_orch_helper.py: added HELPER_PATH env-var import integration test

## Step 13: Local Testing
1. Simple: 130/130 tests pass ✅
2. Complex: YAML valid, all modules compile ✅
3. Regressions: 128 existing tests continue to pass ✅