### PR TITLE
fix: seed copilot config in rust trial

### DIFF
--- a/src/amplihack/rust_trial.py
+++ b/src/amplihack/rust_trial.py
@@ -222,6 +222,31 @@ def build_trial_env(trial_home: Path) -> dict[str, str]:
     return env
 
 
+def _ensure_trial_copilot_config(
+    trial_home: Path, source_home: Path | None = None
+) -> Path:
+    """Ensure the isolated trial home has a visible Copilot config file.
+
+    Copilot CLI interactive startup can hang with no visible terminal output when
+    ~/.copilot/config.json is missing in a brand-new HOME. Seed the trial home
+    from the user's existing config when available; otherwise create a minimal
+    empty config.
+    """
+    copilot_home = trial_home.expanduser().resolve() / ".copilot"
+    config_path = copilot_home / "config.json"
+    if config_path.exists():
+        return config_path
+
+    copilot_home.mkdir(parents=True, exist_ok=True)
+    host_home = Path.home() if source_home is None else source_home.expanduser().resolve()
+    source_config = host_home / ".copilot" / "config.json"
+    if source_config.is_file():
+        shutil.copy2(source_config, config_path)
+    else:
+        config_path.write_text("{}\n", encoding="utf-8")
+    return config_path
+
+
 def ensure_trial_dependencies(rust_args: Sequence[str], trial_home: Path, env: dict[str, str]) -> None:
     """Install subcommand-specific dependencies inside the isolated trial home."""
     if not rust_args or rust_args[0] != "copilot":
@@ -229,6 +254,7 @@ def ensure_trial_dependencies(rust_args: Sequence[str], trial_home: Path, env: d
 
     from .launcher.copilot import check_copilot, install_copilot
 
+    _ensure_trial_copilot_config(trial_home)
     if check_copilot(env=env, home=trial_home):
         return
     if not install_copilot(env=env, home=trial_home):

--- a/tests/test_rust_trial.py
+++ b/tests/test_rust_trial.py
@@ -9,6 +9,7 @@ from amplihack.rust_trial import (
     RUST_RELEASES_API,
     TRIAL_BINARY_ENV,
     TRIAL_HOME_ENV,
+    _ensure_trial_copilot_config,
     _expected_release_asset_name,
     _target_triple,
     build_trial_env,
@@ -129,6 +130,29 @@ def test_ensure_trial_dependencies_skips_non_copilot(tmp_path, monkeypatch):
     assert called == []
 
 
+def test_ensure_trial_copilot_config_creates_empty_config(tmp_path):
+    config_path = _ensure_trial_copilot_config(
+        trial_home=tmp_path / "trial-home",
+        source_home=tmp_path / "host-home",
+    )
+
+    assert config_path.read_text(encoding="utf-8") == "{}\n"
+
+
+def test_ensure_trial_copilot_config_copies_existing_host_config(tmp_path):
+    host_home = tmp_path / "host-home"
+    source_config = host_home / ".copilot" / "config.json"
+    source_config.parent.mkdir(parents=True, exist_ok=True)
+    source_config.write_text('{"installed_plugins":["amplihack"]}\n', encoding="utf-8")
+
+    config_path = _ensure_trial_copilot_config(
+        trial_home=tmp_path / "trial-home",
+        source_home=host_home,
+    )
+
+    assert config_path.read_text(encoding="utf-8") == '{"installed_plugins":["amplihack"]}\n'
+
+
 def test_ensure_trial_dependencies_installs_copilot_into_trial_home(tmp_path, monkeypatch):
     trial_home = tmp_path / "trial-home"
     env = build_trial_env(trial_home)
@@ -148,6 +172,7 @@ def test_ensure_trial_dependencies_installs_copilot_into_trial_home(tmp_path, mo
     assert captured["home"] == trial_home
     assert captured["env"] is env
     assert env["PATH"].split(":")[0] == str(trial_home / ".npm-global" / "bin")
+    assert (trial_home / ".copilot" / "config.json").is_file()
 
 
 def test_ensure_trial_dependencies_errors_when_copilot_install_fails(tmp_path, monkeypatch):


### PR DESCRIPTION
Summary:
- seed ~/.copilot/config.json inside a fresh rust-trial home before launching Copilot
- copy the user's existing config when available, otherwise create a minimal empty config
- add regression tests for config seeding in the rust trial helper

Testing:
- uv run ruff check src/amplihack/rust_trial.py tests/test_rust_trial.py
- ./.venv/bin/pytest tests/test_rust_trial.py -q
- smoke test: uvx --from <local branch> amplihack-rust-trial --trial-home <tmp> copilot with fixed rust binary override
