### PR TITLE
fix: strengthen routing prompt — code file edits always DEV, never Q&A/OPS

### DIFF
--- a/amplifier-bundle/tools/amplihack/hooks/dev_intent_router.py
+++ b/amplifier-bundle/tools/amplihack/hooks/dev_intent_router.py
@@ -48,10 +48,22 @@ Before responding, classify this prompt into one of these categories and act acc
   SKIP (bypass phrases: "just answer", "skip workflow", "skip orchestration", "without workflow")
     → Respect the bypass. Do not invoke any workflow.
 
+MANDATORY RULE — Code File Edits Are ALWAYS DEV:
+  If the task will require editing ANY source code files (.py, .yaml, .ts, .js, .rs, .go, .json, .toml, etc.),
+  it is ALWAYS DEV — never Q&A or OPS, regardless of how "trivial" the change seems.
+  "Change one default value" = DEV. "Update a version string" = DEV. "Fix a typo in code" = DEV.
+  Only pure knowledge questions (no file changes) qualify as Q&A.
+  Only shell commands that don't modify code qualify as OPS.
+
 Key: "make sure it works" = DEV. "write docs" = DEV. "review this PR" = DEV.
      "run tests" = OPS. "run tests and fix failures" = HYBRID. "what's broken?" = INVESTIGATE.
      "tests are failing" without a clear action request = ask if they want you to investigate/fix.
      "investigate X then fix Y" = HYBRID. "what is OAuth?" = Q&A.
+     "change the default model" = DEV (edits code files). "update a config value" = DEV (edits code files).
+     "just change one line" = DEV (still edits code files — workflow required).
+
+When in doubt, choose DEV. False positive (workflow for a simple task) costs minutes.
+False negative (no workflow for code changes) costs quality, testing, and trust.
 </system-reminder>"""
 
 _WELCOME_BANNER = ""  # Deprecated: visible notice now shown by session_start hook via stderr

--- a/amplifier-bundle/tools/amplihack/hooks/tests/test_dev_intent_router.py
+++ b/amplifier-bundle/tools/amplihack/hooks/tests/test_dev_intent_router.py
@@ -326,7 +326,24 @@ class TestRoutingPromptContent(unittest.TestCase):
         self.assertIn("run tests", _ROUTING_PROMPT)
 
     def test_prompt_is_concise(self):
-        self.assertLess(len(_ROUTING_PROMPT), 1900)
+        # Raised from 1900 to 2700 after adding mandatory code-edit rule,
+        # deceptive examples, and "when in doubt choose DEV" guidance.
+        self.assertLess(len(_ROUTING_PROMPT), 2700)
+
+    def test_contains_mandatory_code_edit_rule(self):
+        """Verify the mandatory rule that code file edits are always DEV."""
+        self.assertIn("Code File Edits Are ALWAYS DEV", _ROUTING_PROMPT)
+        self.assertIn("never Q&A or OPS", _ROUTING_PROMPT)
+
+    def test_contains_deceptive_examples(self):
+        """Verify deceptive 'trivial edit' examples route to DEV."""
+        self.assertIn("change the default model", _ROUTING_PROMPT)
+        self.assertIn("update a config value", _ROUTING_PROMPT)
+        self.assertIn("just change one line", _ROUTING_PROMPT)
+
+    def test_contains_when_in_doubt_rule(self):
+        """Verify 'when in doubt choose DEV' guidance is present."""
+        self.assertIn("When in doubt, choose DEV", _ROUTING_PROMPT)
 
     def test_auto_routed_announcement(self):
         self.assertIn("[auto-routed]", _ROUTING_PROMPT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "amplihack"
-version = "0.5.83"
+version = "0.5.84"
 description = "Amplifier bundle for agentic coding with comprehensive skills, recipes, and workflows"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Strengthens the `_ROUTING_PROMPT` in `dev_intent_router.py` to prevent Claude from classifying code file edits as Q&A or OPS.

Closes #2701

## Problem

Claude keeps bypassing the dev-orchestrator for "trivial" code changes:
- "Change the default model" -> classified as Q&A -> directly edits files
- "Update a config value" -> classified as OPS -> no branch, no tests, no PR

The routing prompt lacked an explicit rule about code file edits, so the LLM used its judgment and often misclassified edit requests.

## Changes

1. **Mandatory Code Edit Rule**: "If the task will require editing ANY source code files, it is ALWAYS DEV — never Q&A or OPS"
2. **Deceptive examples**: Added "change the default model" = DEV, "update a config value" = DEV, "just change one line" = DEV
3. **When in doubt, choose DEV**: False positive (workflow for simple task) costs minutes; false negative (no workflow for code changes) costs quality, testing, and trust
4. **Test updates**: Raised conciseness limit from 1900 to 2700 chars, added 3 new tests verifying the new rules

## Files changed

- `amplifier-bundle/tools/amplihack/hooks/dev_intent_router.py` — routing prompt strengthened
- `amplifier-bundle/tools/amplihack/hooks/tests/test_dev_intent_router.py` — updated conciseness limit + 3 new tests
- `pyproject.toml` — version bump 0.5.83 -> 0.5.84

## Step 13: Local Testing Results

### Test 1: Existing test suite (57 tests)
```
57 passed in 0.10s
```
All existing tests pass including the adjusted conciseness limit.

### Test 2: Outside-in content verification
```
PASS: routing prompt contains code-edit enforcement
PASS: routing prompt contains deceptive examples
PASS: routing prompt contains when-in-doubt rule
PASS: mandatory rule is placed before Key: examples
PASS: should_auto_route injects routing for code-edit prompts
PASS: all prompts above min length get injection (LLM does classification)
```

### Test 3: uvx install test
uvx install from branch fails due to pre-existing broken submodule reference (`.claude/worktrees/agent-a5fe46dc` in `.gitmodules`). This is unrelated to this PR's changes.

## Test plan

- [x] Existing dev_intent_router tests pass (57/57)
- [x] New tests verify mandatory code-edit rule is present
- [x] New tests verify deceptive examples are present
- [x] New tests verify when-in-doubt rule is present
- [x] Outside-in: committed content contains all three new rules
- [x] Outside-in: should_auto_route still injects for code-edit prompts
- [ ] uvx install blocked by pre-existing submodule issue (not related to this PR)

Generated with [Claude Code](https://claude.com/claude-code)