### PR TITLE
fix: quality-audit round 3 — extract_json correctness, fallback double-exec, test quality

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -321,7 +321,7 @@ steps:
     type: "agent"
     # Fires when blocked from spawning subworkstreams — executes as single session instead
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and 'BLOCKED' in recursion_guard
+      ('Development' in task_type or 'Investigation' in task_type) and 'BLOCKED' in recursion_guard and int(str(workstream_count).strip() or '1') > 1
     agent: "amplihack:core:builder"
     prompt: |
       Execute this task as a single session (parallel execution is depth-limited).
@@ -513,4 +513,4 @@ output:
     {{summary}}
 
     ---
-    *amplihack smart-orchestrator v1.3.0*
+    *amplihack dev-orchestrator v1.3.0 (smart-orchestrator)*

--- a/amplifier-bundle/tools/orch_helper.py
+++ b/amplifier-bundle/tools/orch_helper.py
@@ -27,36 +27,20 @@ def extract_json(text: str) -> dict:
         except json.JSONDecodeError:
             continue  # malformed block, try next
 
-    # Fallback: scan for balanced-brace JSON objects in document order
-    # Tries each { candidate; if one fails JSON decode, tries the next
+    # Fallback: scan for first valid JSON object in document order.
+    # json.JSONDecoder.raw_decode() correctly handles } inside string values,
+    # unlike a manual depth counter which treats all } as structural.
+    _decoder = json.JSONDecoder()
     pos = 0
     while True:
         start = text.find('{', pos)
         if start == -1:
-            break  # no more candidates
-
-        # Find the matching close brace via depth counting
-        depth = 0
-        end = -1
-        for i, ch in enumerate(text[start:], start):
-            if ch == '{':
-                depth += 1
-            elif ch == '}':
-                depth -= 1
-                if depth == 0:
-                    end = i
-                    break
-
-        if end == -1:
-            break  # unbalanced, no complete object found
-
+            break
         try:
-            return json.loads(text[start:end + 1])
+            return _decoder.raw_decode(text, start)[0]
         except json.JSONDecodeError:
-            # This candidate failed; try the next { after the current start
             pos = start + 1
             continue
-
     return {}
 
 

--- a/tests/test_orch_helper.py
+++ b/tests/test_orch_helper.py
@@ -178,6 +178,27 @@ class TestCLIUnknownSubcommand(unittest.TestCase):
         self.assertIn("Unknown", r.stderr)
 
 
+class TestNormaliseTypePriority(unittest.TestCase):
+    """Document keyword priority when input matches multiple categories.
+    Priority order: Q&A > Operations > Investigation > Development
+    """
+
+    def test_qa_beats_operations_on_overlap(self):
+        """Q&A keywords are checked first."""
+        self.assertEqual(_h.normalise_type("question about operations"), "Q&A")
+
+    def test_operations_beats_investigation_on_overlap(self):
+        """Operations keywords are checked before Investigation.
+        'investigate operations' -> Operations, not Investigation.
+        """
+        self.assertEqual(_h.normalise_type("investigate operations"), "Operations")
+        self.assertEqual(_h.normalise_type("research command"), "Operations")
+
+    def test_investigation_beats_development_on_overlap(self):
+        """Investigation keywords win over the Development default."""
+        self.assertEqual(_h.normalise_type("research and build"), "Investigation")
+
+
 class TestHelperPathImport(unittest.TestCase):
     """Verify the recipe's HELPER_PATH import pattern works."""
 

--- a/tests/test_session_tree.py
+++ b/tests/test_session_tree.py
@@ -218,6 +218,40 @@ class TestSessionRegistration(unittest.TestCase):
             else:
                 os.environ["AMPLIHACK_MAX_DEPTH"] = saved
 
+    def test_register_session_raises_on_capacity_overflow(self):
+        """register_session raises RuntimeError when session count exceeds max_sessions."""
+        tree = self._unique_tree()
+        saved = os.environ.get("AMPLIHACK_MAX_SESSIONS")
+        os.environ["AMPLIHACK_MAX_SESSIONS"] = "2"
+        try:
+            st.register_session("s1", tree_id=tree, depth=0)
+            st.register_session("s2", tree_id=tree, depth=0)
+            with self.assertRaises(RuntimeError) as ctx:
+                st.register_session("s3", tree_id=tree, depth=0)
+            self.assertIn("max_sessions", str(ctx.exception))
+        finally:
+            if saved is None:
+                os.environ.pop("AMPLIHACK_MAX_SESSIONS", None)
+            else:
+                os.environ["AMPLIHACK_MAX_SESSIONS"] = saved
+
+    def test_register_allows_session_at_exactly_max_depth(self):
+        """register_session uses depth > max_depth (strict); depth==max_depth is allowed."""
+        tree = self._unique_tree()
+        saved = os.environ.get("AMPLIHACK_MAX_DEPTH")
+        os.environ["AMPLIHACK_MAX_DEPTH"] = "2"
+        try:
+            # depth=2 with max_depth=2: 2 > 2 is False -> should not raise
+            result = st.register_session("leaf", tree_id=tree, depth=2)
+            self.assertEqual(result["depth"], 2)
+            state = st._load(tree)
+            self.assertEqual(state["sessions"]["leaf"]["status"], "active")
+        finally:
+            if saved is None:
+                os.environ.pop("AMPLIHACK_MAX_DEPTH", None)
+            else:
+                os.environ["AMPLIHACK_MAX_DEPTH"] = saved
+
 
 class TestGetStatus(unittest.TestCase):
     """get_status returns a useful tree summary."""
@@ -440,7 +474,15 @@ class TestCLISubcommands(unittest.TestCase):
 
     def test_check_outputs_allowed_for_new_tree(self):
         """The recipe's derive-recursion-guard step calls: session_tree.py check"""
-        r = self._run_cli(["check"], extra_env={"AMPLIHACK_TREE_ID": ""})
+        r = self._run_cli(
+            ["check"],
+            extra_env={
+                "AMPLIHACK_TREE_ID": "",
+                "AMPLIHACK_SESSION_DEPTH": "0",
+                "AMPLIHACK_MAX_DEPTH": "3",
+                "AMPLIHACK_MAX_SESSIONS": "10",
+            }
+        )
         self.assertEqual(r.returncode, 0)
         self.assertEqual(r.stdout.strip(), "ALLOWED")
 

--- a/tests/test_smart_orchestrator_decomposition.py
+++ b/tests/test_smart_orchestrator_decomposition.py
@@ -501,32 +501,45 @@ class TestTaskTypeClassification(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-class TestNormaliseType(unittest.TestCase):
-    """Verify normalise_type maps abbreviated/variant strings to canonical types."""
+class TestNormaliseTypeRoundTrip(unittest.TestCase):
+    """One round-trip smoke test: parse_decomposition passes task_type through normalise_type.
+    Full normalise_type coverage is in test_orch_helper.py::TestNormaliseType.
+    """
 
-    def test_normalise_type_qa(self):
-        """'qa', 'question', 'Q&A' all resolve to 'Q&A'."""
-        for raw in ("qa", "question", "Q&A", "answer"):
-            with self.subTest(raw=raw):
-                self.assertEqual(normalise_type(raw), "Q&A")
+    def test_abbreviated_type_normalised_in_parse_decomposition(self):
+        """'Ops' input normalises to 'Operations' through the parse_decomposition shim."""
+        raw = _make_decomposition_json(
+            "Ops",
+            [{"name": "ws", "description": "task", "recipe": "default-workflow"}]
+        )
+        task_type, _ = parse_decomposition(raw)
+        self.assertEqual(task_type, "Operations")
 
-    def test_normalise_type_ops(self):
-        """'ops', 'operation', 'admin' all resolve to 'Operations'."""
-        for raw in ("ops", "operation", "admin", "Operations"):
-            with self.subTest(raw=raw):
-                self.assertEqual(normalise_type(raw), "Operations")
 
-    def test_normalise_type_investigation(self):
-        """'invest', 'research', 'understand' all resolve to 'Investigation'."""
-        for raw in ("invest", "research", "understand", "Investigation", "analysis"):
-            with self.subTest(raw=raw):
-                self.assertEqual(normalise_type(raw), "Investigation")
+class TestFallbackBlockedCondition(unittest.TestCase):
+    """Tests for execute-single-fallback-blocked recipe condition (fixed round-3)."""
 
-    def test_normalise_type_development(self):
-        """Everything else resolves to 'Development'."""
-        for raw in ("dev", "build", "feature", "Development", "implement", "unknown"):
-            with self.subTest(raw=raw):
-                self.assertEqual(normalise_type(raw), "Development")
+    def _fallback_condition(self, task_type, recursion_guard, workstream_count):
+        """Simulate the FIXED execute-single-fallback-blocked condition."""
+        return (
+            ("Development" in task_type or "Investigation" in task_type)
+            and "BLOCKED" in recursion_guard
+            and int(str(workstream_count).strip() or "1") > 1
+        )
+
+    def test_fires_for_multi_workstream_blocked(self):
+        """Fires when parallel spawning blocked and multiple workstreams planned."""
+        self.assertTrue(self._fallback_condition("Development", "BLOCKED:depth=3>=max=3", 2))
+
+    def test_does_not_fire_for_single_workstream_blocked(self):
+        """Must NOT fire for single workstream even when blocked — execute-single handles it."""
+        self.assertFalse(self._fallback_condition("Development", "BLOCKED:depth=3>=max=3", 1))
+
+    def test_does_not_fire_when_allowed(self):
+        self.assertFalse(self._fallback_condition("Development", "ALLOWED", 2))
+
+    def test_does_not_fire_for_qa(self):
+        self.assertFalse(self._fallback_condition("Q&A", "BLOCKED:depth=3>=max=3", 2))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2631 (HIGH), #2632 (HIGH), #2633 (MEDIUM), #2634 (MEDIUM). 136 tests pass.

## HIGH: Replace depth-counter in extract_json with JSONDecoder.raw_decode (#2631)
The depth counter misidentified } inside JSON string values as structural. LLMs commonly include } in descriptions (code snippets, templates, regex). Replaced with json.JSONDecoder().raw_decode() — the stdlib tool designed exactly for this. Net: -14 LOC, bug eliminated.

## HIGH: Add workstream_count > 1 guard to execute-single-fallback-blocked (#2632)  
When workstream_count==1 AND recursion_guard==BLOCKED, both execute-single-round-1 AND execute-single-fallback-blocked fired simultaneously. Both wrote to round_1_result — fallback silently overwrote real result. Fixed: added 'and workstream_count > 1' guard.

## MEDIUM: normalise_type priority documented with tests (#2633)
Q&A > Operations > Investigation > Development priority was undocumented. Added TestNormaliseTypePriority class with overlap tests.

## MEDIUM: Test coverage and isolation improvements (#2634)
- Direct test for register_session() RuntimeError on capacity overflow  
- test_check isolation: now resets all 4 AMPLIHACK_ env vars
- Boundary test: depth == max_depth is allowed (strict >)
- Removed duplicate TestNormaliseType from decomposition tests (-20 LOC)
- Added TestFallbackBlockedCondition (4 tests) documenting the fixed condition

## Step 13: Local Testing
1. 136/136 tests pass ✅  
2. YAML valid, all modules compile ✅
3. All 130 prior tests still pass ✅