### PR TITLE
fix: prefer newest rust snapshot release

### DIFF
--- a/src/amplihack/rust_trial.py
+++ b/src/amplihack/rust_trial.py
@@ -11,6 +11,7 @@ import sys
 import tarfile
 import urllib.request
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 
 TRIAL_HOME_ENV = "AMPLIHACK_RUST_TRIAL_HOME"
@@ -126,8 +127,12 @@ def _select_release_asset(releases: object) -> tuple[str, str]:
     if not isinstance(releases, list):
         raise FileNotFoundError("GitHub release response was not a list")
 
-    for release in releases:
+    matches: list[tuple[tuple[datetime, datetime, int], str, str]] = []
+
+    for index, release in enumerate(releases):
         if not isinstance(release, dict):
+            continue
+        if release.get("draft") is True:
             continue
         tag_name = release.get("tag_name")
         assets = release.get("assets", [])
@@ -139,13 +144,37 @@ def _select_release_asset(releases: object) -> tuple[str, str]:
             if asset.get("name") == asset_name and isinstance(
                 asset.get("browser_download_url"), str
             ):
-                return tag_name, asset["browser_download_url"]
+                matches.append(
+                    (_release_sort_key(release, index), tag_name, asset["browser_download_url"])
+                )
+                break
+
+    if matches:
+        _sort_key, tag_name, asset_url = max(matches, key=lambda match: match[0])
+        return tag_name, asset_url
 
     raise FileNotFoundError(
         f"No published amplihack-rs release contains asset {asset_name}. "
         "Wait for the snapshot release workflow to publish binaries, or set "
         "AMPLIHACK_RUST_TRIAL_BINARY explicitly."
     )
+
+
+def _release_sort_key(release: dict[str, object], index: int) -> tuple[datetime, datetime, int]:
+    created_at = _parse_release_timestamp(release.get("created_at"))
+    published_at = _parse_release_timestamp(release.get("published_at"))
+    # Prefer the newest actual snapshot build first; later publish time only
+    # breaks ties for releases created at the same instant.
+    return created_at, published_at, -index
+
+
+def _parse_release_timestamp(value: object) -> datetime:
+    if not isinstance(value, str) or not value:
+        return datetime.min.replace(tzinfo=UTC)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
 
 
 def download_latest_release_binary(trial_home: Path) -> Path:

--- a/tests/test_rust_trial.py
+++ b/tests/test_rust_trial.py
@@ -11,6 +11,7 @@ from amplihack.rust_trial import (
     TRIAL_HOME_ENV,
     _ensure_trial_copilot_config,
     _expected_release_asset_name,
+    _select_release_asset,
     _target_triple,
     build_trial_env,
     download_latest_release_binary,
@@ -59,6 +60,104 @@ def test_target_triple_for_current_platform():
     }
     assert _expected_release_asset_name().startswith("amplihack-")
     assert _expected_release_asset_name().endswith(".tar.gz")
+
+
+def test_select_release_asset_prefers_newest_snapshot_creation_time():
+    asset_name = _expected_release_asset_name()
+    tag_name, asset_url = _select_release_asset(
+        [
+            {
+                "tag_name": "snapshot-republished-old",
+                "created_at": "2026-03-02T12:00:00Z",
+                "published_at": "2026-03-06T12:00:00Z",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.invalid/old.tar.gz",
+                    }
+                ],
+            },
+            {
+                "tag_name": "snapshot-newer-build",
+                "created_at": "2026-03-05T12:00:00Z",
+                "published_at": "2026-03-05T12:00:00Z",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.invalid/new.tar.gz",
+                    }
+                ],
+            },
+        ]
+    )
+
+    assert tag_name == "snapshot-newer-build"
+    assert asset_url == "https://example.invalid/new.tar.gz"
+
+
+def test_select_release_asset_uses_publish_time_when_creation_time_missing():
+    asset_name = _expected_release_asset_name()
+    tag_name, asset_url = _select_release_asset(
+        [
+            {
+                "tag_name": "snapshot-earlier-publish",
+                "published_at": "2026-03-05T12:00:00Z",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.invalid/earlier.tar.gz",
+                    }
+                ],
+            },
+            {
+                "tag_name": "snapshot-later-publish",
+                "published_at": "2026-03-06T12:00:00Z",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.invalid/later.tar.gz",
+                    }
+                ],
+            },
+        ]
+    )
+
+    assert tag_name == "snapshot-later-publish"
+    assert asset_url == "https://example.invalid/later.tar.gz"
+
+
+def test_select_release_asset_skips_draft_releases():
+    asset_name = _expected_release_asset_name()
+    tag_name, asset_url = _select_release_asset(
+        [
+            {
+                "tag_name": "snapshot-draft",
+                "draft": True,
+                "created_at": "2026-03-07T12:00:00Z",
+                "published_at": "2026-03-07T12:00:00Z",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.invalid/draft.tar.gz",
+                    }
+                ],
+            },
+            {
+                "tag_name": "snapshot-public",
+                "created_at": "2026-03-06T12:00:00Z",
+                "published_at": "2026-03-06T12:00:00Z",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.invalid/public.tar.gz",
+                    }
+                ],
+            },
+        ]
+    )
+
+    assert tag_name == "snapshot-public"
+    assert asset_url == "https://example.invalid/public.tar.gz"
 
 
 def test_download_latest_release_binary_extracts_asset(tmp_path, monkeypatch):


### PR DESCRIPTION
Summary:
- rank matching amplihack-rs releases by snapshot creation time instead of trusting API order or publish time
- skip draft releases and keep deterministic tie-breaking when timestamps are missing
- add regression coverage for republished older snapshots, missing creation times, and draft filtering

Testing:
- uv run ruff check src/amplihack/rust_trial.py tests/test_rust_trial.py
- ./.venv/bin/pytest tests/test_rust_trial.py -q
- uv run python -c 'from pathlib import Path; from amplihack.rust_trial import download_latest_release_binary; print(download_latest_release_binary(Path(/tmp/amplihack-rust-release-order-v3-download)))'
- code review: no material issues found
