### PR TITLE
docs(contributing): align python version requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to amplihack! This guide will help y
 
 ### Prerequisites
 
-- **Python 3.12+**
+- **Python 3.11+**
 - **Node.js 18+**
 - **[uv](https://docs.astral.sh/uv/)** — fast Python package manager
 - **git**


### PR DESCRIPTION
## What this PR does
- updates  to require Python 3.11+ instead of 3.12+

## Why
 already documents Python 3.11+, and  declares . This change aligns the contributor guide with the actual project requirement.

## Verification
Before:
-  says 
-  says 
-  said 

After:
-  now says 
- 9:- **Python 3.11+** returns the updated prerequisite line