### PR TITLE
docs: clarify First Session instructions for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,33 @@ source ~/.bashrc  # or source ~/.zshrc
 
 ### First Session
 
-After launching:
+After launching amplihack (e.g., `amplihack claude`), you'll be inside an
+**interactive agent session** — a chat interface powered by your chosen coding
+agent. Everything you type in this session is interpreted by amplihack's
+workflow engine, not by your regular shell.
+
+**New users** — start with the interactive tutorial:
 
 ```
-# New users - interactive tutorial (60-90 minutes)
-Task(subagent_type='guide', prompt='I am new to amplihack. Teach me the basics.')
+I am new to amplihack. Teach me the basics.
+```
 
-# Experienced users - start coding
+This triggers a guided tutorial (60-90 minutes) that walks you through
+amplihack's core concepts and workflows.
+
+**Experienced users** — just describe what you want to build:
+
+```
 cd /path/to/my/project
-[Your prompt here - automatically uses /amplihack:ultrathink workflow]
+Add user authentication with OAuth2 support
 ```
 
 All prompts automatically invoke systematic workflow orchestration. Use
 `--no-ultrathink` flag for simple tasks.
+
+> **Note**: The `Task()` syntax shown in some documentation is an advanced
+> programmatic API for scripting agent workflows. For interactive use, plain
+> natural language prompts are all you need.
 
 ## Core Concepts
 


### PR DESCRIPTION
## Summary

Replaces the confusing `Task()` syntax in the First Session section with plain natural language examples that beginners can immediately understand.

## Problem

The current README jumps from shell commands (`amplihack claude`) to unexplained `Task(subagent_type="guide", ...)` syntax without telling users:
- Where to type it
- What `Task()` is
- Why the syntax changed from shell commands

This is the #1 friction point for new users (see #2479).

## Changes

- Replaced `Task()` examples with plain language prompts
- Added context explaining that the user is now in an interactive agent session
- Added a note about `Task()` being an advanced programmatic API
- Kept all existing information, just made it accessible

Fixes #2479