### PR TITLE
docs(prerequisites): align Python version guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to amplihack! This guide will help y
 
 ### Prerequisites
 
-- **Python 3.12+**
+- **Python 3.11+**
 - **Node.js 18+**
 - **[uv](https://docs.astral.sh/uv/)** — fast Python package manager
 - **git**


### PR DESCRIPTION
  Fixes #3190

  Summary:
  - Align contributor setup guidance with the existing project runtime requirement.
  - Update `CONTRIBUTING.md` to require Python 3.11+ so it matches `README.md` and `pyproject.toml`.

  Reproduction steps:
  1. Inspect the documented Python prerequisites in `README.md` and `CONTRIBUTING.md`.
  2. Compare them with the package metadata in `pyproject.toml`.

  Before Fix:
  ```text
  README.md:10:**Requires**: Python 3.11+, Node.js 18+, git, [uv](https://docs.astral.sh/uv/).
  README.md:74:- **Runtime**: Python 3.11+, Node.js 18+
  README.md:628:# Requires Python 3.11+, Node.js 18+, git, uv
  CONTRIBUTING.md:9:- **Python 3.12+**
  pyproject.toml:8:requires-python = ">=3.11"
  ```

  After Fix:
  ```text
  README.md:10:**Requires**: Python 3.11+, Node.js 18+, git, [uv](https://docs.astral.sh/uv/).
  README.md:74:- **Runtime**: Python 3.11+, Node.js 18+
  README.md:628:# Requires Python 3.11+, Node.js 18+, git, uv
  CONTRIBUTING.md:9:- **Python 3.11+**
  pyproject.toml:8:requires-python = ">=3.11"
  ```

  Changes:
  - Replace `Python 3.12+` with `Python 3.11+` in `CONTRIBUTING.md` prerequisites.

  Validation:
  - Re-ran targeted grep checks to confirm the mismatch is resolved.
  - Attempted lightweight docs validation via `make docs-build`, but `mkdocs` is not installed in the environment.

  AI disclosure:
  - This change was prepared with assistance from an AI coding agent.
