### PR TITLE
fix: remove redundant single quotes from quality-audit-cycle bash templates

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: a2
+## Project: amplihack
 
 ## Overview
 

--- a/amplifier-bundle/recipes/quality-audit-cycle.yaml
+++ b/amplifier-bundle/recipes/quality-audit-cycle.yaml
@@ -391,9 +391,9 @@ steps:
     command: |
       # Use environment variables to pass JSON safely — avoids bash interpreting
       # JSON double-quotes as string terminators inside python3 -c "..." (#2872).
-      export VALIDATED='{{validated_findings}}'
-      export FIX_RESULTS='{{fix_results}}'
-      export FIX_ALL='{{fix_all_per_cycle}}'
+      export VALIDATED={{validated_findings}}
+      export FIX_RESULTS={{fix_results}}
+      export FIX_ALL={{fix_all_per_cycle}}
 
       python3 - <<'PYEOF'
       import json, sys, os
@@ -449,9 +449,9 @@ steps:
   - id: "accumulate-history"
     type: "bash"
     command: |
-      CYCLE='{{cycle_number}}'
-      CURRENT_HISTORY='{{cycle_history}}'
-      FINDINGS='{{validated_findings}}'
+      CYCLE={{cycle_number}}
+      CURRENT_HISTORY={{cycle_history}}
+      FINDINGS={{validated_findings}}
 
       if [ -z "$CURRENT_HISTORY" ]; then
         echo "--- Cycle $CYCLE findings ---"
@@ -471,11 +471,11 @@ steps:
   - id: "recurse-decision"
     type: "bash"
     command: |
-      CYCLE='{{cycle_number}}'
-      MIN_CYCLES='{{min_cycles}}'
-      MAX_CYCLES='{{max_cycles}}'
-      VALIDATED='{{validated_findings}}'
-      FIX_VERIFY='{{fix_verification}}'
+      CYCLE={{cycle_number}}
+      MIN_CYCLES={{min_cycles}}
+      MAX_CYCLES={{max_cycles}}
+      VALIDATED={{validated_findings}}
+      FIX_VERIFY={{fix_verification}}
 
       echo "Cycle $CYCLE complete."
 

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack"
-version = "0.5.109"
+version = "0.5.111"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- `render_shell()` already applies `shlex.quote()` to template variables
- The manual single quotes in YAML (`'{{var}}'`) caused double-quoting: `''{"json":"data"}'` → bash interprets JSON as commands
- Removed single quotes from all bash step template variable assignments in verify-fixes, update-history, and decide-continue steps

## Root cause
`render_shell()` wraps values in `shlex.quote()`, producing `'value'`. The template `export X='{{var}}'` becomes `export X=''value''` — nested single quotes break bash.

## Supersedes
PR #2886 (same bug, insufficient fix — only addressed the python3 quoting, not the export lines)

Closes #2845 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)