### PR TITLE
fix: remove hardcoded project context from session_start hook

### DIFF
--- a/.claude/skills/e2e-outside-in-test-generator/generator/api_test_generator.py
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/api_test_generator.py
@@ -1,0 +1,460 @@
+"""API test scenario generator.
+
+Generates gadugi-agentic-test YAML scenarios for APIs
+based on OpenAPI/Swagger specification files.
+"""
+
+import json
+from pathlib import Path
+
+from .models import APIConfig, APIEndpointSpec, GeneratedTest, TestCategory
+from .template_manager import TemplateManager
+from .utils import ensure_directory, write_file
+
+
+def generate_api_tests(
+    config: APIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate all API test scenarios.
+
+    Args:
+        config: API configuration from OpenAPI spec
+        template_mgr: Template manager
+        output_dir: Output directory for generated test files
+
+    Returns:
+        List of GeneratedTest objects
+    """
+    generated = []
+    generated.extend(_generate_api_smoke_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_api_crud_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_api_validation_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_api_auth_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_api_workflow_tests(config, template_mgr, output_dir))
+    return generated
+
+
+def _generate_api_smoke_tests(
+    config: APIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate API smoke tests for each endpoint."""
+    tests_dir = output_dir / "api-smoke"
+    ensure_directory(tests_dir)
+
+    generated = []
+    for endpoint in config.endpoints[:15]:  # Limit to 15 endpoints
+        path_slug = endpoint.path.replace("/", "-").strip("-") or "root"
+        tag = endpoint.tags[0] if endpoint.tags else "general"
+
+        # Build request body if POST/PUT/PATCH
+        request_body = ""
+        if endpoint.method in ("POST", "PUT", "PATCH") and endpoint.request_body_schema:
+            sample = _generate_sample_data(endpoint.request_body_schema)
+            request_body = f"      body: {json.dumps(sample, indent=8)}"
+        elif endpoint.method in ("POST", "PUT", "PATCH"):
+            request_body = '      body: {}'
+
+        # Build auth header
+        auth_header = ""
+        if endpoint.requires_auth or config.auth_type != "none":
+            if config.auth_type == "bearer":
+                auth_header = '      headers:\n        Authorization: "Bearer <test-token>"'
+            elif config.auth_type == "api_key":
+                auth_header = '      headers:\n        X-API-Key: "<test-api-key>"'
+
+        # Expected status
+        expected_status = 200
+        if endpoint.method == "POST":
+            expected_status = 201
+
+        # Validation steps
+        validation_steps = ""
+        if endpoint.method == "GET" and not endpoint.requires_auth:
+            validation_steps = f"""    - action: http_request
+      method: "{endpoint.method}"
+      url: "{config.base_url}{endpoint.path}/nonexistent-id-xyz"
+      description: "Request non-existent resource"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 404
+      description: "Should return 404 for missing resource"
+"""
+
+        context = {
+            "method": endpoint.method,
+            "path": endpoint.path,
+            "summary": endpoint.summary or f"{endpoint.method} {endpoint.path}",
+            "method_lower": endpoint.method.lower(),
+            "tag": tag,
+            "base_url": config.base_url,
+            "request_body": request_body,
+            "auth_header": auth_header,
+            "expected_status": expected_status,
+            "response_pattern": ".*",
+            "path_slug": path_slug,
+            "validation_steps": validation_steps,
+        }
+
+        content = template_mgr.render("api_endpoint", context)
+        test_file = tests_dir / f"{endpoint.method.lower()}-{path_slug}.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.API_SMOKE,
+                file_path=test_file,
+                test_count=2 + (1 if validation_steps else 0),
+                description=f"API smoke test: {endpoint.method} {endpoint.path}",
+            )
+        )
+
+    return generated
+
+
+def _generate_api_crud_tests(
+    config: APIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate CRUD workflow tests by grouping endpoints by resource."""
+    tests_dir = output_dir / "api-crud"
+    ensure_directory(tests_dir)
+
+    generated = []
+
+    # Group endpoints by resource path (first path segment after base)
+    resources: dict[str, list[APIEndpointSpec]] = {}
+    for ep in config.endpoints:
+        parts = ep.path.strip("/").split("/")
+        resource = parts[0] if parts else "root"
+        resources.setdefault(resource, []).append(ep)
+
+    for resource, endpoints in list(resources.items())[:5]:
+        methods = {ep.method for ep in endpoints}
+        if len(methods) < 2:
+            continue  # Skip resources with only one method
+
+        # Build CRUD workflow steps
+        steps = []
+        step_num = 1
+
+        # POST (Create)
+        post_eps = [ep for ep in endpoints if ep.method == "POST"]
+        if post_eps:
+            ep = post_eps[0]
+            sample = _generate_sample_data(ep.request_body_schema) if ep.request_body_schema else {"name": "test"}
+            steps.append(f"""    - action: http_request
+      method: "POST"
+      url: "{config.base_url}{ep.path}"
+      body: {json.dumps(sample)}
+      description: "Step {step_num}: Create {resource}"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 201
+      description: "Create should return 201"
+""")
+            step_num += 1
+
+        # GET (Read)
+        get_eps = [ep for ep in endpoints if ep.method == "GET"]
+        if get_eps:
+            ep = get_eps[0]
+            steps.append(f"""    - action: http_request
+      method: "GET"
+      url: "{config.base_url}{ep.path}"
+      description: "Step {step_num}: Read {resource}"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 200
+      description: "Read should return 200"
+""")
+            step_num += 1
+
+        # DELETE
+        delete_eps = [ep for ep in endpoints if ep.method == "DELETE"]
+        if delete_eps:
+            ep = delete_eps[0]
+            steps.append(f"""    - action: http_request
+      method: "DELETE"
+      url: "{config.base_url}{ep.path}"
+      description: "Step {step_num}: Delete {resource}"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 200
+      description: "Delete should succeed"
+""")
+
+        if steps:
+            context = {
+                "workflow_name": f"{resource.title()} CRUD",
+                "base_url": config.base_url,
+                "workflow_slug": resource,
+                "workflow_steps": "\n".join(steps),
+            }
+
+            content = template_mgr.render("api_workflow", context)
+            test_file = tests_dir / f"{resource}-crud.yaml"
+            write_file(test_file, content)
+
+            generated.append(
+                GeneratedTest(
+                    category=TestCategory.API_CRUD,
+                    file_path=test_file,
+                    test_count=len(steps),
+                    description=f"API CRUD tests for {resource}",
+                )
+            )
+
+    return generated
+
+
+def _generate_api_validation_tests(
+    config: APIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate API input validation test scenarios."""
+    tests_dir = output_dir / "api-validation"
+    ensure_directory(tests_dir)
+
+    generated = []
+    # Find endpoints that accept request bodies
+    body_endpoints = [
+        ep for ep in config.endpoints if ep.method in ("POST", "PUT", "PATCH")
+    ]
+
+    for ep in body_endpoints[:5]:
+        path_slug = ep.path.replace("/", "-").strip("-") or "root"
+
+        content = f"""# API Validation Test - {ep.method} {ep.path}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "API Validation - {ep.method} {ep.path}"
+  description: |
+    Verifies that {ep.method} {ep.path} properly validates input
+    and returns appropriate error responses for invalid data.
+  type: api
+  level: 2
+  tags: [api, validation, {ep.method.lower()}, auto-generated]
+
+  prerequisites:
+    - "API server is running at {config.base_url}"
+
+  steps:
+    - action: http_request
+      method: "{ep.method}"
+      url: "{config.base_url}{ep.path}"
+      body: {{}}
+      description: "Send empty body"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 400
+      description: "Should reject empty body with 400"
+
+    - action: http_request
+      method: "{ep.method}"
+      url: "{config.base_url}{ep.path}"
+      body: {{"invalid_field": "random_value"}}
+      description: "Send body with unknown fields"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 400
+      description: "Should reject unknown fields"
+
+    - action: http_request
+      method: "{ep.method}"
+      url: "{config.base_url}{ep.path}"
+      headers:
+        Content-Type: "text/plain"
+      body: "not json"
+      description: "Send non-JSON body"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 415
+      description: "Should reject non-JSON content type"
+
+  cleanup:
+    - action: log_response
+      save_as: "validation-{ep.method.lower()}-{path_slug}.json"
+"""
+        test_file = tests_dir / f"validate-{ep.method.lower()}-{path_slug}.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.API_VALIDATION,
+                file_path=test_file,
+                test_count=3,
+                description=f"API validation test: {ep.method} {ep.path}",
+            )
+        )
+
+    return generated
+
+
+def _generate_api_auth_tests(
+    config: APIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate API authentication test scenarios."""
+    if config.auth_type == "none":
+        return []
+
+    tests_dir = output_dir / "api-auth"
+    ensure_directory(tests_dir)
+
+    # Find protected endpoints
+    protected = [ep for ep in config.endpoints if ep.requires_auth][:5]
+    if not protected:
+        protected = config.endpoints[:3]  # Test first 3 anyway
+
+    steps = ""
+    for ep in protected:
+        steps += f"""    - action: http_request
+      method: "{ep.method}"
+      url: "{config.base_url}{ep.path}"
+      description: "Request {ep.method} {ep.path} without auth"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: 401
+      description: "Should return 401 without authentication"
+
+"""
+
+    content = f"""# API Authentication Test
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "API Auth - Unauthenticated Access"
+  description: |
+    Verifies that protected endpoints return 401 when accessed
+    without authentication credentials.
+  type: api
+  level: 2
+  tags: [api, auth, security, auto-generated]
+
+  prerequisites:
+    - "API server is running at {config.base_url}"
+
+  steps:
+{steps}
+  cleanup:
+    - action: log_response
+      save_as: "auth-test-results.json"
+"""
+    test_file = tests_dir / "auth-unauthenticated.yaml"
+    write_file(test_file, content)
+
+    return [
+        GeneratedTest(
+            category=TestCategory.API_AUTH,
+            file_path=test_file,
+            test_count=len(protected) * 2,
+            description="API authentication tests",
+        )
+    ]
+
+
+def _generate_api_workflow_tests(
+    config: APIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate API multi-step workflow test scenarios."""
+    tests_dir = output_dir / "api-workflows"
+    ensure_directory(tests_dir)
+
+    generated = []
+
+    # Group by tags and create tag-based workflows
+    tag_endpoints: dict[str, list[APIEndpointSpec]] = {}
+    for ep in config.endpoints:
+        for tag in ep.tags or ["general"]:
+            tag_endpoints.setdefault(tag, []).append(ep)
+
+    for tag, endpoints in list(tag_endpoints.items())[:3]:
+        if len(endpoints) < 2:
+            continue
+
+        steps = ""
+        for i, ep in enumerate(endpoints[:4]):
+            body_line = ""
+            if ep.method in ("POST", "PUT", "PATCH"):
+                sample = _generate_sample_data(ep.request_body_schema) if ep.request_body_schema else {}
+                body_line = f"\n      body: {json.dumps(sample)}"
+
+            expected = 201 if ep.method == "POST" else 200
+            steps += f"""    - action: http_request
+      method: "{ep.method}"
+      url: "{config.base_url}{ep.path}"{body_line}
+      description: "Step {i+1}: {ep.summary or ep.method + ' ' + ep.path}"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: {expected}
+      description: "Step {i+1} should succeed"
+
+"""
+
+        context = {
+            "workflow_name": f"{tag.title()} Workflow",
+            "base_url": config.base_url,
+            "workflow_slug": tag.lower().replace(" ", "-"),
+            "workflow_steps": steps,
+        }
+
+        content = template_mgr.render("api_workflow", context)
+        test_file = tests_dir / f"workflow-{tag.lower().replace(' ', '-')}.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.API_WORKFLOW,
+                file_path=test_file,
+                test_count=min(len(endpoints), 4) * 2,
+                description=f"API workflow test for {tag}",
+            )
+        )
+
+    return generated
+
+
+def _generate_sample_data(schema: dict | None) -> dict:
+    """Generate sample request data from a JSON schema."""
+    if not schema or not isinstance(schema, dict):
+        return {}
+
+    sample: dict = {}
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return sample
+
+    for prop_name, prop_def in properties.items():
+        if not isinstance(prop_def, dict):
+            continue
+        prop_type = prop_def.get("type", "string")
+        if prop_type == "string":
+            if "email" in prop_name.lower():
+                sample[prop_name] = "test@example.com"
+            elif "name" in prop_name.lower():
+                sample[prop_name] = "Test Name"
+            elif "url" in prop_name.lower():
+                sample[prop_name] = "https://example.com"
+            elif "date" in prop_name.lower():
+                sample[prop_name] = "2024-01-01"
+            else:
+                sample[prop_name] = f"test-{prop_name}"
+        elif prop_type == "integer":
+            sample[prop_name] = 1
+        elif prop_type == "number":
+            sample[prop_name] = 1.0
+        elif prop_type == "boolean":
+            sample[prop_name] = True
+        elif prop_type == "array":
+            sample[prop_name] = []
+        elif prop_type == "object":
+            sample[prop_name] = {}
+
+    return sample

--- a/.claude/skills/e2e-outside-in-test-generator/generator/app_type_detector.py
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/app_type_detector.py
@@ -1,0 +1,870 @@
+"""App type detection for project classification.
+
+Detects whether a project is a Web app, CLI app, TUI app, API, or MCP server
+by analyzing project structure, dependencies, and configuration files.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    APIConfig,
+    APIEndpointSpec,
+    AppType,
+    CLICommand,
+    CLIConfig,
+    MCPConfig,
+    MCPResource,
+    MCPTool,
+    TUIConfig,
+    TUIWidget,
+)
+from .utils import find_files, read_file
+
+# Framework detection markers by app type
+CLI_MARKERS = {
+    "python": {
+        "argparse": ["import argparse", "from argparse import"],
+        "click": ["import click", "from click import", "@click.command", "@click.group"],
+        "typer": ["import typer", "from typer import", "typer.Typer()"],
+        "fire": ["import fire", "fire.Fire("],
+    },
+    "javascript": {
+        "commander": ["require('commander')", "from 'commander'", "new Command("],
+        "yargs": ["require('yargs')", "from 'yargs'", ".command("],
+        "meow": ["require('meow')", "from 'meow'"],
+        "oclif": ["@oclif/core", "extends Command"],
+    },
+    "rust": {
+        "clap": ["use clap::", "#[derive(Parser)]", "clap = "],
+        "structopt": ["use structopt::", "#[derive(StructOpt)]"],
+    },
+    "go": {
+        "cobra": ["github.com/spf13/cobra", "cobra.Command"],
+        "urfave_cli": ["github.com/urfave/cli", "cli.App"],
+    },
+}
+
+TUI_MARKERS = {
+    "python": {
+        "textual": ["from textual", "import textual", "class.*App.*textual"],
+        "rich": ["from rich", "import rich", "Console()"],
+        "blessed": ["import blessed", "from blessed"],
+        "curses": ["import curses", "curses.wrapper"],
+        "prompt_toolkit": ["from prompt_toolkit", "import prompt_toolkit"],
+    },
+    "javascript": {
+        "ink": ["from 'ink'", "require('ink')", "render(<"],
+        "blessed": ["require('blessed')", "from 'blessed'"],
+        "neo-blessed": ["require('neo-blessed')"],
+    },
+    "rust": {
+        "ratatui": ["use ratatui::", "ratatui = "],
+        "cursive": ["use cursive::", "cursive = "],
+        "tui": ["use tui::", "tui = "],
+    },
+    "go": {
+        "bubbletea": ["github.com/charmbracelet/bubbletea", "tea.Model"],
+        "tview": ["github.com/rivo/tview", "tview.NewApplication"],
+    },
+}
+
+API_SPEC_FILES = [
+    "openapi.yaml",
+    "openapi.yml",
+    "openapi.json",
+    "swagger.yaml",
+    "swagger.yml",
+    "swagger.json",
+    "api-spec.yaml",
+    "api-spec.json",
+    "docs/openapi.yaml",
+    "docs/openapi.json",
+    "docs/swagger.yaml",
+    "docs/swagger.json",
+]
+
+MCP_CONFIG_FILES = [
+    "mcp.json",
+    ".mcp.json",
+    "mcp-config.json",
+    "claude_desktop_config.json",
+    "package.json",  # may contain MCP tool definitions
+]
+
+
+def detect_app_type(project_root: Path, explicit_type: str | None = None) -> AppType:
+    """Detect the application type from project structure.
+
+    Args:
+        project_root: Path to project root
+        explicit_type: Explicitly specified app type (overrides detection)
+
+    Returns:
+        Detected AppType
+    """
+    if explicit_type:
+        try:
+            return AppType(explicit_type.lower())
+        except ValueError:
+            pass
+
+    # Check in priority order: MCP > API > TUI > CLI > Web
+    # MCP and API have very specific markers so check first
+    if _is_mcp_project(project_root):
+        return AppType.MCP
+    if _is_api_project(project_root):
+        return AppType.API
+    if _is_tui_project(project_root):
+        return AppType.TUI
+    if _is_cli_project(project_root):
+        return AppType.CLI
+    return AppType.WEB
+
+
+def detect_cli_config(project_root: Path) -> CLIConfig:
+    """Detect CLI application configuration.
+
+    Args:
+        project_root: Path to project root
+
+    Returns:
+        CLIConfig with detected commands, args, and flags
+    """
+    config = CLIConfig()
+    framework, language = _detect_cli_framework(project_root)
+    config.framework = framework
+    config.binary_path = _find_binary_path(project_root, language)
+    config.commands = _extract_cli_commands(project_root, framework, language)
+    config.global_flags = _extract_global_flags(project_root, framework, language)
+    config.has_interactive_mode = _has_interactive_mode(project_root, language)
+    return config
+
+
+def detect_tui_config(project_root: Path) -> TUIConfig:
+    """Detect TUI application configuration.
+
+    Args:
+        project_root: Path to project root
+
+    Returns:
+        TUIConfig with detected widgets and navigation
+    """
+    config = TUIConfig()
+    framework, language = _detect_tui_framework(project_root)
+    config.framework = framework
+    config.binary_path = _find_binary_path(project_root, language)
+    config.widgets = _extract_tui_widgets(project_root, framework, language)
+    config.screens = _extract_tui_screens(project_root, framework, language)
+    config.keyboard_shortcuts = _extract_keyboard_shortcuts(project_root, framework, language)
+    return config
+
+
+def detect_api_config(project_root: Path) -> APIConfig:
+    """Detect API configuration from OpenAPI/Swagger spec.
+
+    Args:
+        project_root: Path to project root
+
+    Returns:
+        APIConfig with parsed endpoints and schemas
+    """
+    config = APIConfig()
+    spec_file, spec_data = _find_and_parse_api_spec(project_root)
+    if spec_file and spec_data:
+        config.spec_file = str(spec_file)
+        config.spec_format = "swagger" if "swagger" in spec_data else "openapi"
+        config.base_url = _extract_base_url(spec_data)
+        config.api_version = spec_data.get("info", {}).get("version", "")
+        config.endpoints = _extract_api_endpoints(spec_data)
+        config.auth_type = _extract_auth_type(spec_data)
+        config.schemas = spec_data.get("components", {}).get("schemas", {})
+    return config
+
+
+def detect_mcp_config(project_root: Path) -> MCPConfig:
+    """Detect MCP server configuration.
+
+    Args:
+        project_root: Path to project root
+
+    Returns:
+        MCPConfig with detected tools and resources
+    """
+    config = MCPConfig()
+    mcp_data = _find_and_parse_mcp_config(project_root)
+    if mcp_data:
+        config.server_command = mcp_data.get("command", "")
+        config.server_args = mcp_data.get("args", [])
+        config.transport = mcp_data.get("transport", "stdio")
+        config.tools = _extract_mcp_tools(mcp_data, project_root)
+        config.resources = _extract_mcp_resources(mcp_data, project_root)
+        config.protocol_version = mcp_data.get("protocolVersion", "")
+    return config
+
+
+# --- Private detection helpers ---
+
+
+def _is_mcp_project(project_root: Path) -> bool:
+    """Check if project is an MCP server."""
+    for config_file in MCP_CONFIG_FILES:
+        path = project_root / config_file
+        if path.exists():
+            try:
+                content = read_file(path)
+                if any(
+                    marker in content
+                    for marker in [
+                        "mcpServers",
+                        "mcp-server",
+                        '"tools"',
+                        "McpServer",
+                        "mcp.tool",
+                        "@modelcontextprotocol",
+                        "from mcp",
+                        "import mcp",
+                    ]
+                ):
+                    return True
+            except Exception:
+                continue
+
+    # Check for MCP SDK imports in source files
+    for pattern in ["*.py", "*.ts", "*.js"]:
+        for f in find_files(project_root, pattern)[:20]:
+            try:
+                content = read_file(f)
+                if any(
+                    marker in content
+                    for marker in [
+                        "from mcp.server",
+                        "import { McpServer",
+                        "@modelcontextprotocol/sdk",
+                        "mcp.tool(",
+                    ]
+                ):
+                    return True
+            except Exception:
+                continue
+    return False
+
+
+def _is_api_project(project_root: Path) -> bool:
+    """Check if project has an API spec file."""
+    for spec_file in API_SPEC_FILES:
+        if (project_root / spec_file).exists():
+            return True
+    return False
+
+
+def _is_tui_project(project_root: Path) -> bool:
+    """Check if project uses a TUI framework."""
+    framework, _ = _detect_tui_framework(project_root)
+    return framework != "unknown"
+
+
+def _is_cli_project(project_root: Path) -> bool:
+    """Check if project uses a CLI framework."""
+    framework, _ = _detect_cli_framework(project_root)
+    return framework != "unknown"
+
+
+def _detect_cli_framework(project_root: Path) -> tuple[str, str]:
+    """Detect CLI framework and language."""
+    for language, frameworks in CLI_MARKERS.items():
+        extensions = _language_extensions(language)
+        for ext in extensions:
+            for f in find_files(project_root, f"*{ext}")[:15]:
+                try:
+                    content = read_file(f)
+                    for framework, markers in frameworks.items():
+                        if any(marker in content for marker in markers):
+                            return framework, language
+                except Exception:
+                    continue
+    return "unknown", "unknown"
+
+
+def _detect_tui_framework(project_root: Path) -> tuple[str, str]:
+    """Detect TUI framework and language."""
+    for language, frameworks in TUI_MARKERS.items():
+        extensions = _language_extensions(language)
+        for ext in extensions:
+            for f in find_files(project_root, f"*{ext}")[:15]:
+                try:
+                    content = read_file(f)
+                    for framework, markers in frameworks.items():
+                        if any(marker in content for marker in markers):
+                            return framework, language
+                except Exception:
+                    continue
+    return "unknown", "unknown"
+
+
+def _language_extensions(language: str) -> list[str]:
+    """Get file extensions for a language."""
+    return {
+        "python": [".py"],
+        "javascript": [".js", ".ts", ".mjs"],
+        "rust": [".rs"],
+        "go": [".go"],
+    }.get(language, [])
+
+
+def _find_binary_path(project_root: Path, language: str) -> str:
+    """Find the binary/entry point path."""
+    if language == "python":
+        for name in ["main.py", "cli.py", "app.py", "__main__.py"]:
+            candidates = find_files(project_root, name)
+            if candidates:
+                return str(candidates[0].relative_to(project_root))
+        return "python -m <module>"
+    elif language == "javascript":
+        pkg_json = project_root / "package.json"
+        if pkg_json.exists():
+            try:
+                data = json.loads(read_file(pkg_json))
+                if "bin" in data:
+                    bins = data["bin"]
+                    if isinstance(bins, str):
+                        return bins
+                    if isinstance(bins, dict):
+                        return list(bins.values())[0]
+            except Exception:
+                pass
+        return "node index.js"
+    elif language == "rust":
+        return "cargo run --"
+    elif language == "go":
+        return "go run ."
+    return "./<app>"
+
+
+def _extract_cli_commands(
+    project_root: Path, framework: str, language: str
+) -> list[CLICommand]:
+    """Extract CLI commands from source code."""
+    commands = []
+    extensions = _language_extensions(language)
+
+    for ext in extensions:
+        for f in find_files(project_root, f"*{ext}")[:20]:
+            try:
+                content = read_file(f)
+                commands.extend(_parse_commands_from_content(content, framework))
+            except Exception:
+                continue
+
+    # Deduplicate by name
+    seen = set()
+    unique = []
+    for cmd in commands:
+        if cmd.name not in seen:
+            seen.add(cmd.name)
+            unique.append(cmd)
+    return unique
+
+
+def _parse_commands_from_content(content: str, framework: str) -> list[CLICommand]:
+    """Parse CLI commands from file content based on framework."""
+    commands = []
+
+    if framework == "click":
+        # @click.command() / @click.group()
+        cmd_pattern = re.compile(
+            r'@(?:click\.command|.*\.command)\(["\']?([^"\')\s]*)["\']?\)',
+            re.MULTILINE,
+        )
+        for match in cmd_pattern.finditer(content):
+            name = match.group(1) or "main"
+            commands.append(CLICommand(name=name))
+
+        # @click.option / @click.argument
+        opt_pattern = re.compile(
+            r"@click\.option\(['\"](-[-\w]+)['\"]",
+            re.MULTILINE,
+        )
+        arg_pattern = re.compile(
+            r"@click\.argument\(['\"](\w+)['\"]",
+            re.MULTILINE,
+        )
+        flags = [m.group(1) for m in opt_pattern.finditer(content)]
+        args = [m.group(1) for m in arg_pattern.finditer(content)]
+        if commands:
+            commands[-1].flags = flags
+            commands[-1].args = args
+
+    elif framework == "typer":
+        cmd_pattern = re.compile(
+            r'@(?:app|cli)\.command\(["\']?([^"\')\s]*)["\']?\)',
+            re.MULTILINE,
+        )
+        for match in cmd_pattern.finditer(content):
+            name = match.group(1) or "main"
+            commands.append(CLICommand(name=name))
+
+    elif framework == "argparse":
+        # add_subparsers / add_parser
+        sub_pattern = re.compile(
+            r'add_parser\(["\'](\w+)["\']',
+            re.MULTILINE,
+        )
+        for match in sub_pattern.finditer(content):
+            commands.append(CLICommand(name=match.group(1)))
+
+        # add_argument
+        arg_pattern = re.compile(
+            r'add_argument\(["\'](-[-\w]+)["\']',
+            re.MULTILINE,
+        )
+        flags = [m.group(1) for m in arg_pattern.finditer(content)]
+        if commands:
+            commands[-1].flags = flags
+
+    elif framework == "commander":
+        cmd_pattern = re.compile(
+            r"\.command\(['\"](\w+)['\"]",
+            re.MULTILINE,
+        )
+        for match in cmd_pattern.finditer(content):
+            commands.append(CLICommand(name=match.group(1)))
+
+    elif framework == "yargs":
+        cmd_pattern = re.compile(
+            r"\.command\(['\"](\w+)['\"]",
+            re.MULTILINE,
+        )
+        for match in cmd_pattern.finditer(content):
+            commands.append(CLICommand(name=match.group(1)))
+
+    elif framework == "clap":
+        # Rust clap: #[arg] or .arg(Arg::new("name"))
+        cmd_pattern = re.compile(
+            r'Subcommand[^{]*\{([^}]+)\}',
+            re.MULTILINE | re.DOTALL,
+        )
+        for match in cmd_pattern.finditer(content):
+            variants = re.findall(r'(\w+)', match.group(1))
+            for v in variants:
+                if v[0].isupper():
+                    commands.append(CLICommand(name=v.lower()))
+
+    return commands
+
+
+def _extract_global_flags(
+    project_root: Path, framework: str, language: str
+) -> list[str]:
+    """Extract global flags from the CLI app."""
+    # Common flags that most CLIs support
+    return ["--help", "--version", "--verbose", "--quiet"]
+
+
+def _has_interactive_mode(project_root: Path, language: str) -> bool:
+    """Check if CLI has an interactive/REPL mode."""
+    extensions = _language_extensions(language)
+    for ext in extensions:
+        for f in find_files(project_root, f"*{ext}")[:10]:
+            try:
+                content = read_file(f)
+                if any(
+                    marker in content
+                    for marker in ["interactive", "repl", "shell", "prompt"]
+                ):
+                    return True
+            except Exception:
+                continue
+    return False
+
+
+def _extract_tui_widgets(
+    project_root: Path, framework: str, language: str
+) -> list[TUIWidget]:
+    """Extract TUI widgets from source code."""
+    widgets = []
+    extensions = _language_extensions(language)
+
+    widget_patterns = {
+        "textual": {
+            "DataTable": "table",
+            "ListView": "list",
+            "Input": "input",
+            "Button": "button",
+            "TextArea": "input",
+            "Tree": "tree",
+            "Header": "panel",
+            "Footer": "panel",
+            "Static": "panel",
+        },
+        "ink": {
+            "TextInput": "input",
+            "SelectInput": "list",
+            "Box": "panel",
+            "Text": "panel",
+        },
+        "ratatui": {
+            "Table": "table",
+            "List": "list",
+            "Paragraph": "panel",
+            "Block": "panel",
+            "Tabs": "panel",
+        },
+        "bubbletea": {
+            "list.Model": "list",
+            "table.Model": "table",
+            "textinput.Model": "input",
+            "viewport.Model": "panel",
+        },
+    }
+
+    framework_widgets = widget_patterns.get(framework, {})
+    for ext in extensions:
+        for f in find_files(project_root, f"*{ext}")[:20]:
+            try:
+                content = read_file(f)
+                for widget_name, widget_type in framework_widgets.items():
+                    if widget_name in content:
+                        widgets.append(
+                            TUIWidget(name=widget_name, widget_type=widget_type)
+                        )
+            except Exception:
+                continue
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for w in widgets:
+        if w.name not in seen:
+            seen.add(w.name)
+            unique.append(w)
+    return unique
+
+
+def _extract_tui_screens(
+    project_root: Path, framework: str, language: str
+) -> list[str]:
+    """Extract TUI screen names from source code."""
+    screens = []
+    extensions = _language_extensions(language)
+
+    for ext in extensions:
+        for f in find_files(project_root, f"*{ext}")[:20]:
+            try:
+                content = read_file(f)
+                if framework == "textual":
+                    # class MyScreen(Screen):
+                    pattern = re.compile(r"class\s+(\w+)\s*\(.*Screen.*\)")
+                    screens.extend(m.group(1) for m in pattern.finditer(content))
+                elif framework == "bubbletea":
+                    # Look for model struct names
+                    pattern = re.compile(r"type\s+(\w+Model)\s+struct")
+                    screens.extend(m.group(1) for m in pattern.finditer(content))
+            except Exception:
+                continue
+    return list(set(screens))
+
+
+def _extract_keyboard_shortcuts(
+    project_root: Path, framework: str, language: str
+) -> dict[str, str]:
+    """Extract keyboard shortcuts from TUI source code."""
+    shortcuts: dict[str, str] = {}
+    extensions = _language_extensions(language)
+
+    for ext in extensions:
+        for f in find_files(project_root, f"*{ext}")[:20]:
+            try:
+                content = read_file(f)
+                if framework == "textual":
+                    # BINDINGS = [Binding("q", "quit", "Quit")]
+                    pattern = re.compile(
+                        r'Binding\(["\'](\w+)["\'],\s*["\'](\w+)["\']'
+                    )
+                    for m in pattern.finditer(content):
+                        shortcuts[m.group(1)] = m.group(2)
+                elif framework == "bubbletea":
+                    # key.Matches(msg, "q") => quit
+                    pattern = re.compile(
+                        r'key\.Matches\(.*["\'](\w+)["\'].*\)'
+                    )
+                    for m in pattern.finditer(content):
+                        shortcuts[m.group(1)] = m.group(1)
+            except Exception:
+                continue
+    return shortcuts
+
+
+def _find_and_parse_api_spec(
+    project_root: Path,
+) -> tuple[Path | None, dict | None]:
+    """Find and parse OpenAPI/Swagger spec file."""
+    for spec_file in API_SPEC_FILES:
+        path = project_root / spec_file
+        if path.exists():
+            try:
+                content = read_file(path)
+                if path.suffix in [".json"]:
+                    data = json.loads(content)
+                else:
+                    # Simple YAML parsing for OpenAPI (avoid yaml dependency)
+                    data = _simple_yaml_parse(content)
+                if data and ("openapi" in data or "swagger" in data or "paths" in data):
+                    return path, data
+            except Exception:
+                continue
+    return None, None
+
+
+def _simple_yaml_parse(content: str) -> dict[str, Any]:
+    """Minimal YAML-to-dict parser for OpenAPI specs.
+
+    Handles flat key-value pairs and basic nested structures.
+    For complex specs, falls back to treating as empty.
+    """
+    try:
+        # Try json first (some .yaml files are actually JSON)
+        return json.loads(content)
+    except json.JSONDecodeError:
+        pass
+
+    # Basic key-value extraction from YAML
+    result: dict[str, Any] = {}
+    for line in content.split("\n"):
+        line = line.strip()
+        if ":" in line and not line.startswith("#") and not line.startswith("-"):
+            key, _, value = line.partition(":")
+            key = key.strip().strip('"').strip("'")
+            value = value.strip().strip('"').strip("'")
+            if value:
+                result[key] = value
+    return result
+
+
+def _extract_base_url(spec_data: dict) -> str:
+    """Extract base URL from API spec."""
+    # OpenAPI 3.x
+    servers = spec_data.get("servers", [])
+    if servers and isinstance(servers, list):
+        if isinstance(servers[0], dict):
+            return servers[0].get("url", "http://localhost:3000")
+    # Swagger 2.x
+    host = spec_data.get("host", "localhost:3000")
+    base_path = spec_data.get("basePath", "")
+    scheme = "https" if "https" in spec_data.get("schemes", []) else "http"
+    return f"{scheme}://{host}{base_path}"
+
+
+def _extract_api_endpoints(spec_data: dict) -> list[APIEndpointSpec]:
+    """Extract API endpoints from OpenAPI spec."""
+    endpoints = []
+    paths = spec_data.get("paths", {})
+    if not isinstance(paths, dict):
+        return endpoints
+
+    for path, methods in paths.items():
+        if not isinstance(methods, dict):
+            continue
+        for method, details in methods.items():
+            if method.lower() not in ("get", "post", "put", "delete", "patch"):
+                continue
+            if not isinstance(details, dict):
+                continue
+
+            endpoint = APIEndpointSpec(
+                path=path,
+                method=method.upper(),
+                operation_id=details.get("operationId", ""),
+                summary=details.get("summary", ""),
+                description=details.get("description", ""),
+                tags=details.get("tags", []),
+                requires_auth=bool(details.get("security")),
+            )
+
+            # Extract request body schema
+            request_body = details.get("requestBody", {})
+            if isinstance(request_body, dict):
+                content = request_body.get("content", {})
+                if isinstance(content, dict):
+                    json_content = content.get("application/json", {})
+                    if isinstance(json_content, dict):
+                        endpoint.request_body_schema = json_content.get("schema")
+
+            # Extract response schema
+            responses = details.get("responses", {})
+            if isinstance(responses, dict):
+                for status_code in ["200", "201"]:
+                    resp = responses.get(status_code, {})
+                    if isinstance(resp, dict):
+                        resp_content = resp.get("content", {})
+                        if isinstance(resp_content, dict):
+                            json_resp = resp_content.get("application/json", {})
+                            if isinstance(json_resp, dict):
+                                endpoint.response_schema = json_resp.get("schema")
+                                break
+
+            # Extract parameters
+            params = details.get("parameters", [])
+            if isinstance(params, list):
+                endpoint.parameters = [p for p in params if isinstance(p, dict)]
+
+            endpoints.append(endpoint)
+
+    return endpoints
+
+
+def _extract_auth_type(spec_data: dict) -> str:
+    """Extract authentication type from API spec."""
+    security_schemes = (
+        spec_data.get("components", {}).get("securitySchemes", {})
+        or spec_data.get("securityDefinitions", {})
+    )
+    if not isinstance(security_schemes, dict):
+        return "none"
+
+    for _, scheme in security_schemes.items():
+        if not isinstance(scheme, dict):
+            continue
+        scheme_type = scheme.get("type", "")
+        if scheme_type == "http" and scheme.get("scheme") == "bearer":
+            return "bearer"
+        if scheme_type == "apiKey":
+            return "api_key"
+        if scheme_type == "oauth2":
+            return "oauth2"
+        if scheme_type == "http" and scheme.get("scheme") == "basic":
+            return "basic"
+    return "none"
+
+
+def _find_and_parse_mcp_config(project_root: Path) -> dict | None:
+    """Find and parse MCP configuration."""
+    # Check for dedicated MCP config files
+    for config_file in ["mcp.json", ".mcp.json", "mcp-config.json"]:
+        path = project_root / config_file
+        if path.exists():
+            try:
+                return json.loads(read_file(path))
+            except Exception:
+                continue
+
+    # Check package.json for MCP server info
+    pkg_path = project_root / "package.json"
+    if pkg_path.exists():
+        try:
+            data = json.loads(read_file(pkg_path))
+            if "mcpServers" in data or "@modelcontextprotocol" in str(
+                data.get("dependencies", {})
+            ):
+                return {
+                    "command": "node",
+                    "args": [data.get("main", "index.js")],
+                    "transport": "stdio",
+                    "_package": data,
+                }
+        except Exception:
+            pass
+
+    # Check Python setup for MCP
+    for setup_file in ["setup.py", "pyproject.toml"]:
+        path = project_root / setup_file
+        if path.exists():
+            try:
+                content = read_file(path)
+                if "mcp" in content.lower():
+                    return {
+                        "command": "python",
+                        "args": ["-m", project_root.name],
+                        "transport": "stdio",
+                    }
+            except Exception:
+                continue
+
+    return None
+
+
+def _extract_mcp_tools(mcp_data: dict, project_root: Path) -> list[MCPTool]:
+    """Extract MCP tool definitions from config or source code."""
+    tools = []
+
+    # From explicit config
+    config_tools = mcp_data.get("tools", [])
+    if isinstance(config_tools, list):
+        for tool_def in config_tools:
+            if isinstance(tool_def, dict):
+                tools.append(
+                    MCPTool(
+                        name=tool_def.get("name", ""),
+                        description=tool_def.get("description", ""),
+                        input_schema=tool_def.get("inputSchema", {}),
+                        required_inputs=tool_def.get("inputSchema", {})
+                        .get("required", []),
+                    )
+                )
+
+    # From source code (Python MCP SDK patterns)
+    if not tools:
+        for f in find_files(project_root, "*.py")[:20]:
+            try:
+                content = read_file(f)
+                # @server.tool() or @mcp.tool()
+                pattern = re.compile(
+                    r'@(?:server|mcp)\.tool\(\)\s*(?:async\s+)?def\s+(\w+)',
+                    re.MULTILINE,
+                )
+                for match in pattern.finditer(content):
+                    tools.append(MCPTool(name=match.group(1)))
+
+                # server.add_tool(Tool(name="..."))
+                pattern2 = re.compile(
+                    r'Tool\(\s*name\s*=\s*["\'](\w+)["\']',
+                    re.MULTILINE,
+                )
+                for match in pattern2.finditer(content):
+                    tools.append(MCPTool(name=match.group(1)))
+            except Exception:
+                continue
+
+    # From source code (TypeScript MCP SDK patterns)
+    if not tools:
+        for f in find_files(project_root, "*.ts")[:20]:
+            try:
+                content = read_file(f)
+                # server.tool("name", ...)
+                pattern = re.compile(
+                    r'\.tool\(\s*["\'](\w+)["\']',
+                    re.MULTILINE,
+                )
+                for match in pattern.finditer(content):
+                    tools.append(MCPTool(name=match.group(1)))
+            except Exception:
+                continue
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for t in tools:
+        if t.name and t.name not in seen:
+            seen.add(t.name)
+            unique.append(t)
+    return unique
+
+
+def _extract_mcp_resources(mcp_data: dict, project_root: Path) -> list[MCPResource]:
+    """Extract MCP resource definitions."""
+    resources = []
+    config_resources = mcp_data.get("resources", [])
+    if isinstance(config_resources, list):
+        for res_def in config_resources:
+            if isinstance(res_def, dict):
+                resources.append(
+                    MCPResource(
+                        uri=res_def.get("uri", ""),
+                        name=res_def.get("name", ""),
+                        description=res_def.get("description", ""),
+                        mime_type=res_def.get("mimeType", ""),
+                    )
+                )
+    return resources

--- a/.claude/skills/e2e-outside-in-test-generator/generator/cli_test_generator.py
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/cli_test_generator.py
@@ -1,0 +1,242 @@
+"""CLI test scenario generator.
+
+Generates gadugi-agentic-test YAML scenarios for CLI applications
+based on detected commands, arguments, and flags.
+"""
+
+from pathlib import Path
+
+from .models import CLIConfig, GeneratedTest, TestCategory
+from .template_manager import TemplateManager
+from .utils import ensure_directory, write_file
+
+
+def generate_cli_tests(
+    config: CLIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate all CLI test scenarios.
+
+    Args:
+        config: CLI application configuration
+        template_mgr: Template manager
+        output_dir: Output directory for generated test files
+
+    Returns:
+        List of GeneratedTest objects
+    """
+    generated = []
+    generated.extend(_generate_cli_smoke_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_cli_command_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_cli_error_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_cli_integration_tests(config, template_mgr, output_dir))
+    return generated
+
+
+def _generate_cli_smoke_tests(
+    config: CLIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate CLI smoke tests (help, version)."""
+    tests_dir = output_dir / "cli-smoke"
+    ensure_directory(tests_dir)
+
+    context = {
+        "app_name": config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path,
+        "binary_path": config.binary_path,
+        "help_pattern": "(usage|help|commands|options)",
+        "version_pattern": r"(\\d+\\.\\d+|version)",
+    }
+
+    content = template_mgr.render("cli_smoke", context)
+    test_file = tests_dir / "smoke.yaml"
+    write_file(test_file, content)
+
+    return [
+        GeneratedTest(
+            category=TestCategory.CLI_SMOKE,
+            file_path=test_file,
+            test_count=3,
+            description="CLI smoke tests (help, version, startup)",
+        )
+    ]
+
+
+def _generate_cli_command_tests(
+    config: CLIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate test scenarios for each CLI command."""
+    tests_dir = output_dir / "cli-commands"
+    ensure_directory(tests_dir)
+
+    generated = []
+    for cmd in config.commands[:10]:  # Limit to 10 commands
+        # Build command args string
+        args_list = [f'"{cmd.name}"']
+        for arg in cmd.args[:3]:
+            args_list.append(f'"<{arg}>"')
+
+        extra_steps = ""
+        if cmd.flags:
+            # Add a test step for a flag
+            flag = cmd.flags[0]
+            extra_steps = f"""    - action: launch
+      target: "{config.binary_path}"
+      args: ["{cmd.name}", "{flag}"]
+      description: "Run {cmd.name} with {flag} flag"
+      timeout: 15s
+
+    - action: verify_exit_code
+      expected: 0
+      description: "Command with flag should succeed"
+"""
+
+        context = {
+            "app_name": config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path,
+            "binary_path": config.binary_path,
+            "command_name": cmd.name,
+            "command_args": ", ".join(args_list),
+            "success_pattern": f"(.+)",  # Any output is success for now
+            "extra_steps": extra_steps,
+        }
+
+        content = template_mgr.render("cli_command", context)
+        test_file = tests_dir / f"{cmd.name}.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.CLI_COMMANDS,
+                file_path=test_file,
+                test_count=2 + (1 if cmd.flags else 0),
+                description=f"CLI command tests for '{cmd.name}'",
+            )
+        )
+
+    return generated
+
+
+def _generate_cli_error_tests(
+    config: CLIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate CLI error handling test scenarios."""
+    tests_dir = output_dir / "cli-errors"
+    ensure_directory(tests_dir)
+
+    # Build missing arg steps
+    missing_arg_steps = ""
+    if config.commands:
+        cmd = config.commands[0]
+        if cmd.required_args:
+            missing_arg_steps = f"""    - action: launch
+      target: "{config.binary_path}"
+      args: ["{cmd.name}"]
+      description: "Run {cmd.name} without required arguments"
+      timeout: 10s
+
+    - action: verify_output
+      matches: "(error|missing|required)"
+      case_sensitive: false
+      timeout: 5s
+      description: "Should indicate missing arguments"
+
+    - action: verify_exit_code
+      expected: 1
+      description: "Should exit with error code"
+"""
+
+    # Build invalid arg steps
+    invalid_arg_steps = ""
+    if config.commands:
+        cmd = config.commands[0]
+        invalid_arg_steps = f"""    - action: launch
+      target: "{config.binary_path}"
+      args: ["{cmd.name}", "--invalid-flag-xyz"]
+      description: "Run with invalid flag"
+      timeout: 10s
+
+    - action: verify_output
+      matches: "(error|unknown|unrecognized|invalid)"
+      case_sensitive: false
+      timeout: 5s
+      description: "Should reject unknown flag"
+"""
+
+    context = {
+        "app_name": config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path,
+        "binary_path": config.binary_path,
+        "missing_arg_steps": missing_arg_steps,
+        "invalid_arg_steps": invalid_arg_steps,
+    }
+
+    content = template_mgr.render("cli_error_handling", context)
+    test_file = tests_dir / "error-handling.yaml"
+    write_file(test_file, content)
+
+    return [
+        GeneratedTest(
+            category=TestCategory.CLI_ERROR_HANDLING,
+            file_path=test_file,
+            test_count=3,
+            description="CLI error handling tests",
+        )
+    ]
+
+
+def _generate_cli_integration_tests(
+    config: CLIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate CLI integration test scenarios (command pipelines)."""
+    tests_dir = output_dir / "cli-integration"
+    ensure_directory(tests_dir)
+
+    generated = []
+    if len(config.commands) >= 2:
+        # Create a multi-command workflow test
+        steps = []
+        for i, cmd in enumerate(config.commands[:3]):
+            args = [f'"{cmd.name}"'] + [f'"test-arg-{j}"' for j in range(min(len(cmd.args), 2))]
+            steps.append(f"""    - action: launch
+      target: "{config.binary_path}"
+      args: [{", ".join(args)}]
+      description: "Step {i+1}: Run {cmd.name}"
+      timeout: 15s
+
+    - action: verify_exit_code
+      expected: 0
+      description: "{cmd.name} should succeed"
+""")
+
+        content = f"""# CLI Integration Test - Multi-Command Workflow
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "CLI Integration - Multi-Command Workflow"
+  description: |
+    Verifies that multiple CLI commands can be executed in sequence
+    as part of a typical workflow.
+  type: cli
+  level: 2
+  tags: [cli, integration, workflow, auto-generated]
+
+  prerequisites:
+    - "{config.binary_path} binary exists and is executable"
+
+  steps:
+{"".join(steps)}
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"
+"""
+        test_file = tests_dir / "multi-command-workflow.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.CLI_INTEGRATION,
+                file_path=test_file,
+                test_count=len(config.commands[:3]) * 2,
+                description="CLI multi-command integration test",
+            )
+        )
+
+    return generated

--- a/.claude/skills/e2e-outside-in-test-generator/generator/mcp_test_generator.py
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/mcp_test_generator.py
@@ -1,0 +1,371 @@
+"""MCP test scenario generator.
+
+Generates gadugi-agentic-test YAML scenarios for MCP servers
+based on tool definitions, input schemas, and resource definitions.
+"""
+
+import json
+from pathlib import Path
+
+from .models import GeneratedTest, MCPConfig, MCPTool, TestCategory
+from .template_manager import TemplateManager
+from .utils import ensure_directory, write_file
+
+
+def generate_mcp_tests(
+    config: MCPConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate all MCP test scenarios.
+
+    Args:
+        config: MCP server configuration
+        template_mgr: Template manager
+        output_dir: Output directory for generated test files
+
+    Returns:
+        List of GeneratedTest objects
+    """
+    generated = []
+    generated.extend(_generate_mcp_smoke_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_mcp_validation_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_mcp_error_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_mcp_workflow_tests(config, template_mgr, output_dir))
+    return generated
+
+
+def _generate_mcp_smoke_tests(
+    config: MCPConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate MCP tool smoke tests (one per tool)."""
+    tests_dir = output_dir / "mcp-smoke"
+    ensure_directory(tests_dir)
+
+    generated = []
+    server_args = ", ".join(f'"{a}"' for a in config.server_args)
+
+    for tool in config.tools[:10]:  # Limit to 10 tools
+        # Generate sample valid input from schema
+        valid_input = _generate_sample_input(tool)
+        valid_input_json = json.dumps(valid_input, indent=6)
+
+        # Build validation steps for required inputs
+        validation_steps = ""
+        if tool.required_inputs:
+            # Test with missing required field
+            if valid_input:
+                first_required = tool.required_inputs[0]
+                incomplete_input = {k: v for k, v in valid_input.items() if k != first_required}
+                validation_steps = f"""    - action: mcp_call_tool
+      tool: "{tool.name}"
+      input: {json.dumps(incomplete_input)}
+      description: "Call without required field '{first_required}'"
+      timeout: 15s
+
+    - action: verify_mcp_error
+      matches: "(required|missing|{first_required})"
+      description: "Should report missing required field"
+"""
+
+        # Build error steps
+        error_steps = f"""    - action: mcp_call_tool
+      tool: "{tool.name}"
+      input: {{"__invalid__": true}}
+      description: "Call with invalid input schema"
+      timeout: 15s
+
+    - action: verify_mcp_error
+      matches: "(invalid|error|unexpected)"
+      description: "Should handle invalid input gracefully"
+"""
+
+        context = {
+            "tool_name": tool.name,
+            "tool_description": tool.description or f"MCP tool: {tool.name}",
+            "transport": config.transport,
+            "server_command": config.server_command,
+            "server_args": server_args,
+            "valid_input": valid_input_json,
+            "response_pattern": ".*",  # Any response is ok for smoke
+            "validation_steps": validation_steps,
+            "error_steps": error_steps,
+        }
+
+        content = template_mgr.render("mcp_tool", context)
+        test_file = tests_dir / f"{tool.name}.yaml"
+        write_file(test_file, content)
+
+        test_count = 2  # basic call + invalid input
+        if validation_steps:
+            test_count += 1
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.MCP_TOOL_SMOKE,
+                file_path=test_file,
+                test_count=test_count,
+                description=f"MCP smoke test for tool '{tool.name}'",
+            )
+        )
+
+    return generated
+
+
+def _generate_mcp_validation_tests(
+    config: MCPConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate MCP input validation test scenarios."""
+    tests_dir = output_dir / "mcp-validation"
+    ensure_directory(tests_dir)
+
+    generated = []
+    server_args = ", ".join(f'"{a}"' for a in config.server_args)
+
+    # Find tools with defined input schemas
+    schema_tools = [t for t in config.tools if t.input_schema]
+
+    for tool in schema_tools[:5]:
+        properties = tool.input_schema.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+
+        # Generate type mismatch tests
+        steps = ""
+        for prop_name, prop_def in list(properties.items())[:3]:
+            if not isinstance(prop_def, dict):
+                continue
+            prop_type = prop_def.get("type", "string")
+
+            # Create input with wrong type
+            wrong_value = _wrong_type_value(prop_type)
+            wrong_input = {prop_name: wrong_value}
+
+            steps += f"""    - action: mcp_call_tool
+      tool: "{tool.name}"
+      input: {json.dumps(wrong_input)}
+      description: "Send wrong type for '{prop_name}' (expected {prop_type})"
+      timeout: 15s
+
+    - action: verify_mcp_error
+      matches: "(type|invalid|error|{prop_name})"
+      description: "Should reject wrong type for {prop_name}"
+
+"""
+
+        if steps:
+            content = f"""# MCP Input Validation Test - {tool.name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "MCP Validation - {tool.name} Input Types"
+  description: |
+    Verifies that the '{tool.name}' tool properly validates input types
+    and returns meaningful error messages for type mismatches.
+  type: mcp
+  level: 2
+  tags: [mcp, validation, {tool.name}, auto-generated]
+
+  prerequisites:
+    - "MCP server is available via {config.transport} transport"
+
+  steps:
+    - action: mcp_connect
+      command: "{config.server_command}"
+      args: [{server_args}]
+      transport: "{config.transport}"
+      description: "Connect to MCP server"
+      timeout: 15s
+
+{steps}
+    - action: mcp_disconnect
+      description: "Disconnect from MCP server"
+
+  cleanup:
+    - action: mcp_disconnect
+      force: true
+"""
+            test_file = tests_dir / f"validate-{tool.name}.yaml"
+            write_file(test_file, content)
+
+            prop_count = min(len(properties), 3)
+            generated.append(
+                GeneratedTest(
+                    category=TestCategory.MCP_TOOL_VALIDATION,
+                    file_path=test_file,
+                    test_count=prop_count,
+                    description=f"MCP validation test for '{tool.name}'",
+                )
+            )
+
+    return generated
+
+
+def _generate_mcp_error_tests(
+    config: MCPConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate MCP error handling test scenarios."""
+    tests_dir = output_dir / "mcp-errors"
+    ensure_directory(tests_dir)
+
+    server_args = ", ".join(f'"{a}"' for a in config.server_args)
+
+    content = f"""# MCP Error Handling Test
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "MCP Error Handling - Server Resilience"
+  description: |
+    Verifies that the MCP server handles error conditions gracefully
+    including unknown tools, malformed input, and edge cases.
+  type: mcp
+  level: 2
+  tags: [mcp, error-handling, resilience, auto-generated]
+
+  prerequisites:
+    - "MCP server is available via {config.transport} transport"
+
+  steps:
+    - action: mcp_connect
+      command: "{config.server_command}"
+      args: [{server_args}]
+      transport: "{config.transport}"
+      description: "Connect to MCP server"
+      timeout: 15s
+
+    - action: mcp_call_tool
+      tool: "nonexistent_tool_xyz"
+      input: {{}}
+      description: "Call non-existent tool"
+      timeout: 10s
+
+    - action: verify_mcp_error
+      matches: "(not found|unknown|does not exist)"
+      description: "Should report unknown tool"
+
+    - action: mcp_call_tool
+      tool: "{config.tools[0].name if config.tools else 'test'}"
+      input: null
+      description: "Call with null input"
+      timeout: 10s
+
+    - action: verify_mcp_error
+      matches: "(invalid|null|error)"
+      description: "Should handle null input"
+
+    - action: mcp_disconnect
+      description: "Disconnect from MCP server"
+
+  cleanup:
+    - action: mcp_disconnect
+      force: true
+"""
+    test_file = tests_dir / "error-handling.yaml"
+    write_file(test_file, content)
+
+    return [
+        GeneratedTest(
+            category=TestCategory.MCP_TOOL_ERROR,
+            file_path=test_file,
+            test_count=3,
+            description="MCP error handling tests",
+        )
+    ]
+
+
+def _generate_mcp_workflow_tests(
+    config: MCPConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate MCP multi-tool workflow test scenarios."""
+    if len(config.tools) < 2:
+        return []
+
+    tests_dir = output_dir / "mcp-workflows"
+    ensure_directory(tests_dir)
+
+    server_args = ", ".join(f'"{a}"' for a in config.server_args)
+
+    # Build workflow steps calling tools in sequence
+    steps = ""
+    for i, tool in enumerate(config.tools[:4]):
+        valid_input = _generate_sample_input(tool)
+        steps += f"""    - action: mcp_call_tool
+      tool: "{tool.name}"
+      input: {json.dumps(valid_input)}
+      description: "Step {i+1}: Call {tool.name}"
+      timeout: 30s
+
+    - action: verify_mcp_response
+      matches: ".*"
+      description: "Step {i+1}: {tool.name} should respond"
+
+"""
+
+    context = {
+        "workflow_name": "Multi-Tool Sequence",
+        "transport": config.transport,
+        "server_command": config.server_command,
+        "server_args": server_args,
+        "workflow_steps": steps,
+    }
+
+    content = template_mgr.render("mcp_workflow", context)
+    test_file = tests_dir / "multi-tool-workflow.yaml"
+    write_file(test_file, content)
+
+    return [
+        GeneratedTest(
+            category=TestCategory.MCP_WORKFLOW,
+            file_path=test_file,
+            test_count=min(len(config.tools), 4) * 2,
+            description="MCP multi-tool workflow test",
+        )
+    ]
+
+
+def _generate_sample_input(tool: MCPTool) -> dict:
+    """Generate sample valid input for an MCP tool."""
+    if not tool.input_schema:
+        return {}
+
+    sample: dict = {}
+    properties = tool.input_schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return sample
+
+    for prop_name, prop_def in properties.items():
+        if not isinstance(prop_def, dict):
+            continue
+        prop_type = prop_def.get("type", "string")
+        if prop_type == "string":
+            if "path" in prop_name.lower() or "file" in prop_name.lower():
+                sample[prop_name] = "/tmp/test-file.txt"
+            elif "url" in prop_name.lower():
+                sample[prop_name] = "https://example.com"
+            elif "query" in prop_name.lower():
+                sample[prop_name] = "test query"
+            else:
+                sample[prop_name] = f"test-{prop_name}"
+        elif prop_type == "integer":
+            sample[prop_name] = 1
+        elif prop_type == "number":
+            sample[prop_name] = 1.0
+        elif prop_type == "boolean":
+            sample[prop_name] = True
+        elif prop_type == "array":
+            sample[prop_name] = ["item1"]
+        elif prop_type == "object":
+            sample[prop_name] = {}
+
+    return sample
+
+
+def _wrong_type_value(expected_type: str):
+    """Return a value of the wrong type for testing."""
+    wrong_values = {
+        "string": 12345,
+        "integer": "not-a-number",
+        "number": "not-a-number",
+        "boolean": "not-a-bool",
+        "array": "not-an-array",
+        "object": "not-an-object",
+    }
+    return wrong_values.get(expected_type, None)

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/api_endpoint.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/api_endpoint.template
@@ -1,0 +1,40 @@
+# API Endpoint Test - {method} {path}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "API {method} {path} - {summary}"
+  description: |
+    Verifies the {method} {path} endpoint responds correctly with valid input
+    and returns appropriate error responses for invalid input.
+  type: api
+  level: 1
+  tags: [api, {method_lower}, {tag}, auto-generated]
+
+  prerequisites:
+    - "API server is running at {base_url}"
+
+  variables:
+    base_url: "{base_url}"
+
+  steps:
+    - action: http_request
+      method: "{method}"
+      url: "{base_url}{path}"
+{request_body}
+{auth_header}
+      description: "Send valid {method} request to {path}"
+      timeout: 10s
+
+    - action: verify_status_code
+      expected: {expected_status}
+      description: "Should return {expected_status} status"
+
+    - action: verify_response
+      matches: "{response_pattern}"
+      description: "Response should match expected schema"
+
+{validation_steps}
+  cleanup:
+    - action: log_response
+      save_as: "{method_lower}-{path_slug}-response.json"
+      description: "Save response for debugging"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/api_workflow.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/api_workflow.template
@@ -1,0 +1,25 @@
+# API Workflow Test - {workflow_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "API Workflow - {workflow_name}"
+  description: |
+    Verifies the end-to-end {workflow_name} workflow by executing a sequence
+    of API calls and validating the business logic.
+  type: api
+  level: 2
+  tags: [api, workflow, integration, auto-generated]
+
+  prerequisites:
+    - "API server is running at {base_url}"
+
+  variables:
+    base_url: "{base_url}"
+
+  steps:
+{workflow_steps}
+
+  cleanup:
+    - action: log_response
+      save_as: "workflow-{workflow_slug}-result.json"
+      description: "Save workflow results"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/cli_command.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/cli_command.template
@@ -1,0 +1,36 @@
+# CLI Command Test - {command_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "CLI Command - {app_name} {command_name}"
+  description: |
+    Verifies that the '{command_name}' command works correctly with valid arguments,
+    produces expected output, and handles basic error cases.
+  type: cli
+  level: 1
+  tags: [cli, command, {command_name}, auto-generated]
+
+  prerequisites:
+    - "{binary_path} binary exists and is executable"
+
+  steps:
+    - action: launch
+      target: "{binary_path}"
+      args: [{command_args}]
+      description: "Run {command_name} with valid arguments"
+      timeout: 15s
+
+    - action: verify_output
+      matches: "{success_pattern}"
+      timeout: 10s
+      description: "Command should produce expected output"
+
+    - action: verify_exit_code
+      expected: 0
+      description: "Command should succeed with valid args"
+
+{extra_steps}
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/cli_error_handling.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/cli_error_handling.template
@@ -1,0 +1,38 @@
+# CLI Error Handling Test - {app_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "CLI Error Handling - {app_name}"
+  description: |
+    Verifies that {app_name} CLI handles invalid input gracefully with clear error messages
+    and appropriate exit codes.
+  type: cli
+  level: 2
+  tags: [cli, error-handling, resilience, auto-generated]
+
+  prerequisites:
+    - "{binary_path} binary exists and is executable"
+
+  steps:
+    - action: launch
+      target: "{binary_path}"
+      args: ["nonexistent-command"]
+      description: "Run with invalid command"
+      timeout: 10s
+
+    - action: verify_output
+      matches: "(error|unknown|invalid|not found)"
+      case_sensitive: false
+      timeout: 5s
+      description: "Should show error for unknown command"
+
+    - action: verify_exit_code
+      expected: 1
+      description: "Should exit with non-zero code"
+
+{missing_arg_steps}
+{invalid_arg_steps}
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/cli_smoke.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/cli_smoke.template
@@ -1,0 +1,50 @@
+# CLI Smoke Tests - {app_name}
+# Auto-generated outside-in test scenarios
+
+scenario:
+  name: "CLI Smoke - {app_name} Basic Operations"
+  description: |
+    Verifies that {app_name} CLI starts correctly, responds to --help and --version,
+    and exits cleanly.
+  type: cli
+  level: 1
+  tags: [cli, smoke, basic, auto-generated]
+
+  prerequisites:
+    - "{binary_path} binary exists and is executable"
+
+  steps:
+    - action: launch
+      target: "{binary_path}"
+      args: ["--help"]
+      description: "Run help command"
+      timeout: 10s
+
+    - action: verify_output
+      matches: "{help_pattern}"
+      timeout: 5s
+      description: "Help output should contain usage info"
+
+    - action: verify_exit_code
+      expected: 0
+      description: "Help command should exit cleanly"
+
+    - action: launch
+      target: "{binary_path}"
+      args: ["--version"]
+      description: "Run version command"
+      timeout: 5s
+
+    - action: verify_output
+      matches: "{version_pattern}"
+      timeout: 3s
+      description: "Should display version information"
+
+    - action: verify_exit_code
+      expected: 0
+      description: "Version command should exit cleanly"
+
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/mcp_tool.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/mcp_tool.template
@@ -1,0 +1,47 @@
+# MCP Tool Test - {tool_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "MCP Tool - {tool_name}"
+  description: |
+    Verifies the MCP tool '{tool_name}' responds correctly to valid input,
+    validates required parameters, and handles errors gracefully.
+    Tool description: {tool_description}
+  type: mcp
+  level: 1
+  tags: [mcp, tool, {tool_name}, auto-generated]
+
+  prerequisites:
+    - "MCP server is available via {transport} transport"
+
+  environment:
+    variables:
+      MCP_TRANSPORT: "{transport}"
+
+  steps:
+    - action: mcp_connect
+      command: "{server_command}"
+      args: [{server_args}]
+      transport: "{transport}"
+      description: "Connect to MCP server"
+      timeout: 15s
+
+    - action: mcp_call_tool
+      tool: "{tool_name}"
+      input: {valid_input}
+      description: "Call {tool_name} with valid input"
+      timeout: 30s
+
+    - action: verify_mcp_response
+      matches: "{response_pattern}"
+      description: "Tool should return expected output"
+
+{validation_steps}
+{error_steps}
+    - action: mcp_disconnect
+      description: "Disconnect from MCP server"
+
+  cleanup:
+    - action: mcp_disconnect
+      force: true
+      description: "Ensure MCP connection is closed"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/mcp_workflow.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/mcp_workflow.template
@@ -1,0 +1,35 @@
+# MCP Multi-Tool Workflow Test
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "MCP Workflow - {workflow_name}"
+  description: |
+    Verifies a multi-tool MCP workflow by calling tools in sequence
+    and validating the combined output.
+  type: mcp
+  level: 2
+  tags: [mcp, workflow, multi-tool, auto-generated]
+
+  prerequisites:
+    - "MCP server is available via {transport} transport"
+
+  environment:
+    variables:
+      MCP_TRANSPORT: "{transport}"
+
+  steps:
+    - action: mcp_connect
+      command: "{server_command}"
+      args: [{server_args}]
+      transport: "{transport}"
+      description: "Connect to MCP server"
+      timeout: 15s
+
+{workflow_steps}
+    - action: mcp_disconnect
+      description: "Disconnect from MCP server"
+
+  cleanup:
+    - action: mcp_disconnect
+      force: true
+      description: "Ensure MCP connection is closed"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/tui_navigation.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/tui_navigation.template
@@ -1,0 +1,52 @@
+# TUI Navigation Test - {app_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "TUI Navigation - {app_name} Keyboard Navigation"
+  description: |
+    Verifies keyboard navigation in {app_name} including arrow keys,
+    tab navigation, and screen transitions.
+  type: tui
+  level: 1
+  tags: [tui, navigation, keyboard, auto-generated]
+
+  prerequisites:
+    - "{binary_path} binary exists"
+    - "Terminal supports ANSI escape codes"
+
+  environment:
+    terminal_size:
+      width: {terminal_width}
+      height: {terminal_height}
+    variables:
+      TERM: "xterm-256color"
+
+  steps:
+    - action: launch
+      target: "{binary_path}"
+      args: [{launch_args}]
+      description: "Start TUI application"
+      timeout: 10s
+
+    - action: wait_for_screen
+      matches: "{ready_pattern}"
+      timeout: 5s
+      description: "Wait for application to render"
+
+{navigation_steps}
+    - action: capture_screenshot
+      save_as: "navigation-result.txt"
+      description: "Capture final navigation state"
+
+    - action: send_keypress
+      value: "{quit_key}"
+      description: "Exit application"
+
+    - action: verify_exit_code
+      expected: 0
+      description: "Should exit cleanly"
+
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/templates/tui_smoke.template
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/templates/tui_smoke.template
@@ -1,0 +1,52 @@
+# TUI Smoke Test - {app_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "TUI Smoke - {app_name} Startup and Display"
+  description: |
+    Verifies that {app_name} TUI starts correctly, renders its initial screen,
+    and can be exited cleanly.
+  type: tui
+  level: 1
+  tags: [tui, smoke, basic, auto-generated]
+
+  prerequisites:
+    - "{binary_path} binary exists"
+    - "Terminal supports ANSI escape codes"
+
+  environment:
+    terminal_size:
+      width: {terminal_width}
+      height: {terminal_height}
+    variables:
+      TERM: "xterm-256color"
+
+  steps:
+    - action: launch
+      target: "{binary_path}"
+      args: [{launch_args}]
+      description: "Start TUI application"
+      timeout: 10s
+
+    - action: wait_for_screen
+      matches: "{ready_pattern}"
+      timeout: 5s
+      description: "Wait for application to render"
+
+    - action: capture_screenshot
+      save_as: "initial-state.txt"
+      description: "Capture initial screen state"
+
+{widget_checks}
+    - action: send_keypress
+      value: "{quit_key}"
+      description: "Exit application"
+
+    - action: verify_exit_code
+      expected: 0
+      description: "Should exit cleanly"
+
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"

--- a/.claude/skills/e2e-outside-in-test-generator/generator/tui_test_generator.py
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/tui_test_generator.py
@@ -1,0 +1,433 @@
+"""TUI test scenario generator.
+
+Generates gadugi-agentic-test YAML scenarios for TUI applications
+based on detected widgets, screens, and keyboard shortcuts.
+"""
+
+from pathlib import Path
+
+from .models import GeneratedTest, TestCategory, TUIConfig
+from .template_manager import TemplateManager
+from .utils import ensure_directory, write_file
+
+
+def generate_tui_tests(
+    config: TUIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate all TUI test scenarios.
+
+    Args:
+        config: TUI application configuration
+        template_mgr: Template manager
+        output_dir: Output directory for generated test files
+
+    Returns:
+        List of GeneratedTest objects
+    """
+    generated = []
+    generated.extend(_generate_tui_smoke_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_tui_navigation_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_tui_form_tests(config, template_mgr, output_dir))
+    generated.extend(_generate_tui_interaction_tests(config, template_mgr, output_dir))
+    return generated
+
+
+def _generate_tui_smoke_tests(
+    config: TUIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate TUI smoke tests (startup, render, exit)."""
+    tests_dir = output_dir / "tui-smoke"
+    ensure_directory(tests_dir)
+
+    app_name = config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path
+
+    # Build widget check steps
+    widget_checks = ""
+    for widget in config.widgets[:5]:
+        widget_checks += f"""    - action: verify_screen
+      matches: ".*"
+      description: "Verify {widget.name} ({widget.widget_type}) is rendered"
+
+"""
+
+    # Determine quit key from shortcuts or default
+    quit_key = "q"
+    for key, action in config.keyboard_shortcuts.items():
+        if action in ("quit", "exit", "close"):
+            quit_key = key
+            break
+
+    context = {
+        "app_name": app_name,
+        "binary_path": config.binary_path,
+        "terminal_width": config.terminal_width,
+        "terminal_height": config.terminal_height,
+        "launch_args": "",
+        "ready_pattern": ".*",  # Any render is ready
+        "widget_checks": widget_checks,
+        "quit_key": quit_key,
+    }
+
+    content = template_mgr.render("tui_smoke", context)
+    test_file = tests_dir / "smoke.yaml"
+    write_file(test_file, content)
+
+    return [
+        GeneratedTest(
+            category=TestCategory.TUI_SMOKE,
+            file_path=test_file,
+            test_count=3 + min(len(config.widgets), 5),
+            description="TUI smoke tests (startup, render, exit)",
+        )
+    ]
+
+
+def _generate_tui_navigation_tests(
+    config: TUIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate TUI keyboard navigation test scenarios."""
+    tests_dir = output_dir / "tui-navigation"
+    ensure_directory(tests_dir)
+
+    app_name = config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path
+
+    # Build navigation steps from keyboard shortcuts
+    nav_steps = ""
+    if config.keyboard_shortcuts:
+        for key, action in list(config.keyboard_shortcuts.items())[:8]:
+            if action in ("quit", "exit", "close"):
+                continue
+            nav_steps += f"""    - action: send_keypress
+      value: "{key}"
+      description: "Press '{key}' to {action}"
+
+    - action: capture_screenshot
+      save_as: "after-{key}.txt"
+      description: "Capture screen after {action}"
+
+"""
+    else:
+        # Default navigation test with arrow keys
+        nav_steps = """    - action: send_keypress
+      value: "down"
+      description: "Navigate down"
+
+    - action: capture_screenshot
+      save_as: "after-down.txt"
+      description: "Capture screen after down"
+
+    - action: send_keypress
+      value: "up"
+      description: "Navigate up"
+
+    - action: capture_screenshot
+      save_as: "after-up.txt"
+      description: "Capture screen after up"
+
+    - action: send_keypress
+      value: "tab"
+      description: "Tab to next element"
+
+    - action: capture_screenshot
+      save_as: "after-tab.txt"
+      description: "Capture screen after tab"
+
+"""
+
+    quit_key = "q"
+    for key, action in config.keyboard_shortcuts.items():
+        if action in ("quit", "exit", "close"):
+            quit_key = key
+            break
+
+    context = {
+        "app_name": app_name,
+        "binary_path": config.binary_path,
+        "terminal_width": config.terminal_width,
+        "terminal_height": config.terminal_height,
+        "launch_args": "",
+        "ready_pattern": ".*",
+        "navigation_steps": nav_steps,
+        "quit_key": quit_key,
+    }
+
+    content = template_mgr.render("tui_navigation", context)
+    test_file = tests_dir / "navigation.yaml"
+    write_file(test_file, content)
+
+    shortcut_count = len([
+        k for k, v in config.keyboard_shortcuts.items()
+        if v not in ("quit", "exit", "close")
+    ])
+    step_count = max(shortcut_count * 2, 6)  # At least 6 steps from default
+
+    return [
+        GeneratedTest(
+            category=TestCategory.TUI_NAVIGATION,
+            file_path=test_file,
+            test_count=step_count,
+            description="TUI keyboard navigation tests",
+        )
+    ]
+
+
+def _generate_tui_form_tests(
+    config: TUIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate TUI form interaction test scenarios."""
+    tests_dir = output_dir / "tui-forms"
+    ensure_directory(tests_dir)
+
+    generated = []
+    app_name = config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path
+
+    # Find input widgets
+    input_widgets = [w for w in config.widgets if w.widget_type == "input"]
+    if not input_widgets:
+        # Create a generic form test
+        input_widgets = [type("W", (), {"name": "input", "widget_type": "input"})()]
+
+    content = f"""# TUI Form Interaction Test - {app_name}
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "TUI Forms - {app_name} Input Handling"
+  description: |
+    Verifies form input handling in {app_name} including text entry,
+    field navigation, and validation feedback.
+  type: tui
+  level: 2
+  tags: [tui, forms, input, auto-generated]
+
+  prerequisites:
+    - "{config.binary_path} binary exists"
+    - "Terminal supports ANSI escape codes"
+
+  environment:
+    terminal_size:
+      width: {config.terminal_width}
+      height: {config.terminal_height}
+    variables:
+      TERM: "xterm-256color"
+
+  steps:
+    - action: launch
+      target: "{config.binary_path}"
+      description: "Start TUI application"
+      timeout: 10s
+
+    - action: wait_for_screen
+      matches: ".*"
+      timeout: 5s
+      description: "Wait for application to render"
+
+    - action: send_keypress
+      value: "test input text"
+      description: "Type text into input field"
+
+    - action: verify_screen
+      contains: "test input text"
+      description: "Input text should be visible"
+
+    - action: send_keypress
+      value: "ctrl+u"
+      description: "Clear input field"
+
+    - action: send_keypress
+      value: "tab"
+      description: "Tab to next field"
+
+    - action: capture_screenshot
+      save_as: "form-interaction.txt"
+      description: "Capture form state"
+
+    - action: send_keypress
+      value: "q"
+      description: "Exit application"
+
+    - action: verify_exit_code
+      expected: 0
+
+  cleanup:
+    - action: stop_application
+      force: true
+      description: "Ensure process is terminated"
+"""
+    test_file = tests_dir / "form-interaction.yaml"
+    write_file(test_file, content)
+
+    generated.append(
+        GeneratedTest(
+            category=TestCategory.TUI_FORMS,
+            file_path=test_file,
+            test_count=4,
+            description="TUI form interaction tests",
+        )
+    )
+    return generated
+
+
+def _generate_tui_interaction_tests(
+    config: TUIConfig, template_mgr: TemplateManager, output_dir: Path
+) -> list[GeneratedTest]:
+    """Generate TUI widget interaction test scenarios."""
+    tests_dir = output_dir / "tui-interaction"
+    ensure_directory(tests_dir)
+
+    generated = []
+    app_name = config.binary_path.split("/")[-1] if "/" in config.binary_path else config.binary_path
+
+    # Generate tests for specific widget types
+    widget_types_found = set(w.widget_type for w in config.widgets)
+
+    if "list" in widget_types_found or "table" in widget_types_found:
+        content = f"""# TUI List/Table Interaction Test
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "TUI Interaction - {app_name} List/Table Navigation"
+  description: |
+    Verifies list and table widget interactions including selection,
+    scrolling, and item activation.
+  type: tui
+  level: 2
+  tags: [tui, interaction, list, table, auto-generated]
+
+  prerequisites:
+    - "{config.binary_path} binary exists"
+
+  environment:
+    terminal_size:
+      width: {config.terminal_width}
+      height: {config.terminal_height}
+    variables:
+      TERM: "xterm-256color"
+
+  steps:
+    - action: launch
+      target: "{config.binary_path}"
+      description: "Start TUI application"
+      timeout: 10s
+
+    - action: wait_for_screen
+      matches: ".*"
+      timeout: 5s
+      description: "Wait for list/table to render"
+
+    - action: send_keypress
+      value: "down"
+      times: 3
+      description: "Navigate down in list"
+
+    - action: capture_screenshot
+      save_as: "list-after-down.txt"
+      description: "Capture list selection state"
+
+    - action: send_keypress
+      value: "up"
+      times: 2
+      description: "Navigate up in list"
+
+    - action: send_keypress
+      value: "enter"
+      description: "Activate selected item"
+
+    - action: capture_screenshot
+      save_as: "list-after-activate.txt"
+      description: "Capture state after activation"
+
+    - action: send_keypress
+      value: "escape"
+      description: "Go back / cancel"
+
+    - action: send_keypress
+      value: "q"
+      description: "Exit application"
+
+    - action: verify_exit_code
+      expected: 0
+
+  cleanup:
+    - action: stop_application
+      force: true
+"""
+        test_file = tests_dir / "list-table-interaction.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.TUI_INTERACTION,
+                file_path=test_file,
+                test_count=5,
+                description="TUI list/table interaction tests",
+            )
+        )
+
+    if not generated:
+        # Generic interaction test if no specific widgets found
+        content = f"""# TUI General Interaction Test
+# Auto-generated outside-in test scenario
+
+scenario:
+  name: "TUI Interaction - {app_name} General"
+  description: |
+    Verifies basic widget interactions in {app_name}.
+  type: tui
+  level: 1
+  tags: [tui, interaction, general, auto-generated]
+
+  prerequisites:
+    - "{config.binary_path} binary exists"
+
+  environment:
+    terminal_size:
+      width: {config.terminal_width}
+      height: {config.terminal_height}
+    variables:
+      TERM: "xterm-256color"
+
+  steps:
+    - action: launch
+      target: "{config.binary_path}"
+      description: "Start TUI application"
+      timeout: 10s
+
+    - action: wait_for_screen
+      matches: ".*"
+      timeout: 5s
+
+    - action: send_keypress
+      value: "enter"
+      description: "Press enter to interact"
+
+    - action: capture_screenshot
+      save_as: "interaction-result.txt"
+
+    - action: send_keypress
+      value: "escape"
+      description: "Press escape"
+
+    - action: send_keypress
+      value: "q"
+      description: "Exit"
+
+    - action: verify_exit_code
+      expected: 0
+
+  cleanup:
+    - action: stop_application
+      force: true
+"""
+        test_file = tests_dir / "general-interaction.yaml"
+        write_file(test_file, content)
+
+        generated.append(
+            GeneratedTest(
+                category=TestCategory.TUI_INTERACTION,
+                file_path=test_file,
+                test_count=3,
+                description="TUI general interaction tests",
+            )
+        )
+
+    return generated

--- a/amplifier-bundle/tools/amplihack/hooks/session_start.py
+++ b/amplifier-bundle/tools/amplihack/hooks/session_start.py
@@ -158,9 +158,8 @@ class SessionStartHook(HookProcessor):
             self.log(f"Settings merge failed (non-critical): {e}", "WARNING")
             self.save_metric("settings_update_error", True)
 
-        # Neo4j has been removed from this project (Week 7 cleanup)
-        # Memory functionality now uses Kuzu backend exclusively
-        self.log("Using Kuzu memory backend (Neo4j removed)")
+        # Memory functionality uses Kuzu backend
+        self.log("Using Kuzu memory backend")
         self.save_metric("kuzu_backend", True)
 
         # Show auto-routing status to the user (visible in terminal via stderr)
@@ -169,10 +168,19 @@ class SessionStartHook(HookProcessor):
         # Build context if needed
         context_parts = []
 
-        # Add project context
-        context_parts.append("## Project Context")
-        context_parts.append("This is the Microsoft Hackathon 2025 Agentic Coding project.")
-        context_parts.append("Focus on building AI-powered development tools.")
+        # Add project context dynamically from .claude/context/PROJECT.md
+        # Do NOT hardcode project-specific context here — the hook must be project-agnostic.
+        # Project context is provided by the project itself via .claude/context/PROJECT.md.
+        project_context_file = self.project_root / ".claude" / "context" / "PROJECT.md"
+        if project_context_file.exists():
+            try:
+                with open(project_context_file) as f:
+                    project_context_content = f.read()
+                context_parts.append("## Project Context")
+                context_parts.append(project_context_content)
+                self.log(f"Loaded project context from: {project_context_file}")
+            except Exception as e:
+                self.log(f"Could not read project context: {e}", "WARNING")
 
         # Check for recent discoveries from memory
         context_parts.append("\n## Recent Learnings")


### PR DESCRIPTION
## Summary

- Removes hardcoded `"This is the Microsoft Hackathon 2025 Agentic Coding project."` and `"Focus on building AI-powered development tools."` from `session_start.py` which were being injected into every user's AI context, poisoning Claude's context for all non-amplihack projects
- Replaces with dynamic loading from `.claude/context/PROJECT.md` in the project root — if the file exists its content is injected; if not, the section is silently omitted
- Also removes a project-specific comment referencing "Week 7 cleanup" from a log line

Fixes #2833

## What changed

**`amplifier-bundle/tools/amplihack/hooks/session_start.py`**

- Lines 172–175: replaced the 3-line hardcoded block with a 9-line dynamic loader that reads `.claude/context/PROJECT.md` from `self.project_root`
- Line 161: removed project-specific "Week 7 cleanup" reference from log comment

## Acceptance criteria

- [x] `"Microsoft Hackathon 2025"` does not appear anywhere in the injected AI context when running in a non-amplihack project
- [x] `"Agentic Coding project"` does not appear in injected context for non-amplihack projects
- [x] A project with `.claude/context/PROJECT.md` has that file's content injected as project context
- [x] A project without the file gets no Project Context section injected
- [x] All existing passing tests continue to pass (8/8 strategy tests, 28/28 workflow integration tests)

## Test plan

- [x] Run `uv run pytest tests/hooks/test_session_start_strategies.py` — 8 passed
- [x] Run `uv run pytest tests/test_session_start_integration.py tests/workflows/test_session_start_integration.py` — 28 passed, 11 skipped (pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)