### PR TITLE
fix: agent resolver now handles 3-part refs (namespace:category:name)

### DIFF
--- a/src/amplihack/recipes/agent_resolver.py
+++ b/src/amplihack/recipes/agent_resolver.py
@@ -1,7 +1,7 @@
 """Agent resolver for mapping agent references to system prompt content.
 
-Resolves references like ``amplihack:builder`` to the markdown content of the
-corresponding agent definition file.
+Resolves references like ``amplihack:builder`` or ``amplihack:core:architect``
+to the markdown content of the corresponding agent definition file.
 """
 
 from __future__ import annotations
@@ -46,7 +46,9 @@ class AgentResolver:
         """Resolve an agent reference to its system prompt content.
 
         Args:
-            agent_ref: Reference in ``namespace:name`` format (e.g. ``amplihack:builder``).
+            agent_ref: Reference in ``namespace:name`` or
+                ``namespace:category:name`` format
+                (e.g. ``amplihack:builder`` or ``amplihack:core:architect``).
 
         Returns:
             The full text content of the agent's markdown definition file.
@@ -60,29 +62,41 @@ class AgentResolver:
                 f"Agent reference must be in 'namespace:name' format, got: '{agent_ref}'"
             )
 
-        namespace, name = agent_ref.split(":", 1)
+        parts = agent_ref.split(":")
 
-        # Validate that namespace and name are simple identifiers to prevent
-        # path traversal attacks (e.g. "../../etc:passwd" or "ns:../../secret").
-        if not _SAFE_NAME_RE.match(namespace):
+        # Validate every segment to prevent path traversal
+        for part in parts:
+            if not _SAFE_NAME_RE.match(part):
+                raise ValueError(
+                    f"Invalid agent reference segment '{part}': must contain only "
+                    "alphanumeric characters, hyphens, and underscores"
+                )
+
+        if len(parts) == 3:
+            # namespace:category:name (e.g. amplihack:core:architect)
+            namespace, category, name = parts
+        elif len(parts) == 2:
+            # namespace:name (e.g. amplihack:builder)
+            namespace, name = parts
+            category = None
+        else:
             raise ValueError(
-                f"Invalid agent namespace '{namespace}': must contain only "
-                "alphanumeric characters, hyphens, and underscores"
-            )
-        if not _SAFE_NAME_RE.match(name):
-            raise ValueError(
-                f"Invalid agent name '{name}': must contain only "
-                "alphanumeric characters, hyphens, and underscores"
+                f"Agent reference must be 'namespace:name' or "
+                f"'namespace:category:name', got: '{agent_ref}'"
             )
 
-        # Candidate relative paths to try within each search directory
-        candidates = [
+        # Build candidate paths. When category is explicit, try it first.
+        candidates: list[Path] = []
+        if category:
+            candidates.append(Path(namespace) / category / f"{name}.md")
+            candidates.append(Path(category) / f"{name}.md")
+        candidates.extend([
             Path(namespace) / "core" / f"{name}.md",
             Path(namespace) / "specialized" / f"{name}.md",
             Path("core") / f"{name}.md",
             Path("specialized") / f"{name}.md",
             Path(f"{name}.md"),
-        ]
+        ])
 
         searched: list[str] = []
         for base in self._search_paths:

--- a/tests/unit/recipes/test_agent_resolver.py
+++ b/tests/unit/recipes/test_agent_resolver.py
@@ -1,10 +1,12 @@
 """Tests for AgentResolver.
 
 These tests verify that AgentResolver can:
-- Resolve core agent names (e.g. 'amplihack:builder') to system prompts
+- Resolve 2-part agent names (e.g. 'amplihack:builder') to system prompts
+- Resolve 3-part agent names (e.g. 'amplihack:core:architect') to system prompts
 - Resolve specialized agent names (e.g. 'amplihack:security') to system prompts
 - Raise AgentNotFoundError for unknown agent references
 - Raise an error for invalid agent name format (missing namespace colon)
+- Block path traversal in agent references
 """
 
 from __future__ import annotations
@@ -38,6 +40,34 @@ class TestResolveSpecializedAgent:
         assert len(prompt) > 0
 
 
+class TestResolveThreePartRef:
+    """Test resolution of 3-part agent references (namespace:category:name)."""
+
+    def test_resolve_core_architect(self) -> None:
+        """'amplihack:core:architect' resolves to a non-empty system prompt."""
+        resolver = AgentResolver()
+        prompt = resolver.resolve("amplihack:core:architect")
+
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    def test_resolve_core_reviewer(self) -> None:
+        """'amplihack:core:reviewer' resolves to a non-empty system prompt."""
+        resolver = AgentResolver()
+        prompt = resolver.resolve("amplihack:core:reviewer")
+
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    def test_resolve_specialized_security(self) -> None:
+        """'amplihack:specialized:security' resolves to a non-empty system prompt."""
+        resolver = AgentResolver()
+        prompt = resolver.resolve("amplihack:specialized:security")
+
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+
 class TestResolveErrors:
     """Test error handling for invalid agent references."""
 
@@ -54,3 +84,17 @@ class TestResolveErrors:
 
         with pytest.raises((ValueError, AgentNotFoundError)):
             resolver.resolve("nonamespace")
+
+    def test_path_traversal_blocked(self) -> None:
+        """Path traversal via '..' in agent ref segments is rejected."""
+        resolver = AgentResolver()
+
+        with pytest.raises(ValueError, match="Invalid agent reference segment"):
+            resolver.resolve("amplihack:../etc:passwd")
+
+    def test_four_part_ref_rejected(self) -> None:
+        """4-part refs like 'a:b:c:d' are rejected."""
+        resolver = AgentResolver()
+
+        with pytest.raises(ValueError, match="namespace:name"):
+            resolver.resolve("a:b:c:d")


### PR DESCRIPTION
## Summary
- Agent resolver now correctly parses 3-part refs like `amplihack:core:architect`
- Previously, `split(":", 1)` left `core:architect` as the name, failing the safety regex
- All recipe steps using `amplihack:core:*` or `amplihack:specialized:*` silently lost their agent system prompts

## Root cause
`agent_ref.split(":", 1)` on `amplihack:core:architect` produces `name="core:architect"`, which contains a colon and fails `_SAFE_NAME_RE`. The error was caught and logged as a warning, so steps still ran but without specialized agent context.

## Changes
- `agent_resolver.py`: Split on all colons, handle 2-part and 3-part formats, validate each segment, reject 4+ parts
- `test_agent_resolver.py`: Added 5 new tests (3-part core, 3-part reviewer, 3-part specialized, path traversal, 4-part rejection)

## Test plan
- [x] 9/9 tests pass (`uv run pytest tests/unit/recipes/test_agent_resolver.py`)
- [x] Manual verification: `amplihack:core:architect` -> 6528 chars, `amplihack:core:reviewer` -> 8602 chars
- [x] Security: path traversal still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)