### PR TITLE
fix: skip sessionStart prompt in non-interactive runs

### DIFF
--- a/.claude/tools/amplihack/hooks/session_start.py
+++ b/.claude/tools/amplihack/hooks/session_start.py
@@ -458,6 +458,21 @@ class SessionStartHook(HookProcessor):
                 )
                 return
 
+            stdin = getattr(sys, "stdin", None)
+            if stdin is None or not hasattr(stdin, "isatty") or not stdin.isatty():
+                self.log("Non-interactive session detected - skipping update prompt")
+                print(
+                    f"\n⚠️  .claude/ directory out of date (package: {version_info.package_commit}, project: {version_info.project_commit or 'unknown'})",
+                    file=sys.stderr,
+                )
+                print(
+                    "  Non-interactive session detected - skipping update prompt. "
+                    "Set /amplihack:customize auto_update to always/never or update manually.\n",
+                    file=sys.stderr,
+                )
+                self.save_metric("version_prompt_skipped_non_interactive", True)
+                return
+
             # No preference - prompt user
             print("\n" + "=" * 70, file=sys.stderr)
             print("⚠️  Version Mismatch Detected", file=sys.stderr)
@@ -488,7 +503,13 @@ class SessionStartHook(HookProcessor):
             print("\nChoice (y/n/a/v): ", end="", file=sys.stderr, flush=True)
 
             # 30 second timeout for user response
-            ready, _, _ = select.select([sys.stdin], [], [], 30)
+            try:
+                ready, _, _ = select.select([sys.stdin], [], [], 30)
+            except (AttributeError, OSError, ValueError) as exc:
+                self.log(f"Interactive prompt unavailable - skipping update prompt: {exc}")
+                print("\n\n(non-interactive stdin unavailable - skipping update)\n", file=sys.stderr)
+                self.save_metric("version_prompt_skipped_non_interactive", True)
+                return
 
             if not ready:
                 print("\n\n(timeout - skipping update)\n", file=sys.stderr)

--- a/.claude/tools/amplihack/hooks/tests/test_session_lifecycle.py
+++ b/.claude/tools/amplihack/hooks/tests/test_session_lifecycle.py
@@ -6,6 +6,7 @@ context building, session stop memory store bridge, uncommitted work detection.
 """
 
 import json
+from io import StringIO
 import os
 import sys
 import tempfile
@@ -74,6 +75,39 @@ class TestVersionCheck:
                 hook._check_version_mismatch()
             except Exception:
                 pass  # Expected if internal imports fail; the point is no crash
+
+    def test_noninteractive_version_prompt_skips_select(self, tmp_path):
+        hook = _make_session_start_hook(tmp_path)
+        version_info = MagicMock()
+        version_info.is_mismatched = True
+        version_info.package_commit = "pkg123"
+        version_info.project_commit = "proj456"
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "update_engine": MagicMock(perform_update=MagicMock()),
+                "update_prefs": MagicMock(
+                    load_update_preference=MagicMock(return_value=None),
+                    save_update_preference=MagicMock(),
+                ),
+                "version_checker": MagicMock(
+                    check_version_mismatch=MagicMock(return_value=version_info)
+                ),
+            },
+        ):
+            with patch("sys.stdin", mock_stdin):
+                with patch("select.select") as mock_select:
+                    with patch("sys.stderr", new_callable=StringIO) as stderr:
+                        hook._check_version_mismatch()
+
+        mock_select.assert_not_called()
+        hook.log.assert_any_call("Non-interactive session detected - skipping update prompt")
+        hook.save_metric.assert_any_call("version_prompt_skipped_non_interactive", True)
+        assert "Non-interactive session detected - skipping update prompt" in stderr.getvalue()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- skip the version-mismatch update prompt when session_start is running without an interactive stdin
- treat unavailable stdin/select support as a non-interactive path instead of waiting or crashing
- add lifecycle regression coverage for the non-interactive mismatch case

## Testing
- PYTHONPATH=/home/azureuser/src/amplihack-fix/worktrees/recovery-workflow/src:/home/azureuser/src/amplihack-fix/amplihack-memory-lib/src /home/azureuser/src/amplihack-fix/.venv/bin/python -m pytest -q .claude/tools/amplihack/hooks/tests/test_session_lifecycle.py