### PR TITLE
docs(prerequisites)

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -359,13 +359,13 @@ This requires explicit opt-in for security.
 
 **Purpose:** Enhanced debugging and traffic logging for Claude Code
 
-**Installation (Required):**
+**Installation (Optional):**
 
 ```bash
 npm install -g @mariozechner/claude-trace
 ```
 
-**Note:** This is a **required dependency** as of the simplified implementation. Install it during initial setup.
+**Note:** `claude-trace` is optional during initial setup. If you skip this step, amplihack installs it automatically the first time tracing is needed.
 
 **Documentation:** Part of claude-code ecosystem (https://github.com/mariozechner/claude-trace)
 


### PR DESCRIPTION
  Fixes #3191

  Summary:
  - make the claude-trace setup wording consistent in `docs/PREREQUISITES.md`
  - keep claude-trace optional during initial setup
  - explain that amplihack auto-installs claude-trace on first trace use

  Reproduction steps:
  - open `docs/PREREQUISITES.md`
  - compare the `claude-trace` section with the `Next Steps` checklist

  Before Fix:
  - `docs/PREREQUISITES.md` described claude-trace as `Installation (Required)`
  - the same section said it was a `required dependency`
  - the `Next Steps` section later said `Install claude-trace (optional): Automatically installed on first use`
  - lightweight docs check attempt: `make docs-build` failed because `mkdocs` is not installed in the task environment (`make: mkdocs: No such file or directory`)

  After Fix:
  - the `claude-trace` section now says `Installation (Optional)`
  - the note now explains that skipping manual installation is okay because amplihack installs claude-trace automatically the first time tracing is needed
  - targeted verification confirmed the conflicting required wording is gone:
    - `required_heading_removed=True`
    - `required_note_removed=True`
    - `optional_guidance_present=True`

  Changes:
  - update the `claude-trace` subsection in `docs/PREREQUISITES.md` to match the existing optional/auto-install behavior

  AI disclosure:
  - This change was prepared by an AI coding agent and reviewed locally before submission.
