### PR TITLE
docs(prerequisites): add Rust guidance for WSL

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -149,6 +149,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # git
 sudo apt install git
+
+# Rust/cargo (for recipe runner)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 #### After Installation
@@ -161,6 +164,7 @@ node --version
 npm --version
 uv --version
 git --version
+cargo --version
 ```
 
 ---


### PR DESCRIPTION
## Summary
Fixes #3192.

Adds the missing Rust/cargo installation step and verification command to the WSL Ubuntu section of `docs/PREREQUISITES.md`, matching the required tools list and the Ubuntu/Debian Linux instructions.

## Reproduction
- Inspected `docs/PREREQUISITES.md`.
- Confirmed the required tools table lists `cargo` as required.
- Confirmed the Linux `Ubuntu/Debian` section includes Rust/cargo installation.
- Confirmed the `Windows Subsystem for Linux (WSL)` -> `Ubuntu WSL` section omitted any Rust/cargo install guidance and omitted `cargo --version` from the verify block.

## Before Fix
```text
required_tool_lists_cargo= True
ubuntu_debian_includes_rust= True
wsl_section_includes_rust_guidance= False
```

## After Fix
```text
required_tool_lists_cargo= True
ubuntu_debian_includes_rust= True
wsl_section_includes_rust_guidance= True
markdownlint config parses OK
```

## AI Disclosure
This pull request was prepared with assistance from an AI coding agent.
