### PR TITLE
fix: move agent-framework to optional dep to fix uv resolution failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,9 @@ dependencies = [
     "litellm>=1.0.0",
     "python-dotenv>=0.19.0",
 
-    "agent-framework>=1.0.0rc1", # Microsoft Agent Framework for goal-seeking agents
-    "opentelemetry-semantic-conventions-ai>=0.4.1,<0.4.14", # Pin for agent-framework compat (0.4.14 removed LLM_REQUEST_MODEL)
+    # agent-framework is optional because it requires pre-release Azure deps
+    # that break uv resolution outside the project. Install separately:
+    #   pip install "agent-framework>=1.0.0rc1" --prerelease=allow
     "claude-agent-sdk>=0.1.0", # Claude Python Agent SDK for auto mode streaming
     "github-copilot-sdk>=0.1.0", # GitHub Copilot SDK for embedding Copilot in applications
     "rich>=13.0.0", # Required for --ui interactive TUI mode
@@ -54,6 +55,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Microsoft Agent Framework requires pre-release Azure deps
+microsoft-sdk = [
+    "agent-framework>=1.0.0rc1",
+    "opentelemetry-semantic-conventions-ai>=0.4.1,<0.4.14",
+]
 # When running as an Amplifier bundle, hook modules need amplifier-core
 amplifier = [
     "amplifier-core @ git+https://github.com/microsoft/amplifier-core@main",

--- a/uv.lock
+++ b/uv.lock
@@ -519,10 +519,9 @@ dependencies = [
 
 [[package]]
 name = "amplihack"
-version = "0.5.71"
+version = "0.5.72"
 source = { editable = "." }
 dependencies = [
-    { name = "agent-framework" },
     { name = "aiohttp" },
     { name = "amplihack-agent-eval" },
     { name = "amplihack-memory-lib" },
@@ -542,7 +541,6 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "litellm" },
     { name = "neo4j" },
-    { name = "opentelemetry-semantic-conventions-ai" },
     { name = "packaging" },
     { name = "protobuf" },
     { name = "psutil" },
@@ -579,6 +577,10 @@ dev = [
     { name = "rich" },
     { name = "ruff" },
 ]
+microsoft-sdk = [
+    { name = "agent-framework" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -599,7 +601,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", specifier = ">=1.0.0rc1" },
+    { name = "agent-framework", marker = "extra == 'microsoft-sdk'", specifier = ">=1.0.0rc1" },
     { name = "aiohttp", specifier = ">=3.8.0" },
     { name = "amplifier-core", marker = "extra == 'amplifier'", git = "https://github.com/microsoft/amplifier-core?rev=main" },
     { name = "amplihack-agent-eval", git = "https://github.com/rysweet/amplihack-agent-eval.git?rev=main" },
@@ -624,7 +626,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.0.0" },
     { name = "lxml", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "neo4j", specifier = ">=5.25.0" },
-    { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.4.1,<0.4.14" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "extra == 'microsoft-sdk'", specifier = ">=0.4.1,<0.4.14" },
     { name = "packaging", specifier = ">=21.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "protobuf", specifier = ">=5.29.0" },
@@ -656,7 +658,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvicorn", specifier = ">=0.15.0" },
 ]
-provides-extras = ["amplifier", "ui", "tui-testing", "test", "dev", "blarify-all"]
+provides-extras = ["microsoft-sdk", "amplifier", "ui", "tui-testing", "test", "dev", "blarify-all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Problem
`amplihack launch` fails with uv resolution error because agent-framework
requires pre-release Azure deps (azure-ai-projects>=2.0.0b3) that uv won't
resolve outside the project directory.

```
Because only azure-ai-projects<2.0.0b3 is available and agent-framework-core==1.0.0rc1
depends on azure-ai-projects>=2.0.0b3, we can conclude that agent-framework cannot be used.
```

## Fix
Move agent-framework from required to optional `[microsoft-sdk]` extra.
Base install works everywhere. Microsoft SDK users install separately:
```bash
pip install amplihack[microsoft-sdk] --prerelease=allow
```

## Test
- `uv lock` resolves cleanly (240 packages)
- `amplihack launch` no longer fails

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>