### PR TITLE
fix: make agent binary selection agent-agnostic across codebase

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: amploxy
+## Project: amplihack-workrep
 
 ## Overview
 

--- a/.claude/skills/dev-orchestrator/SKILL.md
+++ b/.claude/skills/dev-orchestrator/SKILL.md
@@ -120,16 +120,15 @@ When this skill is activated:
 ### REQUIRED: Execute via Recipe Runner — IMMEDIATELY
 
 Your next tool call(s) must include the recipe runner launch (alongside
-`report_intent` if your runtime requires it). **CRITICAL**: Claude
-Code's `run_in_background` kills processes after ~10 minutes. Recipe
-workstreams can take hours. You MUST use a tmux session for execution:
+`report_intent` if your runtime requires it). **CRITICAL**: Some agent
+runtimes kill background processes after a timeout. Recipe workstreams
+can take hours. You MUST use a tmux session for execution:
 
 ```bash
 LOG_FILE=$(mktemp /tmp/recipe-runner-output.XXXXXX.log)
 chmod 600 "$LOG_FILE"
-tmux new-session -d -s recipe-runner "env -u CLAUDECODE PYTHONPATH=src python3 -c \"
+tmux new-session -d -s recipe-runner "PYTHONPATH=src python3 -c \"
 import os
-os.environ.pop('CLAUDECODE', None)
 
 from amplihack.recipes import run_recipe_by_name
 
@@ -148,7 +147,6 @@ echo \"Recipe runner log: $LOG_FILE\"
 
 **Key points:**
 
-- `env -u CLAUDECODE` — unset so nested Claude Code sessions can launch
 - `PYTHONPATH=src python3` — uses the interpreter on PATH while forcing imports from the checked-out repo source tree (do NOT hardcode `.venv/bin/python`)
 - `run_recipe_by_name` — delegates to the Rust binary; the adapter parameter is no longer needed
 - `progress=True` — streams recipe-runner stderr live so tmux logs show nested step activity
@@ -174,8 +172,8 @@ tmux send-keys -t recipe-runner "exit" Enter 2>/dev/null; sleep 1
 If using Option A, update the `tail -f` / `tmux attach` commands to use the
 same session name.
 
-**DO NOT use `run_in_background`** for recipe execution — it will be killed
-after ~10 minutes (Issue #2909).
+**DO NOT use runtime-specific background APIs** (e.g. `run_in_background`) for
+recipe execution — they may kill processes after a timeout. Use tmux instead.
 
 **The recipe runner is the required execution path for Development and
 Investigation tasks.** Always try `smart-orchestrator` first.
@@ -257,12 +255,12 @@ Do not declare success when agents produced no meaningful work.
 
 The recipe runner requires these environment variables to function:
 
-| Variable                   | Purpose                                           | Default       |
-| -------------------------- | ------------------------------------------------- | ------------- |
-| `AMPLIHACK_HOME`           | Root of amplihack installation (for asset lookup) | Auto-detected |
-| `AMPLIHACK_AGENT_BINARY`   | Which agent binary to use (claude, copilot, etc.) | `claude`      |
-| `AMPLIHACK_MAX_DEPTH`      | Max recursion depth for nested sessions           | `3`           |
-| `AMPLIHACK_NONINTERACTIVE` | Set to `1` to skip interactive prompts            | Unset         |
+| Variable                   | Purpose                                           | Default         |
+| -------------------------- | ------------------------------------------------- | --------------- |
+| `AMPLIHACK_HOME`           | Root of amplihack installation (for asset lookup) | Auto-detected   |
+| `AMPLIHACK_AGENT_BINARY`   | Which agent binary to use (claude, copilot, etc.) | Set by launcher |
+| `AMPLIHACK_MAX_DEPTH`      | Max recursion depth for nested sessions           | `3`             |
+| `AMPLIHACK_NONINTERACTIVE` | Set to `1` to skip interactive prompts            | Unset           |
 
 If `AMPLIHACK_HOME` is not set and auto-detection fails, `parse-decomposition`
 and `activate-workflow` will fail with "orch_helper.py not found". Set it to
@@ -334,12 +332,12 @@ to block parallel spawning and fall back to single-session mode for all tasks:
 
 ```bash
 export AMPLIHACK_MAX_DEPTH=0  # set in your shell first
-/dev build a webui and an api  # then type in Claude Code
+/dev build a webui and an api  # then invoke /dev in your agent session
 ```
 
-Note: The env var must be set in your shell before starting Claude Code — it cannot
-be prefixed inline on the `/dev` command. This affects all depth checks, not just
-parallel workstream spawning.
+Note: The env var must be set in your shell before starting the agent session — it
+cannot be prefixed inline on the `/dev` command. This affects all depth checks, not
+just parallel workstream spawning.
 
 ## Canonical Sources
 

--- a/.claude/skills/multitask/orchestrator.py
+++ b/.claude/skills/multitask/orchestrator.py
@@ -303,7 +303,11 @@ class ParallelOrchestrator:
             export AMPLIHACK_SESSION_DEPTH={_safe_depth}
             export AMPLIHACK_MAX_DEPTH={_safe_max_depth}
             export AMPLIHACK_MAX_SESSIONS={_safe_max_sessions}
-            amplihack ${{AMPLIHACK_AGENT_BINARY:-claude}} --subprocess-safe -- -p "@TASK.md Execute task autonomously following DEFAULT_WORKFLOW.md. NO QUESTIONS. Work through all steps. Create PR when complete."
+            if [ -z "$AMPLIHACK_AGENT_BINARY" ]; then
+                echo "WARNING: AMPLIHACK_AGENT_BINARY not set, defaulting to claude" >&2
+                export AMPLIHACK_AGENT_BINARY=claude
+            fi
+            amplihack "$AMPLIHACK_AGENT_BINARY" --subprocess-safe -- -p "@TASK.md Execute task autonomously following DEFAULT_WORKFLOW.md. NO QUESTIONS. Work through all steps. Create PR when complete."
             """)
         )
         run_sh.chmod(0o755)

--- a/.claude/skills/pm-architect/scripts/delegate_response.py
+++ b/.claude/skills/pm-architect/scripts/delegate_response.py
@@ -101,8 +101,24 @@ def run_auto_mode_delegation(
     """
     try:
         # Run amplihack auto mode with the active agent binary
-        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY") or "claude"
-        cmd = ["amplihack", agent_binary, "--auto", "--max-turns", str(max_turns), "--", "-p", prompt]
+        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY")
+        if not agent_binary:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "AMPLIHACK_AGENT_BINARY not set, defaulting to 'claude'"
+            )
+            agent_binary = "claude"
+        cmd = [
+            "amplihack",
+            agent_binary,
+            "--auto",
+            "--max-turns",
+            str(max_turns),
+            "--",
+            "-p",
+            prompt,
+        ]
 
         result = subprocess.run(
             cmd,

--- a/.claude/tools/amplihack/orchestration/claude_process.py
+++ b/.claude/tools/amplihack/orchestration/claude_process.py
@@ -199,12 +199,13 @@ class ClaudeProcess:
                 self.log(f"Error during termination: {e}", level="ERROR")
 
     def _build_command(self) -> list[str]:
-        """Build the Claude CLI command.
+        """Build the agent CLI command.
 
         Returns:
             Command as list of strings
         """
-        cmd = ["claude", "--dangerously-skip-permissions", "-p", self.prompt]
+        agent = os.environ.get("AMPLIHACK_AGENT_BINARY", "claude")
+        cmd = [agent, "--dangerously-skip-permissions", "-p", self.prompt]
 
         if self.model:
             cmd.extend(["--model", self.model])

--- a/.claude/tools/amplihack/remote/executor.py
+++ b/.claude/tools/amplihack/remote/executor.py
@@ -229,8 +229,12 @@ fi
 # Decode prompt from base64
 PROMPT=$(echo '{encoded_prompt}' | base64 -d)
 
-# Run amplihack command
-amplihack ${{AMPLIHACK_AGENT_BINARY:-claude}} --{command} --max-turns {max_turns} -- -p "$PROMPT"
+# Run amplihack command (AMPLIHACK_AGENT_BINARY set by launcher; defaults to claude)
+if [ -z "$AMPLIHACK_AGENT_BINARY" ]; then
+    echo "WARNING: AMPLIHACK_AGENT_BINARY not set, defaulting to claude" >&2
+    AMPLIHACK_AGENT_BINARY=claude
+fi
+amplihack "$AMPLIHACK_AGENT_BINARY" --{command} --max-turns {max_turns} -- -p "$PROMPT"
 """
 
         # Execute with timeout
@@ -267,7 +271,13 @@ amplihack ${{AMPLIHACK_AGENT_BINARY:-claude}} --{command} --max-turns {max_turns
             # Try to terminate remote process
             try:
                 subprocess.run(
-                    ["azlin", "connect", *self._azlin_port_args(), self.vm.name, "pkill -TERM -f amplihack"],
+                    [
+                        "azlin",
+                        "connect",
+                        *self._azlin_port_args(),
+                        self.vm.name,
+                        "pkill -TERM -f amplihack",
+                    ],
                     timeout=30,
                     capture_output=True,
                 )
@@ -332,7 +342,13 @@ fi
             # Download archive (azlin cp requires relative paths)
             local_archive = local_dest / "logs.tar.gz"
             subprocess.run(
-                ["azlin", "cp", *self._azlin_port_args(), f"{self.vm.name}:~/logs.tar.gz", "logs.tar.gz"],
+                [
+                    "azlin",
+                    "cp",
+                    *self._azlin_port_args(),
+                    f"{self.vm.name}:~/logs.tar.gz",
+                    "logs.tar.gz",
+                ],
                 cwd=str(local_dest),  # Run from destination directory
                 capture_output=True,
                 text=True,
@@ -395,7 +411,13 @@ echo "Bundle created"
             # Download bundle (azlin cp requires relative paths)
             local_bundle = local_dest / "results.bundle"
             subprocess.run(
-                ["azlin", "cp", *self._azlin_port_args(), f"{self.vm.name}:~/results.bundle", "results.bundle"],
+                [
+                    "azlin",
+                    "cp",
+                    *self._azlin_port_args(),
+                    f"{self.vm.name}:~/results.bundle",
+                    "results.bundle",
+                ],
                 cwd=str(local_dest),  # Run from destination directory
                 capture_output=True,
                 text=True,
@@ -540,7 +562,7 @@ source ~/.amplihack-venv/bin/activate
 export ANTHROPIC_API_KEY=$(echo '{encoded_api_key}' | base64 -d)
 export NODE_OPTIONS='--max-old-space-size=32768'
 PROMPT=$(echo '{encoded_prompt}' | base64 -d)
-exec amplihack ${{AMPLIHACK_AGENT_BINARY:-claude}} --{command} --max-turns {max_turns} -- -p "$PROMPT"
+exec amplihack "${{AMPLIHACK_AGENT_BINARY:-claude}}" --{command} --max-turns {max_turns} -- -p "$PROMPT"
 AMPLIHACK_RUN_EOF
 chmod +x "$SCRIPT"
 

--- a/amplifier-bundle/skills/pm-architect/scripts/delegate_response.py
+++ b/amplifier-bundle/skills/pm-architect/scripts/delegate_response.py
@@ -101,8 +101,24 @@ def run_auto_mode_delegation(
     """
     try:
         # Run amplihack auto mode with the active agent binary
-        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY") or "claude"
-        cmd = ["amplihack", agent_binary, "--auto", "--max-turns", str(max_turns), "--", "-p", prompt]
+        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY")
+        if not agent_binary:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "AMPLIHACK_AGENT_BINARY not set, defaulting to 'claude'"
+            )
+            agent_binary = "claude"
+        cmd = [
+            "amplihack",
+            agent_binary,
+            "--auto",
+            "--max-turns",
+            str(max_turns),
+            "--",
+            "-p",
+            prompt,
+        ]
 
         result = subprocess.run(
             cmd,

--- a/amplifier-bundle/tools/amplihack/orchestration/claude_process.py
+++ b/amplifier-bundle/tools/amplihack/orchestration/claude_process.py
@@ -199,12 +199,13 @@ class ClaudeProcess:
                 self.log(f"Error during termination: {e}", level="ERROR")
 
     def _build_command(self) -> list[str]:
-        """Build the Claude CLI command.
+        """Build the agent CLI command.
 
         Returns:
             Command as list of strings
         """
-        cmd = ["claude", "--dangerously-skip-permissions", "-p", self.prompt]
+        agent = os.environ.get("AMPLIHACK_AGENT_BINARY", "claude")
+        cmd = [agent, "--dangerously-skip-permissions", "-p", self.prompt]
 
         if self.model:
             cmd.extend(["--model", self.model])

--- a/docs/claude/skills/pm-architect/scripts/delegate_response.py
+++ b/docs/claude/skills/pm-architect/scripts/delegate_response.py
@@ -101,8 +101,24 @@ def run_auto_mode_delegation(
     """
     try:
         # Run amplihack auto mode with the active agent binary
-        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY") or "claude"
-        cmd = ["amplihack", agent_binary, "--auto", "--max-turns", str(max_turns), "--", "-p", prompt]
+        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY")
+        if not agent_binary:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "AMPLIHACK_AGENT_BINARY not set, defaulting to 'claude'"
+            )
+            agent_binary = "claude"
+        cmd = [
+            "amplihack",
+            agent_binary,
+            "--auto",
+            "--max-turns",
+            str(max_turns),
+            "--",
+            "-p",
+            prompt,
+        ]
 
         result = subprocess.run(
             cmd,

--- a/docs/claude/tools/amplihack/orchestration/claude_process.py
+++ b/docs/claude/tools/amplihack/orchestration/claude_process.py
@@ -199,12 +199,13 @@ class ClaudeProcess:
                 self.log(f"Error during termination: {e}", level="ERROR")
 
     def _build_command(self) -> list[str]:
-        """Build the Claude CLI command.
+        """Build the agent CLI command.
 
         Returns:
             Command as list of strings
         """
-        cmd = ["claude", "--dangerously-skip-permissions", "-p", self.prompt]
+        agent = os.environ.get("AMPLIHACK_AGENT_BINARY", "claude")
+        cmd = [agent, "--dangerously-skip-permissions", "-p", self.prompt]
 
         if self.model:
             cmd.extend(["--model", self.model])

--- a/src/amplihack/fleet/fleet_adopt.py
+++ b/src/amplihack/fleet/fleet_adopt.py
@@ -16,6 +16,7 @@ Public API:
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -76,7 +77,12 @@ class SessionAdopter:
                 return self._parse_discovery_output(vm_name, result.stdout)
 
             if result.returncode != 0:
-                logger.warning("Session discovery command failed for %s (rc=%d): %s", vm_name, result.returncode, result.stderr[:200])
+                logger.warning(
+                    "Session discovery command failed for %s (rc=%d): %s",
+                    vm_name,
+                    result.returncode,
+                    result.stderr[:200],
+                )
                 return []
 
             return self._parse_discovery_output(vm_name, result.stdout)
@@ -118,7 +124,8 @@ class SessionAdopter:
                 prompt=prompt,
                 repo_url=session.inferred_repo,
                 priority=TaskPriority.MEDIUM,
-                agent_command=session.agent_type or "claude",
+                agent_command=session.agent_type
+                or os.environ.get("AMPLIHACK_AGENT_BINARY", "claude"),
             )
             # Mark as already running (don't try to start it)
             task.assign(vm_name, session.session_name)
@@ -176,7 +183,9 @@ class SessionAdopter:
                 try:
                     validate_session_name(session_name)
                 except ValueError:
-                    logger.warning("Skipping invalid session name from SSH output: %r", session_name)
+                    logger.warning(
+                        "Skipping invalid session name from SSH output: %r", session_name
+                    )
                     current = None
                     continue
                 current = AdoptedSession(vm_name=vm_name, session_name=session_name)

--- a/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
+++ b/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
@@ -8,13 +8,13 @@ from amplihack.knowledge_builder.kb_types import Question
 class KnowledgeAcquirer:
     """Acquires knowledge by answering questions via web search."""
 
-    def __init__(self, claude_cmd: str = "claude"):
+    def __init__(self, agent_cmd: str = "claude"):
         """Initialize knowledge acquirer.
 
         Args:
-            claude_cmd: Claude command to use (default: "claude")
+            agent_cmd: Agent command to use (default: "claude")
         """
-        self.claude_cmd = claude_cmd
+        self.agent_cmd = agent_cmd
 
     def answer_question(self, question: Question, topic: str) -> tuple[str, list[str]]:
         """Answer a question using web search.
@@ -42,7 +42,7 @@ Requirements:
   - [url3]"""
 
         result = subprocess.run(
-            [self.claude_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/knowledge_builder/modules/question_generator.py
+++ b/src/amplihack/knowledge_builder/modules/question_generator.py
@@ -8,13 +8,13 @@ from amplihack.knowledge_builder.kb_types import Question
 class QuestionGenerator:
     """Generates questions using Socratic method (3 levels deep)."""
 
-    def __init__(self, claude_cmd: str = "claude"):
+    def __init__(self, agent_cmd: str = "claude"):
         """Initialize question generator.
 
         Args:
-            claude_cmd: Claude command to use (default: "claude")
+            agent_cmd: Agent command to use (default: "claude")
         """
-        self.claude_cmd = claude_cmd
+        self.agent_cmd = agent_cmd
 
     def generate_initial_questions(self, topic: str) -> list[Question]:
         """Generate 10 initial questions about a topic.
@@ -35,7 +35,7 @@ Requirements:
 - No additional commentary"""
 
         result = subprocess.run(
-            [self.claude_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
             capture_output=True,
             text=True,
             check=False,
@@ -92,7 +92,7 @@ Requirements:
 - No additional commentary"""
 
         result = subprocess.run(
-            [self.claude_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/knowledge_builder/orchestrator.py
+++ b/src/amplihack/knowledge_builder/orchestrator.py
@@ -1,5 +1,6 @@
 """Knowledge Builder orchestrator - main entry point."""
 
+import os
 import sys
 from pathlib import Path
 
@@ -12,16 +13,17 @@ from amplihack.knowledge_builder.modules.question_generator import QuestionGener
 class KnowledgeBuilder:
     """Main orchestrator for Knowledge Builder workflow."""
 
-    def __init__(self, topic: str, claude_cmd: str = "claude", output_base: Path | None = None):
+    def __init__(self, topic: str, agent_cmd: str | None = None, output_base: Path | None = None):
         """Initialize Knowledge Builder.
 
         Args:
             topic: Topic to build knowledge about (1-2 sentences)
-            claude_cmd: Claude command to use (default: "claude")
+            agent_cmd: Agent command to use. Reads AMPLIHACK_AGENT_BINARY if
+                not provided, falls back to "claude".
             output_base: Base directory for output (default: .claude/data)
         """
         self.topic = topic.strip()
-        self.claude_cmd = claude_cmd
+        self.agent_cmd = agent_cmd or os.environ.get("AMPLIHACK_AGENT_BINARY", "claude")
 
         # Sanitize topic for directory name
         topic_slug = "".join(c if c.isalnum() or c in " -_" else "_" for c in self.topic[:50])
@@ -33,8 +35,8 @@ class KnowledgeBuilder:
         self.output_dir = output_base / topic_slug
 
         # Initialize modules
-        self.question_gen = QuestionGenerator(claude_cmd)
-        self.knowledge_acq = KnowledgeAcquirer(claude_cmd)
+        self.question_gen = QuestionGenerator(self.agent_cmd)
+        self.knowledge_acq = KnowledgeAcquirer(self.agent_cmd)
         self.artifact_gen = ArtifactGenerator(self.output_dir)
 
         # Initialize knowledge graph

--- a/src/amplihack/launcher/auto_mode.py
+++ b/src/amplihack/launcher/auto_mode.py
@@ -343,11 +343,18 @@ class AutoMode:
             (exit_code, output)
         """
         if self.sdk == "copilot":
-            cmd = ["copilot", "--allow-all-tools", "--add-dir", "/", "-p", prompt]
+            cmd = ["amplihack", "copilot", "--allow-all-tools", "--add-dir", "/", "-p", prompt]
         elif self.sdk == "codex":
-            cmd = ["codex", "--dangerously-bypass-approvals-and-sandbox", "exec", prompt]
+            cmd = [
+                "amplihack",
+                "codex",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "exec",
+                prompt,
+            ]
         else:
-            cmd = ["claude", "--dangerously-skip-permissions", "--verbose", "-p", prompt]
+            agent = os.environ.get("AMPLIHACK_AGENT_BINARY", self.sdk or "claude")
+            cmd = ["amplihack", agent, "--dangerously-skip-permissions", "--verbose", "-p", prompt]
 
         self.log(f"Running: {cmd[0]} ...")
 

--- a/src/amplihack/meta_delegation/platform_cli.py
+++ b/src/amplihack/meta_delegation/platform_cli.py
@@ -294,7 +294,9 @@ Focus on delivering working code that meets the stated requirements.""",
         prompt = self.format_prompt(goal, persona, kwargs.get("context", ""))
 
         # Build command - use amplihack with the active agent binary
-        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY") or "claude"
+        from amplihack.utils import get_agent_binary
+
+        agent_binary = get_agent_binary()
         command = ["amplihack", agent_binary, "--", "-p", prompt]
 
         # Add extra arguments if provided

--- a/src/amplihack/utils/__init__.py
+++ b/src/amplihack/utils/__init__.py
@@ -1,5 +1,8 @@
 """Utility functions for amplihack."""
 
+import logging
+import os
+
 from .defensive import (
     DefensiveError,
     FileOperationError,
@@ -18,6 +21,31 @@ from .process import ProcessManager
 from .string_utils import slugify
 from .uvx_staging import stage_uvx_framework
 
+_logger = logging.getLogger(__name__)
+
+
+def get_agent_binary() -> str:
+    """Return the active agent binary name from AMPLIHACK_AGENT_BINARY.
+
+    This env var is set by the amplihack CLI dispatcher (cli.py) when the user
+    runs ``amplihack claude``, ``amplihack copilot``, etc.  Every subprocess
+    that needs to launch a coding agent should call this function instead of
+    hard-coding ``"claude"``.
+
+    Returns:
+        The agent binary name (e.g. ``"claude"``, ``"copilot"``, ``"codex"``).
+        Falls back to ``"claude"`` with a warning if the env var is unset.
+    """
+    binary = os.environ.get("AMPLIHACK_AGENT_BINARY")
+    if not binary:
+        _logger.warning(
+            "AMPLIHACK_AGENT_BINARY not set — defaulting to 'claude'. "
+            "This usually means a subprocess was launched outside the "
+            "amplihack CLI dispatcher."
+        )
+        binary = "claude"
+    return binary
+
 
 def is_uvx_deployment() -> bool:
     """Simple UVX detection based on sys.executable location."""
@@ -28,6 +56,8 @@ def is_uvx_deployment() -> bool:
 
 
 __all__ = [
+    # Agent binary
+    "get_agent_binary",
     # Path utilities
     "FrameworkPathResolver",
     # Process utilities

--- a/src/amplihack/utils/claude_cli.py
+++ b/src/amplihack/utils/claude_cli.py
@@ -455,7 +455,7 @@ def _get_current_claude_version(binary_path: str | None = None) -> str | None:
     Returns:
         Version string (e.g. "1.2.3") or None if detection fails.
     """
-    cmd = [binary_path or "claude", "--version"]
+    cmd = [binary_path or os.environ.get("AMPLIHACK_AGENT_BINARY", "claude"), "--version"]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
         if result.returncode != 0 or not result.stdout.strip():
@@ -515,7 +515,10 @@ def ensure_latest_claude() -> bool:
 
         latest_result = subprocess.run(
             [npm_path, "view", "@anthropic-ai/claude-code", "version"],
-            capture_output=True, text=True, timeout=15, check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
         )
         if latest_result.returncode != 0:
             return True
@@ -527,16 +530,28 @@ def ensure_latest_claude() -> bool:
         print(f"🔄 Claude Code update available: {current} → {latest}")
         user_npm_dir = Path.home() / ".npm-global"
         result = subprocess.run(
-            [npm_path, "install", "-g", "--prefix", str(user_npm_dir),
-             "@anthropic-ai/claude-code", "--ignore-scripts"],
-            capture_output=True, text=True, timeout=120, check=False,
+            [
+                npm_path,
+                "install",
+                "-g",
+                "--prefix",
+                str(user_npm_dir),
+                "@anthropic-ai/claude-code",
+                "--ignore-scripts",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
         )
         if result.returncode == 0:
             post = _get_current_claude_version(claude_path) or latest
             print(f"✓ Claude Code updated to {post}")
             return True
 
-        print(f"⚠ Claude Code update failed — continuing with current version: {result.stderr.strip()}")
+        print(
+            f"⚠ Claude Code update failed — continuing with current version: {result.stderr.strip()}"
+        )
         return False
     except Exception:
         return False

--- a/tests/knowledge_builder/test_kb_integration.py
+++ b/tests/knowledge_builder/test_kb_integration.py
@@ -43,7 +43,7 @@ class TestKnowledgeBuilderIntegration:
         mock_run.side_effect = mock_subprocess
 
         # Run workflow
-        builder = KnowledgeBuilder(topic="Test Topic", claude_cmd="claude", output_base=tmp_path)
+        builder = KnowledgeBuilder(topic="Test Topic", agent_cmd="claude", output_base=tmp_path)
         output_dir = builder.build()
 
         # Verify output directory created
@@ -66,7 +66,7 @@ class TestKnowledgeBuilderIntegration:
         """Test that output directory is created with sanitized name."""
         builder = KnowledgeBuilder(
             topic="Test Topic: With Special!@#$% Characters",
-            claude_cmd="claude",
+            agent_cmd="claude",
             output_base=tmp_path,
         )
 
@@ -82,7 +82,7 @@ class TestKnowledgeBuilderIntegration:
         """Test error handling during workflow."""
         mock_run.return_value = MagicMock(returncode=1, stderr="Error")
 
-        builder = KnowledgeBuilder(topic="Test Topic", claude_cmd="claude", output_base=tmp_path)
+        builder = KnowledgeBuilder(topic="Test Topic", agent_cmd="claude", output_base=tmp_path)
 
         with pytest.raises(RuntimeError, match="Knowledge Builder failed"):
             builder.build()
@@ -125,7 +125,7 @@ class TestKnowledgeBuilderIntegration:
         mock_run.side_effect = mock_subprocess
 
         builder = KnowledgeBuilder(
-            topic="Quantum Computing", claude_cmd="claude", output_base=tmp_path
+            topic="Quantum Computing", agent_cmd="claude", output_base=tmp_path
         )
         output_dir = builder.build()
 

--- a/tests/knowledge_builder/test_kb_modules.py
+++ b/tests/knowledge_builder/test_kb_modules.py
@@ -20,7 +20,7 @@ class TestQuestionGenerator:
             stdout="\n".join([f"{i}. Question {i}?" for i in range(1, 11)]),
         )
 
-        gen = QuestionGenerator(claude_cmd="claude")
+        gen = QuestionGenerator(agent_cmd="claude")
         questions = gen.generate_initial_questions("Test Topic")
 
         assert len(questions) == 10
@@ -35,7 +35,7 @@ class TestQuestionGenerator:
             returncode=0, stdout="1. Follow-up 1?\n2. Follow-up 2?\n3. Follow-up 3?"
         )
 
-        gen = QuestionGenerator(claude_cmd="claude")
+        gen = QuestionGenerator(agent_cmd="claude")
         parent = Question(text="Parent question?", depth=0, parent_index=None)
         questions = gen.generate_socratic_questions(parent, 0)
 
@@ -46,7 +46,7 @@ class TestQuestionGenerator:
     @patch("subprocess.run")
     def test_max_depth_limit(self, mock_run):
         """Test that Socratic method stops at depth 3."""
-        gen = QuestionGenerator(claude_cmd="claude")
+        gen = QuestionGenerator(agent_cmd="claude")
         parent = Question(text="Deep question?", depth=3, parent_index=0)
         questions = gen.generate_socratic_questions(parent, 0)
 
@@ -65,7 +65,7 @@ class TestKnowledgeAcquirer:
             stdout="ANSWER: This is the answer.\nSOURCES:\n- https://example.com\n- https://test.org",
         )
 
-        acq = KnowledgeAcquirer(claude_cmd="claude")
+        acq = KnowledgeAcquirer(agent_cmd="claude")
         question = Question(text="What is this?", depth=0, parent_index=None)
         answer, sources = acq.answer_question(question, "Topic")
 
@@ -79,7 +79,7 @@ class TestKnowledgeAcquirer:
         """Test answering when no sources are provided."""
         mock_run.return_value = MagicMock(returncode=0, stdout="ANSWER: Just an answer.")
 
-        acq = KnowledgeAcquirer(claude_cmd="claude")
+        acq = KnowledgeAcquirer(agent_cmd="claude")
         question = Question(text="What?", depth=0, parent_index=None)
         answer, sources = acq.answer_question(question, "Topic")
 
@@ -91,7 +91,7 @@ class TestKnowledgeAcquirer:
         """Test handling of failed answer attempt."""
         mock_run.return_value = MagicMock(returncode=1, stderr="Error")
 
-        acq = KnowledgeAcquirer(claude_cmd="claude")
+        acq = KnowledgeAcquirer(agent_cmd="claude")
         question = Question(text="What?", depth=0, parent_index=None)
         answer, sources = acq.answer_question(question, "Topic")
 

--- a/tests/knowledge_builder/test_rust_expert_scenario.py
+++ b/tests/knowledge_builder/test_rust_expert_scenario.py
@@ -114,7 +114,7 @@ SOURCES:
 
         # Create knowledge builder for Rust
         topic = "Rust programming language tooling, ecosystem, and best practices"
-        builder = KnowledgeBuilder(topic=topic, claude_cmd="claude", output_base=tmp_path)
+        builder = KnowledgeBuilder(topic=topic, agent_cmd="claude", output_base=tmp_path)
 
         # Monkey-patch to generate fewer questions for faster testing
         original_generate = builder.question_gen.generate_initial_questions
@@ -228,7 +228,7 @@ SOURCES:
         mock_run.side_effect = self.mock_subprocess_rust(rust_mock_responses)
 
         topic = "Rust programming language tooling, ecosystem, and best practices"
-        builder = KnowledgeBuilder(topic=topic, claude_cmd="claude", output_base=tmp_path)
+        builder = KnowledgeBuilder(topic=topic, agent_cmd="claude", output_base=tmp_path)
 
         # Limit questions for speed
         original_generate = builder.question_gen.generate_initial_questions
@@ -277,7 +277,7 @@ SOURCES:
         mock_run.side_effect = self.mock_subprocess_rust(rust_mock_responses)
 
         topic = "Rust programming language tooling, ecosystem, and best practices"
-        builder = KnowledgeBuilder(topic=topic, claude_cmd="claude", output_base=tmp_path)
+        builder = KnowledgeBuilder(topic=topic, agent_cmd="claude", output_base=tmp_path)
 
         # Limit for speed
         original_generate = builder.question_gen.generate_initial_questions


### PR DESCRIPTION
## Summary

Makes amplihack fully agent-agnostic. When launched with `amplihack <agent>`, ALL subprocess orchestration now uses that same agent — no more hardcoded "claude" fallbacks.

**Closes #3162** (dev-orchestrator SKILL.md coupled to Claude Code)
**Closes #3163** (4 files hardcode "claude" as fallback agent binary)

## Changes (20 files)

### Core: `get_agent_binary()` helper
- Added `get_agent_binary()` to `src/amplihack/utils/__init__.py` — central function that reads `AMPLIHACK_AGENT_BINARY` env var with warning on fallback

### Python fixes (hardcoded "claude" → env var)
| File | Line | Before | After |
|------|------|--------|-------|
| `meta_delegation/platform_cli.py` | 297 | `or "claude"` | `get_agent_binary()` |
| `fleet/fleet_adopt.py` | 121 | `or "claude"` | `os.environ.get(...)` |
| `utils/claude_cli.py` | 458 | `or "claude"` | `os.environ.get(...)` |
| `launcher/auto_mode.py` | 345-350 | `["claude", ...]` | `["amplihack", agent, ...]` |
| `claude_process.py` (×3 copies) | 207 | `["claude", ...]` | `[os.environ.get(...), ...]` |
| `delegate_response.py` (×3 copies) | 104 | `or "claude"` | warn + default |

### Bash script fixes (explicit guard instead of silent default)
| File | Pattern | Fix |
|------|---------|-----|
| `remote/executor.py` | `${VAR:-claude}` | Guard with warning if unset |
| `multitask/orchestrator.py` | `${VAR:-claude}` | Guard with warning if unset |

### Knowledge builder refactor
- Renamed `claude_cmd` parameter to `agent_cmd` throughout orchestrator.py, question_generator.py, knowledge_acquirer.py
- Updated all 3 test files to use new parameter name

### Documentation: dev-orchestrator SKILL.md
- Replaced 5 "Claude Code" text references with generic "agent session" language
- Removed `CLAUDECODE` env var handling (runtime-specific)
- Replaced `run_in_background` warning with generic "runtime-specific background APIs" warning
- Changed env var table default from `claude` to `Set by launcher`

## Testing
- 25 tests pass (KB modules, KB integration, meta-delegator, auto_mode_log_formatting)
- All ruff checks pass
- Pre-existing pyright errors in amplifier-bundle/docs copies unchanged

## Design Decision
Used **pragmatic fallback** (warn + default to "claude") rather than hard fail when `AMPLIHACK_AGENT_BINARY` is unset, because:
1. Direct Python imports of modules bypass cli.py dispatcher
2. Tests may not set the env var
3. The Rust recipe runner already uses this approach successfully