### PR TITLE
docs: fix README/CONTRIBUTING gaps (sessions, install order, /dev, uv sync)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for your interest in contributing to amplihack! This guide will help y
 git clone https://github.com/<your-username>/amplihack.git
 cd amplihack
 
-# 2. Install dependencies with uv
+# 2. Install all dependencies (dev + runtime) into a local .venv
 uv sync
 
 # 3. Install pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Detailed setup:
 
 ### Installation
 
+Install the prerequisites above first, then choose an option below.
+
 **Option 1: Zero-Install** (try before you commit)
 
 ```bash
@@ -84,6 +86,8 @@ uvx --from git+https://github.com/rysweet/amplihack amplihack amplifier
 # Launch with GitHub Copilot
 uvx --from git+https://github.com/rysweet/amplihack amplihack copilot
 ```
+
+This launches an interactive Claude Code session enhanced with amplihack's workflows, specialized agents, and development tools. You'll get a CLI prompt where you can describe tasks and the framework orchestrates their execution.
 
 **Option 2: Global Install** (for daily use)
 
@@ -133,8 +137,7 @@ cd /path/to/my/project
 Add user authentication with OAuth2 support
 ```
 
-The `/dev` command automatically classifies your task, detects parallel
-workstreams, and orchestrates execution.
+The `/dev` command is amplihack's primary entry point for development tasks. It automatically classifies your task, detects parallel workstreams, and orchestrates execution through the 23-step default workflow.
 
 ### Developer Quick Example
 

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack"
-version = "0.5.106"
+version = "0.5.109"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Small targeted edits to fill documentation gaps identified by new-user review:

- **#2777**: Explain what the interactive session does after install
- **#2778**: Clarify `uv sync` installs all deps into local `.venv`
- **#2780**: Add "install prerequisites first" before install options
- **#2781**: Expand first `/dev` mention with what it does and the 23-step workflow

## Also closed (no changes needed)
- **#2782**: Already addressed — cost info exists in Configuration section
- **#2783**: Closed per owner — workflow section is intentional
- **#2784**: Closed — `amplihack` command already checks prerequisites post-install

## Test plan
- [x] All edits are additive (no removed content)
- [x] No broken links introduced

Closes #2777, closes #2778, closes #2780, closes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)