### PR TITLE
fix: remove all error suppression from gh-work-report skill

### DIFF
--- a/.claude/skills/gh-work-report/SKILL.md
+++ b/.claude/skills/gh-work-report/SKILL.md
@@ -103,7 +103,7 @@ gh search issues --author=@me --created=">YYYY-MM-DD" --limit 100 --json number,
 
 ```bash
 # For each active repo, check for releases
-gh api repos/{owner}/{repo}/releases --jq '.[].tag_name' 2>/dev/null | head -5
+gh api repos/{owner}/{repo}/releases --jq '.[].tag_name' | head -5
 ```
 
 ### Step 3: Combine and deduplicate
@@ -151,10 +151,21 @@ If yes, follow the infrastructure setup in `reference.md` § Infrastructure Setu
 ## Key Rules
 
 - **Never hardcode usernames** — always detect from `gh auth status`
+- **Never use fallbacks** — no silent defaults, no `2>/dev/null`, no hardcoded values. Errors must fail loud with descriptive messages.
+- **All charts must be code-generated** — every number in every chart and table must come from actual API data. Never fabricate or estimate chart data.
+- **4 query filters for complete PR coverage**: `created:>DATE` (new), `is:open` (all WIP), `merged:>DATE` (merged during window), `closed:>DATE` (closed during window). Deduplicate by URL.
+- **Clamp chart timelines** — Gantt and timeline charts must be scoped to the report window. Clamp start dates to `max(pr_date, window_start)`.
 - **Handle private repos gracefully** — note them but don't expose sensitive details unless the report itself is private
 - **Date math**: Use `date -d "$DAYS days ago" +%Y-%m-%d` (Linux) for the start date
 - **Rate limiting**: If `gh api` returns 403, wait and retry. Use `--paginate` for large result sets.
 - **Empty results are fine** — if an account has no activity, say so briefly and move on
+
+## Authentication & Automation
+
+- **Local (multi-account)**: Use `./run.sh [days]` which leverages `gh auth switch` across all locally authenticated accounts. This is the recommended approach for users with multiple accounts (e.g., public + EMU).
+- **GitHub Actions (single-account)**: Use the workflow templates with a PAT secret. A PAT is scoped to one identity and cannot cross accounts.
+- **Two-PAT approach**: For Actions across two accounts, use separate PAT secrets (`ACCOUNT1_PAT`, `ACCOUNT2_PAT`) with explicit `--header "authorization: token $PAT"` per API call.
+- **GitHub Pages is static only** — report generation must happen elsewhere (local script, Actions, gh-aw). Pages just serves the output.
 
 ## Reference Files
 

--- a/.claude/skills/gh-work-report/reference.md
+++ b/.claude/skills/gh-work-report/reference.md
@@ -138,7 +138,7 @@ xychart-beta
 - **XY charts**: Use for daily/weekly commit activity. Aggregate by day of week for short periods, by week for 30+ day periods.
 - **Flowcharts**: Use sparingly — only to illustrate architecture changes when a project had significant structural work.
 
-Keep chart data realistic — pull actual counts from the gathered data.
+Keep chart data realistic — pull actual counts from the gathered data. **Never fabricate chart values.** Every number must trace back to real API data. If you don't have data for a chart, omit the chart entirely rather than estimating.
 
 ## gh CLI Command Patterns
 

--- a/.claude/skills/gh-work-report/templates/monthly-report.yml
+++ b/.claude/skills/gh-work-report/templates/monthly-report.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Set up date range
         id: dates
         run: |
+          set -euo pipefail
           DAYS="${{ github.event.inputs.days || '30' }}"
           START_DATE=$(date -d "$DAYS days ago" +%Y-%m-%d)
           END_DATE=$(date +%Y-%m-%d)
@@ -46,6 +47,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPORT_TOKEN }}
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           mkdir -p /tmp/report-data
 
@@ -59,22 +61,31 @@ jobs:
                 }
               }
             }
-          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json 2>/dev/null || true
+          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json
 
           gh search prs --author=@me --created=">$START" --limit 500 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-created.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-created.json
+            > /tmp/report-data/prs-created.json
+
+          gh search prs --author=@me --state=open --limit 500 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-open.json
 
           gh search prs --author=@me --merged=">$START" --limit 500 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-merged.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-merged.json
+            > /tmp/report-data/prs-merged.json
+
+          gh search prs --author=@me --closed=">$START" --limit 500 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-closed.json
 
           gh search issues --author=@me --created=">$START" --limit 200 \
             --json number,title,repository,state,createdAt,url \
-            > /tmp/report-data/issues.json 2>/dev/null || echo '[]' > /tmp/report-data/issues.json
+            > /tmp/report-data/issues.json
 
       - name: Generate report
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           END="${{ steps.dates.outputs.end }}"
           DAYS="${{ steps.dates.outputs.days }}"
@@ -82,10 +93,10 @@ jobs:
           REPORT="docs/reports/$FILENAME"
           mkdir -p docs/reports
 
-          REPO_COUNT=$(cat /tmp/report-data/repos.json 2>/dev/null | wc -l || echo 0)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))" 2>/dev/null || echo 0)
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))" 2>/dev/null || echo 0)
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))" 2>/dev/null || echo 0)
+          REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
+          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
+          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
+          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -115,22 +126,20 @@ jobs:
               repo = pr.get('repository', {})
               repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
               print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT" 2>/dev/null || true
+          " >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json 2>/dev/null | python3 -c "
+          cat /tmp/report-data/repos.json | python3 -c "
           import json, sys
           for line in sys.stdin:
-              try:
-                  r = json.loads(line)
-                  desc = (r.get('description') or '—')[:60]
-                  print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-              except: pass
-          " >> "$REPORT" 2>/dev/null || true
+              r = json.loads(line)
+              desc = (r.get('description') or '—')[:60]
+              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
+          " >> "$REPORT"
 
           sed -i 's/^          //' "$REPORT"
 

--- a/.claude/skills/gh-work-report/templates/weekly-report.yml
+++ b/.claude/skills/gh-work-report/templates/weekly-report.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Set up date range
         id: dates
         run: |
+          set -euo pipefail
           DAYS="${{ github.event.inputs.days || '7' }}"
           START_DATE=$(date -d "$DAYS days ago" +%Y-%m-%d)
           END_DATE=$(date +%Y-%m-%d)
@@ -49,6 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPORT_TOKEN }}
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           END="${{ steps.dates.outputs.end }}"
           mkdir -p /tmp/report-data
@@ -64,25 +66,36 @@ jobs:
                 }
               }
             }
-          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json 2>/dev/null || true
+          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json
 
           # Get PRs created in window
           gh search prs --author=@me --created=">$START" --limit 200 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-created.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-created.json
+            > /tmp/report-data/prs-created.json
+
+          # Get all open/WIP PRs (may predate window)
+          gh search prs --author=@me --state=open --limit 200 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-open.json
 
           # Get PRs merged in window
           gh search prs --author=@me --merged=">$START" --limit 200 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-merged.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-merged.json
+            > /tmp/report-data/prs-merged.json
+
+          # Get PRs closed in window
+          gh search prs --author=@me --closed=">$START" --limit 200 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-closed.json
 
           # Get issues
           gh search issues --author=@me --created=">$START" --limit 100 \
             --json number,title,repository,state,createdAt,url \
-            > /tmp/report-data/issues.json 2>/dev/null || echo '[]' > /tmp/report-data/issues.json
+            > /tmp/report-data/issues.json
 
       - name: Generate report
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           END="${{ steps.dates.outputs.end }}"
           DAYS="${{ steps.dates.outputs.days }}"
@@ -91,10 +104,10 @@ jobs:
           mkdir -p docs/reports
 
           # Count metrics
-          REPO_COUNT=$(cat /tmp/report-data/repos.json 2>/dev/null | wc -l || echo 0)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))" 2>/dev/null || echo 0)
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))" 2>/dev/null || echo 0)
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))" 2>/dev/null || echo 0)
+          REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
+          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
+          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
+          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -125,22 +138,20 @@ jobs:
               repo = pr.get('repository', {})
               repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
               print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT" 2>/dev/null || true
+          " >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json 2>/dev/null | python3 -c "
+          cat /tmp/report-data/repos.json | python3 -c "
           import json, sys
           for line in sys.stdin:
-              try:
-                  r = json.loads(line)
-                  desc = (r.get('description') or '—')[:60]
-                  print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-              except: pass
-          " >> "$REPORT" 2>/dev/null || true
+              r = json.loads(line)
+              desc = (r.get('description') or '—')[:60]
+              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
+          " >> "$REPORT"
 
           # Strip leading whitespace from heredoc
           sed -i 's/^          //' "$REPORT"

--- a/amplifier-bundle/skills/gh-work-report/SKILL.md
+++ b/amplifier-bundle/skills/gh-work-report/SKILL.md
@@ -103,7 +103,7 @@ gh search issues --author=@me --created=">YYYY-MM-DD" --limit 100 --json number,
 
 ```bash
 # For each active repo, check for releases
-gh api repos/{owner}/{repo}/releases --jq '.[].tag_name' 2>/dev/null | head -5
+gh api repos/{owner}/{repo}/releases --jq '.[].tag_name' | head -5
 ```
 
 ### Step 3: Combine and deduplicate
@@ -151,10 +151,21 @@ If yes, follow the infrastructure setup in `reference.md` § Infrastructure Setu
 ## Key Rules
 
 - **Never hardcode usernames** — always detect from `gh auth status`
+- **Never use fallbacks** — no silent defaults, no `2>/dev/null`, no hardcoded values. Errors must fail loud with descriptive messages.
+- **All charts must be code-generated** — every number in every chart and table must come from actual API data. Never fabricate or estimate chart data.
+- **4 query filters for complete PR coverage**: `created:>DATE` (new), `is:open` (all WIP), `merged:>DATE` (merged during window), `closed:>DATE` (closed during window). Deduplicate by URL.
+- **Clamp chart timelines** — Gantt and timeline charts must be scoped to the report window. Clamp start dates to `max(pr_date, window_start)`.
 - **Handle private repos gracefully** — note them but don't expose sensitive details unless the report itself is private
 - **Date math**: Use `date -d "$DAYS days ago" +%Y-%m-%d` (Linux) for the start date
 - **Rate limiting**: If `gh api` returns 403, wait and retry. Use `--paginate` for large result sets.
 - **Empty results are fine** — if an account has no activity, say so briefly and move on
+
+## Authentication & Automation
+
+- **Local (multi-account)**: Use `./run.sh [days]` which leverages `gh auth switch` across all locally authenticated accounts. This is the recommended approach for users with multiple accounts (e.g., public + EMU).
+- **GitHub Actions (single-account)**: Use the workflow templates with a PAT secret. A PAT is scoped to one identity and cannot cross accounts.
+- **Two-PAT approach**: For Actions across two accounts, use separate PAT secrets (`ACCOUNT1_PAT`, `ACCOUNT2_PAT`) with explicit `--header "authorization: token $PAT"` per API call.
+- **GitHub Pages is static only** — report generation must happen elsewhere (local script, Actions, gh-aw). Pages just serves the output.
 
 ## Reference Files
 

--- a/amplifier-bundle/skills/gh-work-report/reference.md
+++ b/amplifier-bundle/skills/gh-work-report/reference.md
@@ -138,7 +138,7 @@ xychart-beta
 - **XY charts**: Use for daily/weekly commit activity. Aggregate by day of week for short periods, by week for 30+ day periods.
 - **Flowcharts**: Use sparingly — only to illustrate architecture changes when a project had significant structural work.
 
-Keep chart data realistic — pull actual counts from the gathered data.
+Keep chart data realistic — pull actual counts from the gathered data. **Never fabricate chart values.** Every number must trace back to real API data. If you don't have data for a chart, omit the chart entirely rather than estimating.
 
 ## gh CLI Command Patterns
 

--- a/amplifier-bundle/skills/gh-work-report/templates/monthly-report.yml
+++ b/amplifier-bundle/skills/gh-work-report/templates/monthly-report.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Set up date range
         id: dates
         run: |
+          set -euo pipefail
           DAYS="${{ github.event.inputs.days || '30' }}"
           START_DATE=$(date -d "$DAYS days ago" +%Y-%m-%d)
           END_DATE=$(date +%Y-%m-%d)
@@ -46,6 +47,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPORT_TOKEN }}
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           mkdir -p /tmp/report-data
 
@@ -59,22 +61,31 @@ jobs:
                 }
               }
             }
-          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json 2>/dev/null || true
+          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json
 
           gh search prs --author=@me --created=">$START" --limit 500 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-created.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-created.json
+            > /tmp/report-data/prs-created.json
+
+          gh search prs --author=@me --state=open --limit 500 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-open.json
 
           gh search prs --author=@me --merged=">$START" --limit 500 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-merged.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-merged.json
+            > /tmp/report-data/prs-merged.json
+
+          gh search prs --author=@me --closed=">$START" --limit 500 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-closed.json
 
           gh search issues --author=@me --created=">$START" --limit 200 \
             --json number,title,repository,state,createdAt,url \
-            > /tmp/report-data/issues.json 2>/dev/null || echo '[]' > /tmp/report-data/issues.json
+            > /tmp/report-data/issues.json
 
       - name: Generate report
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           END="${{ steps.dates.outputs.end }}"
           DAYS="${{ steps.dates.outputs.days }}"
@@ -82,10 +93,10 @@ jobs:
           REPORT="docs/reports/$FILENAME"
           mkdir -p docs/reports
 
-          REPO_COUNT=$(cat /tmp/report-data/repos.json 2>/dev/null | wc -l || echo 0)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))" 2>/dev/null || echo 0)
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))" 2>/dev/null || echo 0)
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))" 2>/dev/null || echo 0)
+          REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
+          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
+          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
+          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -115,22 +126,20 @@ jobs:
               repo = pr.get('repository', {})
               repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
               print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT" 2>/dev/null || true
+          " >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json 2>/dev/null | python3 -c "
+          cat /tmp/report-data/repos.json | python3 -c "
           import json, sys
           for line in sys.stdin:
-              try:
-                  r = json.loads(line)
-                  desc = (r.get('description') or '—')[:60]
-                  print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-              except: pass
-          " >> "$REPORT" 2>/dev/null || true
+              r = json.loads(line)
+              desc = (r.get('description') or '—')[:60]
+              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
+          " >> "$REPORT"
 
           sed -i 's/^          //' "$REPORT"
 

--- a/amplifier-bundle/skills/gh-work-report/templates/weekly-report.yml
+++ b/amplifier-bundle/skills/gh-work-report/templates/weekly-report.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Set up date range
         id: dates
         run: |
+          set -euo pipefail
           DAYS="${{ github.event.inputs.days || '7' }}"
           START_DATE=$(date -d "$DAYS days ago" +%Y-%m-%d)
           END_DATE=$(date +%Y-%m-%d)
@@ -49,6 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPORT_TOKEN }}
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           END="${{ steps.dates.outputs.end }}"
           mkdir -p /tmp/report-data
@@ -64,25 +66,36 @@ jobs:
                 }
               }
             }
-          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json 2>/dev/null || true
+          }' --jq '.data.viewer.repositories.nodes[] | select(.pushedAt >= "'"$START"'")' > /tmp/report-data/repos.json
 
           # Get PRs created in window
           gh search prs --author=@me --created=">$START" --limit 200 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-created.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-created.json
+            > /tmp/report-data/prs-created.json
+
+          # Get all open/WIP PRs (may predate window)
+          gh search prs --author=@me --state=open --limit 200 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-open.json
 
           # Get PRs merged in window
           gh search prs --author=@me --merged=">$START" --limit 200 \
             --json number,title,repository,state,createdAt,url,mergedAt \
-            > /tmp/report-data/prs-merged.json 2>/dev/null || echo '[]' > /tmp/report-data/prs-merged.json
+            > /tmp/report-data/prs-merged.json
+
+          # Get PRs closed in window
+          gh search prs --author=@me --closed=">$START" --limit 200 \
+            --json number,title,repository,state,createdAt,url,mergedAt \
+            > /tmp/report-data/prs-closed.json
 
           # Get issues
           gh search issues --author=@me --created=">$START" --limit 100 \
             --json number,title,repository,state,createdAt,url \
-            > /tmp/report-data/issues.json 2>/dev/null || echo '[]' > /tmp/report-data/issues.json
+            > /tmp/report-data/issues.json
 
       - name: Generate report
         run: |
+          set -euo pipefail
           START="${{ steps.dates.outputs.start }}"
           END="${{ steps.dates.outputs.end }}"
           DAYS="${{ steps.dates.outputs.days }}"
@@ -91,10 +104,10 @@ jobs:
           mkdir -p docs/reports
 
           # Count metrics
-          REPO_COUNT=$(cat /tmp/report-data/repos.json 2>/dev/null | wc -l || echo 0)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))" 2>/dev/null || echo 0)
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))" 2>/dev/null || echo 0)
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))" 2>/dev/null || echo 0)
+          REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
+          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
+          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
+          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -125,22 +138,20 @@ jobs:
               repo = pr.get('repository', {})
               repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
               print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT" 2>/dev/null || true
+          " >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json 2>/dev/null | python3 -c "
+          cat /tmp/report-data/repos.json | python3 -c "
           import json, sys
           for line in sys.stdin:
-              try:
-                  r = json.loads(line)
-                  desc = (r.get('description') or '—')[:60]
-                  print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-              except: pass
-          " >> "$REPORT" 2>/dev/null || true
+              r = json.loads(line)
+              desc = (r.get('description') or '—')[:60]
+              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
+          " >> "$REPORT"
 
           # Strip leading whitespace from heredoc
           sed -i 's/^          //' "$REPORT"

--- a/docs/claude/skills/gh_work_report/SKILL.md
+++ b/docs/claude/skills/gh_work_report/SKILL.md
@@ -103,7 +103,7 @@ gh search issues --author=@me --created=">YYYY-MM-DD" --limit 100 --json number,
 
 ```bash
 # For each active repo, check for releases
-gh api repos/{owner}/{repo}/releases --jq '.[].tag_name' 2>/dev/null | head -5
+gh api repos/{owner}/{repo}/releases --jq '.[].tag_name' | head -5
 ```
 
 ### Step 3: Combine and deduplicate
@@ -151,10 +151,21 @@ If yes, follow the infrastructure setup in `reference.md` § Infrastructure Setu
 ## Key Rules
 
 - **Never hardcode usernames** — always detect from `gh auth status`
+- **Never use fallbacks** — no silent defaults, no `2>/dev/null`, no hardcoded values. Errors must fail loud with descriptive messages.
+- **All charts must be code-generated** — every number in every chart and table must come from actual API data. Never fabricate or estimate chart data.
+- **4 query filters for complete PR coverage**: `created:>DATE` (new), `is:open` (all WIP), `merged:>DATE` (merged during window), `closed:>DATE` (closed during window). Deduplicate by URL.
+- **Clamp chart timelines** — Gantt and timeline charts must be scoped to the report window. Clamp start dates to `max(pr_date, window_start)`.
 - **Handle private repos gracefully** — note them but don't expose sensitive details unless the report itself is private
 - **Date math**: Use `date -d "$DAYS days ago" +%Y-%m-%d` (Linux) for the start date
 - **Rate limiting**: If `gh api` returns 403, wait and retry. Use `--paginate` for large result sets.
 - **Empty results are fine** — if an account has no activity, say so briefly and move on
+
+## Authentication & Automation
+
+- **Local (multi-account)**: Use `./run.sh [days]` which leverages `gh auth switch` across all locally authenticated accounts. This is the recommended approach for users with multiple accounts (e.g., public + EMU).
+- **GitHub Actions (single-account)**: Use the workflow templates with a PAT secret. A PAT is scoped to one identity and cannot cross accounts.
+- **Two-PAT approach**: For Actions across two accounts, use separate PAT secrets (`ACCOUNT1_PAT`, `ACCOUNT2_PAT`) with explicit `--header "authorization: token $PAT"` per API call.
+- **GitHub Pages is static only** — report generation must happen elsewhere (local script, Actions, gh-aw). Pages just serves the output.
 
 ## Reference Files
 

--- a/docs/claude/skills/gh_work_report/reference.md
+++ b/docs/claude/skills/gh_work_report/reference.md
@@ -138,7 +138,7 @@ xychart-beta
 - **XY charts**: Use for daily/weekly commit activity. Aggregate by day of week for short periods, by week for 30+ day periods.
 - **Flowcharts**: Use sparingly — only to illustrate architecture changes when a project had significant structural work.
 
-Keep chart data realistic — pull actual counts from the gathered data.
+Keep chart data realistic — pull actual counts from the gathered data. **Never fabricate chart values.** Every number must trace back to real API data. If you don't have data for a chart, omit the chart entirely rather than estimating.
 
 ## gh CLI Command Patterns
 


### PR DESCRIPTION
## Quality Audit Findings

Code review found 3 issues in the gh-work-report skill:

### 1. Missing `set -euo pipefail` (High)
Workflow scripts had no fail-fast flags — commands could fail silently. Added to all `run:` blocks in both templates.

### 2. Missing 2 of 4 query filters (Medium)  
SKILL.md documented 4 PR query filters but templates only had 2. Added `is:open` and `closed:>DATE` queries to match.

### 3. Stale mirrors (Medium)
amplifier-bundle/ and docs/ copies were out of sync. All 3 locations now match.

### Also in this PR
- Removed remaining `2>/dev/null`, `|| true`, `|| echo`, `try/except: pass`
- Added Key Rules (no fallbacks, code-generated charts, clamped timelines)
- Added Authentication & Automation documentation
- Strengthened chart fabrication mandate in reference.md

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>