### PR TITLE
docs(prerequisites): align claude-trace requirement

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -557,7 +557,7 @@ echo "For installation instructions, see docs/PREREQUISITES.md"
 After installing all prerequisites:
 
 1. **Verify installation:** Run `amplihack` to check all tools are detected
-2. **Install claude-trace (optional):** Automatically installed on first use
+2. **Install claude-trace (required):** Install it during initial setup so tracing is available when amplihack needs it
 3. **Configure git:** Set up your name and email
 4. **Start using AmplihHack:** See README.md for usage instructions
 


### PR DESCRIPTION
## Summary
Fixes #3191.

Aligns the `claude-trace` setup guidance in `docs/PREREQUISITES.md` so the document consistently treats it as required, matching the dedicated `claude-trace` section.

## Reproduction
- Inspected `docs/PREREQUISITES.md`.
- Found the dedicated `claude-trace` section says it is a required dependency that should be installed during initial setup.
- Found the post-install checklist still said `claude-trace` was optional and automatically installed on first use.

## Before Fix
```text
required_dependency_note= True
optional_install_phrase_present= True
```
The document described `claude-trace` as both required and optional.

## After Fix
```text
required_dependency_note= True
optional_install_phrase_present= False
```

## Changes
- Reworded the post-install checklist entry to mark `claude-trace` as required.
- Clarified it should be installed during initial setup so the checklist matches the dedicated dependency section.

## AI Disclosure
This pull request was prepared with assistance from an AI coding agent.
