### PR TITLE
fix: complete session TTL pruning for missing completed_at (#2639)

### DIFF
--- a/amplifier-bundle/tools/session_tree.py
+++ b/amplifier-bundle/tools/session_tree.py
@@ -200,13 +200,12 @@ def _save(tree_id: str, state: dict, max_age_hours: float = 24.0, active_max_age
     completed_cutoff = now - (max_age_hours * 3600)
     active_cutoff = now - (active_max_age_hours * 3600)
 
-    # started_at defaults to 0 (epoch): sessions with no start time are treated
-    #   as maximally old and always pruned when their slot would otherwise be leaked.
-    # completed_at defaults to float("inf"): sessions with no completion time are
-    #   treated as never completed and are preserved (safe default: don't prune).
+    # started_at and completed_at default to 0 (epoch): sessions missing these
+    #   timestamps are treated as maximally old and always pruned, preventing
+    #   leaked sessions from occupying capacity slots permanently.
     pruned = {}
     for sid, s in state["sessions"].items():
-        if s.get("status") == "completed" and s.get("completed_at", float("inf")) < completed_cutoff:
+        if s.get("status") == "completed" and s.get("completed_at", 0) < completed_cutoff:
             continue  # prune old completed session
         if s.get("status") == "active" and s.get("started_at", 0) < active_cutoff:
             print(

--- a/tests/test_session_tree.py
+++ b/tests/test_session_tree.py
@@ -447,17 +447,17 @@ class TestTTLPruning(unittest.TestCase):
         self.assertNotIn("no-ts", state_after["sessions"],
             "Active session with missing started_at must be pruned")
 
-    def test_completed_session_missing_completed_at_is_preserved(self):
-        """Completed sessions with no completed_at default to float('inf') — preserved."""
+    def test_completed_session_missing_completed_at_is_pruned(self):
+        """Completed sessions with no completed_at default to 0 (epoch) — always pruned."""
         tree = self._unique_tree()
         st.register_session("no-ct", tree_id=tree, depth=0)
         st.complete_session("no-ct", tree_id=tree)
         state = st._load(tree)
         del state["sessions"]["no-ct"]["completed_at"]
-        st._save(tree, state)  # triggers TTL; should NOT prune (float('inf') default)
+        st._save(tree, state)  # triggers TTL; epoch default means always prunable
         state_after = st._load(tree)
-        self.assertIn("no-ct", state_after["sessions"],
-            "Completed session with missing completed_at must be preserved")
+        self.assertNotIn("no-ct", state_after["sessions"],
+            "Completed session with missing completed_at must be pruned")
 
 
 class TestCLISubcommands(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Change `completed_at` default in `_save()` TTL pruning from `float('inf')` to `0` (epoch), matching the existing `started_at` fix from PR #2642
- Completed sessions missing a `completed_at` timestamp are now pruned instead of leaking capacity slots permanently
- Update test to verify the new pruning behavior (42/42 tests pass)

## Context

PR #2642 fixed the `started_at` half of issue #2639 but intentionally kept `completed_at` as `float('inf')`. A completed session without a `completed_at` timestamp is anomalous (marked completed but timestamp not recorded), and using `float('inf')` means such sessions are never pruned. Defaulting to `0` ensures these leaked sessions are always cleaned up.

Closes #2639

## Test plan

- [x] Ran `python -m unittest tests.test_session_tree -v` — 42/42 tests pass
- [x] Verified `test_completed_session_missing_completed_at_is_pruned` confirms sessions without `completed_at` are now pruned
- [x] Verified `test_recent_completed_session_preserved` still passes (sessions WITH `completed_at` set to now are preserved)
- [x] Verified `test_old_completed_session_pruned` still passes (sessions with `completed_at` > 24h ago are pruned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)