### PR TITLE
feat: smart context inference for recipe runner

### DIFF
--- a/src/amplihack/recipe_cli/recipe_command.py
+++ b/src/amplihack/recipe_cli/recipe_command.py
@@ -142,8 +142,11 @@ def handle_run(
         adapter = CLISubprocessAdapter(working_dir=wd)
         runner = RecipeRunner(adapter=adapter)
 
-        # Merge context: user context overrides recipe defaults
-        merged_context = {**(recipe.context or {}), **context}
+        # Merge context: user context overrides recipe defaults.
+        # Smart inference fills gaps for common variables when not provided.
+        recipe_defaults = recipe.context or {}
+        merged_context = {**recipe_defaults, **context}
+        merged_context = _infer_missing_context(recipe_defaults, merged_context, verbose)
 
         # Execute recipe
         result = runner.execute(
@@ -178,6 +181,69 @@ def handle_run(
 
             traceback.print_exc()
         return 1
+
+
+def _infer_missing_context(
+    recipe_defaults: dict[str, Any],
+    merged: dict[str, Any],
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Infer missing context variables from environment when not explicitly set.
+
+    Inference strategies (in priority order):
+    1. Explicit --context values (already in merged, highest priority)
+    2. Environment variables (AMPLIHACK_CONTEXT_<KEY>)
+    3. Recipe defaults (already in merged from recipe YAML)
+
+    Only infers for variables that exist in recipe defaults but are empty strings
+    (the recipe declared them but no value was provided).
+
+    Args:
+        recipe_defaults: Original defaults from recipe YAML
+        merged: Already-merged context (recipe defaults + user overrides)
+        verbose: Print inference details
+
+    Returns:
+        Updated context dict with inferred values
+    """
+    import os
+
+    result = merged.copy()
+    inferred: list[str] = []
+
+    for key, value in result.items():
+        # Only infer for empty-string defaults (recipe declared but unfilled)
+        if value != "":
+            continue
+
+        # Strategy: check AMPLIHACK_CONTEXT_<KEY> environment variable
+        env_key = f"AMPLIHACK_CONTEXT_{key.upper()}"
+        env_value = os.environ.get(env_key, "")
+        if env_value:
+            result[key] = env_value
+            inferred.append(f"{key} (from ${env_key})")
+            continue
+
+        # Strategy: common variable inference from well-known env vars
+        if key == "task_description":
+            # Check if the smart-orchestrator already set this via user_context
+            task = os.environ.get("AMPLIHACK_TASK_DESCRIPTION", "")
+            if task:
+                result[key] = task
+                inferred.append(f"{key} (from $AMPLIHACK_TASK_DESCRIPTION)")
+        elif key == "repo_path":
+            # Default to current directory if not set
+            result[key] = os.environ.get("AMPLIHACK_REPO_PATH", ".")
+            if result[key] != ".":
+                inferred.append(f"{key} (from $AMPLIHACK_REPO_PATH)")
+
+    if inferred and verbose:
+        print(
+            f"[context] Inferred {len(inferred)} variable(s): {', '.join(inferred)}",
+            file=sys.stderr,
+        )
+
+    return result
 
 
 def handle_list(


### PR DESCRIPTION
## Summary

Recipe runner now infers missing context variables from environment when not explicitly provided via `--context`. This enables running recipes without manually specifying every variable.

### Inference Priority (highest to lowest)
1. Explicit `--context key=value` (unchanged, always wins)
2. `AMPLIHACK_CONTEXT_<KEY>` environment variables (new)
3. Well-known env vars: `AMPLIHACK_TASK_DESCRIPTION`, `AMPLIHACK_REPO_PATH` (new)
4. Recipe YAML defaults (unchanged)

### Example
```bash
# Before: required explicit context
amplihack recipe run qa-workflow.yaml -c "question=What is amplihack?"

# After: inferred from environment
export AMPLIHACK_CONTEXT_QUESTION="What is amplihack?"
amplihack recipe run qa-workflow.yaml
# question inferred automatically
```

### Step 13: Local Testing Results

**Test 1**: Syntax + unit tests
```
Python syntax valid ✅
145/145 tests pass ✅
Pre-commit hooks pass ✅
```

**Test 2**: Outside-in
```
uvx install + recipe validate → ✓ ✅
```

## Test plan
- [x] Python syntax validates
- [x] 145/145 tests pass
- [x] Pre-commit hooks pass (ruff, pyright)
- [x] uvx install from branch succeeds
- [x] Backward compatible (explicit --context still works)

Closes #2349

🤖 Generated with [Claude Code](https://claude.com/claude-code)