### PR TITLE
fix: improve ADO skill auto-activation with keyword-rich descriptions

### DIFF
--- a/.claude/skills/azure-devops-cli/SKILL.md
+++ b/.claude/skills/azure-devops-cli/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: azure-devops-cli
 description: Expert guidance for Azure DevOps CLI (az devops) - automation, pipelines, repos, boards, and artifacts management. Use when working with Azure DevOps, managing pipelines, creating work items, or when user mentions ADO, builds, releases, or Azure repos.
+auto_activate_keywords:
+  - az devops
+  - azure devops cli
+  - az pipelines
+  - az repos
+  - az boards
+  - az artifacts
 ---
 
 # Azure DevOps CLI Skill

--- a/.claude/skills/azure-devops/SKILL.md
+++ b/.claude/skills/azure-devops/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: azure-devops
-description: Complete Azure DevOps automation - boards, repos, pipelines, artifacts
+description: |
+  Complete Azure DevOps (ADO) automation — work items, boards, sprints, repos, pull requests,
+  pipelines, builds, artifacts. Use when user mentions ADO, work items, user stories, bugs,
+  sprints, builds, releases, or Azure DevOps URLs.
 version: 2.0.0
 type: skill
 auto_activate_keywords:

--- a/amplifier-bundle/skills/azure-devops/SKILL.md
+++ b/amplifier-bundle/skills/azure-devops/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: azure-devops
-description: Complete Azure DevOps automation - boards, repos, pipelines, artifacts
+description: |
+  Complete Azure DevOps (ADO) automation — work items, boards, sprints, repos, pull requests,
+  pipelines, builds, artifacts. Use when user mentions ADO, work items, user stories, bugs,
+  sprints, builds, releases, or Azure DevOps URLs.
 version: 2.0.0
 type: skill
 auto_activate_keywords:


### PR DESCRIPTION
## Summary
- `azure-devops` skill: expanded description with natural-language keywords (ADO, work items, user stories, bugs, sprints, builds, releases)
- `azure-devops-cli` skill: added `auto_activate_keywords` (az devops, az pipelines, az repos, etc.)

Closes #2850

🤖 Generated with [Claude Code](https://claude.com/claude-code)