### PR TITLE
fix: add timeout to Rust CLI delegation in run_update_command

### DIFF
--- a/src/amplihack/auto_update.py
+++ b/src/amplihack/auto_update.py
@@ -370,6 +370,9 @@ def _find_rust_cli() -> Path | None:
     return None
 
 
+_RUST_CLI_UPDATE_TIMEOUT = 300  # seconds; generous for slow downloads
+
+
 def run_update_command() -> int:
     """Handle explicit `amplihack update` invocations.
 
@@ -379,8 +382,20 @@ def run_update_command() -> int:
     rust_cli = _find_rust_cli()
     if rust_cli is not None:
         print(f"Delegating update to Rust CLI at {rust_cli}")
-        result = subprocess.run([str(rust_cli), "update"], check=False)
-        return result.returncode
+        try:
+            result = subprocess.run(
+                [str(rust_cli), "update"],
+                check=False,
+                timeout=_RUST_CLI_UPDATE_TIMEOUT,
+            )
+            return result.returncode
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "Rust CLI update timed out after %ds. Try running '%s update' directly.",
+                _RUST_CLI_UPDATE_TIMEOUT,
+                rust_cli,
+            )
+            return 1
 
     if _run_upgrade():
         print("Updated Python amplihack.")

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -664,9 +664,29 @@ class TestManualUpdateCommand:
             result = run_update_command()
 
         assert result == 0
-        mock_run.assert_called_once_with([str(rust_cli.resolve()), "update"], check=False)
+        mock_run.assert_called_once_with(
+            [str(rust_cli.resolve()), "update"],
+            check=False,
+            timeout=300,
+        )
         captured = capsys.readouterr()
         assert str(rust_cli.resolve()) in captured.out
+
+    @patch("amplihack.auto_update.subprocess.run")
+    def test_run_update_command_timeout_returns_error(self, mock_run, tmp_path, capsys):
+        cargo_bin = tmp_path / ".cargo" / "bin"
+        cargo_bin.mkdir(parents=True)
+        rust_cli = cargo_bin / "amplihack"
+        rust_cli.write_text("")
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["amplihack", "update"], timeout=300)
+
+        with (
+            patch("amplihack.auto_update.Path.home", return_value=tmp_path),
+            patch("amplihack.auto_update._current_cli_path", return_value=None),
+        ):
+            result = run_update_command()
+
+        assert result == 1
 
     def test_run_update_command_falls_back_to_python_upgrade(self, capsys):
         with (


### PR DESCRIPTION
## Summary

- `run_update_command()` called `subprocess.run()` without a timeout when delegating to the Rust CLI binary
- This could hang indefinitely if the Rust CLI stalls during a network operation or becomes unresponsive
- Added a 300-second timeout constant (`_RUST_CLI_UPDATE_TIMEOUT`) with a clear error message on expiry
- Added a test covering the timeout path

## Finding

Discovered during quality audit (issue #3036). The existing `_run_upgrade()` function correctly uses a `timeout` parameter, but the new `run_update_command()` function added in PR #3035 omitted it for the Rust CLI delegation path.

## Test plan

- [x] `uv run pytest tests/test_auto_update.py::TestManualUpdateCommand` - all 4 tests pass
- [x] `uv run pytest tests/test_auto_update.py tests/test_cli_claude_command_guard.py tests/integration/test_cli_platform.py` - all 74 tests pass

Closes #3036 (partial - addresses the missing timeout finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)