### PR TITLE
fix: README — Windows requires WSL, native not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ high-quality code.
 
 ### Prerequisites
 
-- **Platform**: macOS, Linux, or Windows (via WSL or native — see
-  [Prerequisites](docs/PREREQUISITES.md))
+- **Platform**: macOS, Linux, or Windows via WSL (native Windows is not
+  supported)
 - **Runtime**: Python 3.12+, Node.js 18+
 - **Tools**: git, npm, uv ([astral.sh/uv](https://docs.astral.sh/uv/))
 - **Optional**: GitHub CLI (`gh`), Azure CLI (`az`)


### PR DESCRIPTION
Corrects the platform line from "Windows (via WSL or native)" to
"Windows via WSL (native Windows is not supported)".

amplihack does not work on native Windows — WSL is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)