### PR TITLE
Fix external-runtime orchestrator resolution

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -81,10 +81,12 @@ steps:
   - id: "parse-decomposition"
     type: "bash"
     command: |
-      HELPER_PATH=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/orch_helper.py") || {
-          echo "ERROR: orch_helper.py not found. Set AMPLIHACK_HOME to your amplihack installation root." >&2
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      if [ ! -f "$HELPER_PATH" ]; then
+          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
+          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
           exit 1
-      }
+      fi
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
@@ -130,17 +132,19 @@ steps:
   - id: "activate-workflow"
     type: "bash"
     command: |
-      HELPER_PATH=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/orch_helper.py") || {
-          echo "ERROR: orch_helper.py not found. Set AMPLIHACK_HOME to your amplihack installation root." >&2
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      if [ ! -f "$HELPER_PATH" ]; then
+          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
+          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
           exit 1
-      }
+      fi
       DECOMP_JSON=$(cat <<EOFDECOMP
       {{decomposition_json}}
       EOFDECOMP
       )
       TASK_TYPE={{task_type}}
       FORCE_SINGLE={{force_single_workstream}}
-      HOOKS_DIR=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/amplihack/hooks" 2>/dev/null) || HOOKS_DIR=""
+      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
@@ -216,7 +220,7 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type or task_type == ''"
     command: |
-      TREE_SCRIPT=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/session_tree.py" 2>/dev/null) || TREE_SCRIPT=""
+      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
       SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
 
       if [ -f "$TREE_SCRIPT" ]; then
@@ -343,10 +347,12 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      HELPER_PATH=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/orch_helper.py") || {
-          echo "ERROR: orch_helper.py not found. Set AMPLIHACK_HOME to your amplihack installation root." >&2
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      if [ ! -f "$HELPER_PATH" ]; then
+          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
+          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
           exit 1
-      }
+      fi
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
@@ -834,8 +840,8 @@ steps:
       {{session_info}}
       EOFSESSIONJSON
       )
-      TREE_SCRIPT=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/session_tree.py" 2>/dev/null) || TREE_SCRIPT=""
-      HOOKS_DIR=$(python3 -m amplihack.resolve_bundle_asset "amplifier-bundle/tools/amplihack/hooks" 2>/dev/null) || HOOKS_DIR=""
+      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
+      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
       # Parse session fields and clear workflow semaphore in one Python subprocess.
       # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
       export SESSION_JSON HOOKS_DIR

--- a/src/amplihack/cli.py
+++ b/src/amplihack/cli.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import time
@@ -910,9 +911,9 @@ def _configure_amplihack_marketplace() -> bool:
 
 
 def _fallback_to_directory_copy(reason: str = "Plugin installation failed") -> str:
-    """Copy .claude directory to ~/.amplihack/.claude/ (primary install location).
+    """Stage runtime assets into ~/.amplihack/ (primary install location).
 
-    This is the primary mechanism for deploying amplihack's .claude components
+    This is the primary mechanism for deploying amplihack's runtime components
     to the user's home directory. Used both as a fallback when Claude Code plugin
     installation is unavailable AND as the primary method for amplifier command.
 
@@ -930,13 +931,61 @@ def _fallback_to_directory_copy(reason: str = "Plugin installation failed") -> s
     if os.environ.get("AMPLIHACK_DEBUG", "").lower() == "true":
         print(f"   Reason: {reason}")
 
-    install_dir = str(Path.home() / ".amplihack" / ".claude")
     amplihack_src = Path(amplihack.__file__).parent
-    Path(install_dir).mkdir(parents=True, exist_ok=True)
-    copied = copytree_manifest(str(amplihack_src), install_dir, ".claude")
-    if not copied:
-        print("❌ Failed to copy .claude directory")
+    return str(_stage_home_runtime_assets(amplihack_src))
+
+
+def _sync_home_runtime_directory(source_dir: Path, target_dir: Path, description: str) -> None:
+    """Sync a non-.claude runtime directory into ~/.amplihack."""
+    if not source_dir.exists():
+        print(f"❌ Required runtime directory missing: {source_dir}")
         sys.exit(1)
+
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copytree(source_dir, target_dir, dirs_exist_ok=True)
+    except OSError as exc:
+        print(f"❌ Failed to stage {description} to {target_dir}: {exc}")
+        sys.exit(1)
+
+
+def _resolve_runtime_source_root(amplihack_src: Path) -> Path:
+    """Resolve the source root that contains runtime assets for staging."""
+    candidates = [
+        amplihack_src,
+        amplihack_src.parent.parent,
+    ]
+
+    for candidate in candidates:
+        if (candidate / ".claude").exists():
+            return candidate
+
+    return amplihack_src
+
+
+def _stage_home_runtime_assets(amplihack_src: Path) -> Path:
+    """Stage the runtime layout expected by external-repo workflows into ~/.amplihack."""
+    home_root = Path.home() / ".amplihack"
+    home_root.mkdir(parents=True, exist_ok=True)
+    source_root = _resolve_runtime_source_root(amplihack_src)
+
+    install_dir = home_root / ".claude"
+    copied = copytree_manifest(str(source_root), str(install_dir), ".claude")
+    if not copied:
+        print("❌ Failed to stage amplihack framework to ~/.amplihack/.claude/")
+        sys.exit(1)
+
+    bundle_source = source_root / "amplifier-bundle"
+    _sync_home_runtime_directory(bundle_source, home_root / "amplifier-bundle", "amplifier-bundle/")
+
+    for filename in ("CLAUDE.md", "AMPLIHACK.md"):
+        source_file = source_root / filename
+        if source_file.exists():
+            try:
+                shutil.copy2(source_file, home_root / filename)
+            except OSError as exc:
+                print(f"❌ Failed to stage {filename} to {home_root}: {exc}")
+                sys.exit(1)
 
     return install_dir
 
@@ -1083,14 +1132,14 @@ def _common_launcher_startup(args: "argparse.Namespace") -> None:
 
 
 def _ensure_amplihack_staged() -> None:
-    """Ensure .claude/ files are staged to ~/.amplihack/.claude/ for non-Claude commands.
+    """Ensure runtime assets are staged to ~/.amplihack/ for non-Claude commands.
 
     This function populates the unified staging directory used by copilot, amplifier,
     rustyclawd, and codex commands. Only runs in UVX deployment mode.
 
     The staging process:
-    1. Creates ~/.amplihack/.claude/ if it doesn't exist
-    2. Copies essential framework files using copytree_manifest()
+    1. Creates ~/.amplihack/ if it doesn't exist
+    2. Copies .claude/ and amplifier-bundle/ runtime assets
     3. Exits with code 1 if staging fails
 
     Raises:
@@ -1127,28 +1176,18 @@ def _ensure_amplihack_staged() -> None:
 
     # Debug logging
     if os.environ.get("AMPLIHACK_DEBUG", "").lower() == "true":
-        print("📦 Staging amplihack framework to ~/.amplihack/.claude/")
+        print("📦 Staging amplihack runtime to ~/.amplihack/")
 
     # Determine source directory (package installation)
     import amplihack
 
     amplihack_src = Path(amplihack.__file__).parent
 
-    # Unified staging directory for all commands
-    staging_dir = Path.home() / ".amplihack" / ".claude"
-    staging_dir.mkdir(parents=True, exist_ok=True)
-
-    # Copy .claude/ files to staging directory
-    copied = copytree_manifest(str(amplihack_src), str(staging_dir), ".claude")
-
-    if not copied:
-        print("❌ Failed to stage amplihack framework to ~/.amplihack/.claude/")
-        print("   This is required for amplihack commands to work in UVX mode.")
-        sys.exit(1)
+    staging_dir = _stage_home_runtime_assets(amplihack_src)
 
     # Debug logging
     if os.environ.get("AMPLIHACK_DEBUG", "").lower() == "true":
-        print(f"✓ Staged {len(copied)} directories to {staging_dir}")
+        print(f"✓ Staged amplihack runtime assets to {staging_dir.parent}")
 
     # Configure Claude Code hooks in ~/.claude/settings.json
     from .settings import ensure_settings_json

--- a/src/amplihack/launcher/copilot.py
+++ b/src/amplihack/launcher/copilot.py
@@ -554,12 +554,17 @@ def install_copilot(env: MutableMapping[str, str] | None = None, home: Path | No
     npm_prefix.mkdir(parents=True, exist_ok=True)
 
     try:
-        kwargs = {"check": False}
         if env is not None:
-            kwargs["env"] = effective_env
-        result = subprocess.run(
-            ["npm", "install", "-g", "--prefix", str(npm_prefix), "@github/copilot"], **kwargs
-        )
+            result = subprocess.run(
+                ["npm", "install", "-g", "--prefix", str(npm_prefix), "@github/copilot"],
+                check=False,
+                env=effective_env,
+            )
+        else:
+            result = subprocess.run(
+                ["npm", "install", "-g", "--prefix", str(npm_prefix), "@github/copilot"],
+                check=False,
+            )
         if result.returncode == 0:
             print("✓ Copilot CLI installed")
 
@@ -917,6 +922,57 @@ INSTRUCTIONS_MARKER_START = "<!-- AMPLIHACK_INSTRUCTIONS_START -->"
 INSTRUCTIONS_MARKER_END = "<!-- AMPLIHACK_INSTRUCTIONS_END -->"
 
 
+def _read_text_if_exists(path: Path) -> str:
+    """Read a text file if it exists, otherwise return an empty string."""
+    return path.read_text() if path.exists() else ""
+
+
+def _extract_heading_block(text: str, start_heading: str, end_heading: str) -> str:
+    """Extract a markdown section bounded by two headings."""
+    start = text.find(start_heading)
+    if start == -1:
+        return ""
+
+    block = text[start:]
+    end = block.find(end_heading)
+    if end != -1:
+        block = block[:end]
+
+    return block.strip()
+
+
+def build_copilot_agents_context(claude_dir: Path, preferences_text: str | None = None) -> str:
+    """Build the AGENTS.md context Copilot needs for workflow enforcement."""
+    routing_prompt = _read_text_if_exists(
+        claude_dir / "tools" / "amplihack" / "hooks" / "templates" / "routing_prompt.txt"
+    ).strip()
+    dev_skill = _read_text_if_exists(claude_dir / "skills" / "dev-orchestrator" / "SKILL.md")
+    execution_block = _extract_heading_block(
+        dev_skill, "## Execution Instructions", "## Task Type Classification"
+    )
+
+    sections = [
+        "## Amplihack Copilot Workflow Rules\n\n"
+        "For any DEV, INVESTIGATE, or HYBRID request, invoke "
+        '`Skill(skill="dev-orchestrator")` immediately.\n\n'
+        "After the skill is activated, the next tool call must execute the "
+        '`smart-orchestrator` recipe via `run_recipe_by_name("smart-orchestrator")`.\n\n'
+        "Do not follow the workflow manually and do not fall back to legacy "
+        "`ultrathink` behavior.",
+    ]
+
+    if routing_prompt:
+        sections.append("## Auto-routing prompt\n\n" + routing_prompt)
+
+    if execution_block:
+        sections.append(execution_block)
+
+    if preferences_text:
+        sections.append("## User Preferences\n\n" + preferences_text.strip())
+
+    return "\n\n".join(section for section in sections if section)
+
+
 def generate_copilot_instructions(copilot_home: Path) -> None:
     """Inject amplihack section into ~/.copilot/copilot-instructions.md.
 
@@ -954,7 +1010,8 @@ Read workflow files from `{copilot_home}/workflow/amplihack/` to follow structur
 - `INVESTIGATION_WORKFLOW.md` — Research and exploration (6 phases)
 - `CASCADE_WORKFLOW.md`, `DEBATE_WORKFLOW.md`, `N_VERSION_WORKFLOW.md` — Fault tolerance patterns
 
-For any non-trivial development task, read DEFAULT_WORKFLOW.md and follow its steps.
+    For any non-trivial development or investigation task, use `/dev` (or `Skill(skill="dev-orchestrator")`)
+    so the smart-orchestrator recipe executes the workflow instead of handling it manually.
 
 ## Context
 Read context files from `{copilot_home}/context/amplihack/` for project philosophy and patterns:
@@ -963,11 +1020,12 @@ Read context files from `{copilot_home}/context/amplihack/` for project philosop
 - `TRUST.md` — Anti-sycophancy and direct communication guidelines
 - `USER_PREFERENCES.md` — User-specific preferences (MANDATORY)
 
-## Commands
-Read command definitions from `{copilot_home}/commands/amplihack/` for available capabilities:
-- `ultrathink.md` — Deep analysis orchestration for complex tasks
-- `analyze.md` — Comprehensive code review
-- `improve.md` — Self-improvement and learning capture
+    ## Commands
+    Read command definitions from `{copilot_home}/commands/amplihack/` for available capabilities:
+    - `dev.md` — Primary dev-orchestrator entry point
+    - `ultrathink.md` — Deprecated alias to `/dev`
+    - `analyze.md` — Comprehensive code review
+    - `improve.md` — Self-improvement and learning capture
 
 ## Agents
 Custom agents are available at `{copilot_home}/agents/amplihack/`. Use them via the task tool.
@@ -1177,12 +1235,14 @@ def launch_copilot(args: list[str] | None = None, interactive: bool = True) -> i
         # Generate copilot-instructions.md so copilot knows where everything is
         generate_copilot_instructions(copilot_home)
 
-        # Inject preferences into AGENTS.md for copilot context
+        # Inject workflow instructions and preferences into AGENTS.md for Copilot context.
+        # Copilot's UserPromptSubmit hook is observe-only, so AGENTS.md must carry the
+        # actual routing/workflow instructions up front.
         prefs_file = user_dir / ".claude/context/USER_PREFERENCES.md"
         if not prefs_file.exists():
             prefs_file = claude_dir / "context/USER_PREFERENCES.md"
-        if prefs_file.exists():
-            strategy.inject_context(prefs_file.read_text())
+        preferences_text = prefs_file.read_text() if prefs_file.exists() else None
+        strategy.inject_context(build_copilot_agents_context(claude_dir, preferences_text))
     except Exception as e:
         # Fail gracefully - Copilot will work without preferences
         print(f"Warning: Could not prepare Copilot environment: {e}")

--- a/src/amplihack/runtime_assets.py
+++ b/src/amplihack/runtime_assets.py
@@ -1,0 +1,89 @@
+"""Resolve runtime asset paths for installed and editable amplihack layouts."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+_ASSET_RELATIVE_PATHS: dict[str, tuple[str, ...]] = {
+    "helper-path": ("amplifier-bundle/tools/orch_helper.py",),
+    "session-tree-path": ("amplifier-bundle/tools/session_tree.py",),
+    "hooks-dir": (
+        ".claude/tools/amplihack/hooks",
+        "amplifier-bundle/tools/amplihack/hooks",
+    ),
+}
+
+
+def iter_runtime_roots() -> list[Path]:
+    """Return candidate roots for bundled runtime assets."""
+    roots: list[Path] = []
+
+    env_root = os.environ.get("AMPLIHACK_HOME")
+    if env_root:
+        roots.append(Path(env_root).expanduser())
+
+    roots.append(Path.home() / ".amplihack")
+
+    package_root = Path(__file__).resolve().parent
+    roots.append(package_root)
+
+    repo_root = package_root.parent.parent
+    roots.append(repo_root)
+
+    roots.append(Path.cwd().resolve())
+
+    unique_roots: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        resolved = root.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique_roots.append(resolved)
+
+    return unique_roots
+
+
+def resolve_asset_path(asset_name: str, search_roots: Iterable[Path] | None = None) -> Path:
+    """Resolve the first existing runtime asset path for the requested asset."""
+    if asset_name not in _ASSET_RELATIVE_PATHS:
+        valid = ", ".join(sorted(_ASSET_RELATIVE_PATHS))
+        raise ValueError(f"Unknown asset {asset_name!r}. Expected one of: {valid}")
+
+    roots = list(search_roots) if search_roots is not None else iter_runtime_roots()
+    rel_paths = _ASSET_RELATIVE_PATHS[asset_name]
+
+    for root in roots:
+        base = Path(root).expanduser().resolve()
+        for rel_path in rel_paths:
+            candidate = base / rel_path
+            if candidate.exists():
+                return candidate
+
+    attempted = ", ".join(str(Path(root).expanduser()) for root in roots)
+    raise FileNotFoundError(
+        f"Could not resolve {asset_name} from any runtime root. Checked: {attempted}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for recipe shell commands."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        valid = " | ".join(sorted(_ASSET_RELATIVE_PATHS))
+        print(f"Usage: python -m amplihack.runtime_assets <{valid}>", file=sys.stderr)
+        return 2
+
+    try:
+        print(resolve_asset_path(args[0]))
+    except (FileNotFoundError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_cli_unified_staging.py
+++ b/tests/integration/test_cli_unified_staging.py
@@ -242,6 +242,28 @@ class TestStagingUnitBehavior:
                         assert staging_dir.exists()
                         assert exit_code == 0
 
+    def test_home_runtime_staging_copies_amplifier_bundle(self, tmp_path, monkeypatch):
+        """Runtime staging must populate ~/.amplihack/amplifier-bundle for external repos."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        package_root = tmp_path / "package"
+        bundle_helper = package_root / "amplifier-bundle" / "tools" / "orch_helper.py"
+        bundle_helper.parent.mkdir(parents=True, exist_ok=True)
+        bundle_helper.write_text("# helper\n")
+
+        def mock_copytree(*args, **kwargs):
+            target = Path(args[1])
+            target.mkdir(parents=True, exist_ok=True)
+            return ["tools"]
+
+        from src.amplihack.cli import _stage_home_runtime_assets
+
+        with patch("src.amplihack.cli.copytree_manifest", side_effect=mock_copytree):
+            install_dir = _stage_home_runtime_assets(package_root)
+
+        assert install_dir == tmp_path / ".amplihack" / ".claude"
+        assert (tmp_path / ".amplihack" / "amplifier-bundle" / "tools" / "orch_helper.py").exists()
+
 
 class TestStagingErrorHandling:
     """Test error handling in staging process."""

--- a/tests/test_copilot_workflow_context.py
+++ b/tests/test_copilot_workflow_context.py
@@ -1,0 +1,43 @@
+from src.amplihack.launcher.copilot import (
+    build_copilot_agents_context,
+    generate_copilot_instructions,
+)
+
+
+def test_build_copilot_agents_context_includes_dev_orchestrator_rules(tmp_path):
+    claude_dir = tmp_path / ".claude"
+    routing_prompt = (
+        claude_dir / "tools" / "amplihack" / "hooks" / "templates" / "routing_prompt.txt"
+    )
+    routing_prompt.parent.mkdir(parents=True, exist_ok=True)
+    routing_prompt.write_text('Say "DEV → launching dev-orchestrator" and invoke the skill.')
+
+    skill_md = claude_dir / "skills" / "dev-orchestrator" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text(
+        "# Dev Orchestrator Skill\n\n"
+        "## Execution Instructions\n\n"
+        'Run `run_recipe_by_name("smart-orchestrator")` immediately.\n\n'
+        "## Task Type Classification\n"
+    )
+
+    context = build_copilot_agents_context(claude_dir, "Preference: autonomous")
+
+    assert 'Skill(skill="dev-orchestrator")' in context
+    assert 'run_recipe_by_name("smart-orchestrator")' in context
+    assert "Preference: autonomous" in context
+    assert "Do not follow the workflow manually" in context
+
+
+def test_generate_copilot_instructions_prefers_dev_command(tmp_path):
+    copilot_home = tmp_path / ".copilot"
+    workflow_dir = copilot_home / "workflow" / "amplihack"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "DEFAULT_WORKFLOW.md").write_text("### Step 0:\n### Step 1:\n")
+
+    generate_copilot_instructions(copilot_home)
+
+    instructions = (copilot_home / "copilot-instructions.md").read_text()
+    assert "/dev" in instructions
+    assert "dev-orchestrator" in instructions
+    assert "Deprecated alias to `/dev`" in instructions

--- a/tests/unit/test_runtime_assets.py
+++ b/tests/unit/test_runtime_assets.py
@@ -1,0 +1,41 @@
+from src.amplihack.runtime_assets import resolve_asset_path
+
+
+def test_resolve_asset_path_prefers_home_runtime_root(tmp_path):
+    home_root = tmp_path / "home-runtime"
+    package_root = tmp_path / "package-runtime"
+
+    home_helper = home_root / "amplifier-bundle" / "tools" / "orch_helper.py"
+    home_helper.parent.mkdir(parents=True, exist_ok=True)
+    home_helper.write_text("# home helper\n")
+
+    package_helper = package_root / "amplifier-bundle" / "tools" / "orch_helper.py"
+    package_helper.parent.mkdir(parents=True, exist_ok=True)
+    package_helper.write_text("# package helper\n")
+
+    resolved = resolve_asset_path("helper-path", [home_root, package_root])
+
+    assert resolved == home_helper
+
+
+def test_resolve_asset_path_finds_hooks_in_home_claude_layout(tmp_path):
+    home_root = tmp_path / "home-runtime"
+    hooks_dir = home_root / ".claude" / "tools" / "amplihack" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "dev_intent_router.py").write_text("# hook\n")
+
+    resolved = resolve_asset_path("hooks-dir", [home_root])
+
+    assert resolved == hooks_dir
+
+
+def test_resolve_asset_path_raises_for_missing_assets(tmp_path):
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+
+    try:
+        resolve_asset_path("session-tree-path", [empty_root])
+    except FileNotFoundError as exc:
+        assert "session-tree-path" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError for missing runtime asset")


### PR DESCRIPTION
## Summary
Fixes the external-runtime orchestrator regression cluster behind #3170, #3158, and #3120.

This PR:
- stages full runtime assets into `~/.amplihack`, including `amplifier-bundle/`
- resolves `smart-orchestrator` helper/session-tree/hooks assets from real runtime roots
- injects current `dev-orchestrator` workflow instructions into Copilot context
- adds regression coverage for runtime staging and external resolution behavior

## Testing
- `pytest -q tests/test_copilot_workflow_context.py tests/unit/test_runtime_assets.py tests/integration/test_cli_unified_staging.py::TestStagingUnitBehavior::test_home_runtime_staging_copies_amplifier_bundle tests/test_multitask_orchestrator_local_src_bootstrap.py tests/test_resolve_bundle_asset.py`
- external temp-home smoke validation from outside the repo with `AMPLIHACK_HOME` unset, verifying `helper-path`, `session-tree-path`, and `hooks-dir` resolve from `~/.amplihack`
- commit hooks passed, including `pyright`

## Notes
There is still a separate main-branch orchestrator outage under investigation around Rust recipe-runner CLI compatibility (`#3176`-class behavior). This PR is limited to the external-runtime/Copilot-context fix cluster.