### PR TITLE
fix: skip session start prompts in non-interactive runs

### DIFF
--- a/.claude/tools/amplihack/hooks/session_start.py
+++ b/.claude/tools/amplihack/hooks/session_start.py
@@ -458,6 +458,21 @@ class SessionStartHook(HookProcessor):
                 )
                 return
 
+            stdin = getattr(sys, "stdin", None)
+            if stdin is None or not hasattr(stdin, "isatty") or not stdin.isatty():
+                self.log("Non-interactive session detected - skipping update prompt")
+                print(
+                    f"\n⚠️  .claude/ directory out of date (package: {version_info.package_commit}, project: {version_info.project_commit or 'unknown'})",
+                    file=sys.stderr,
+                )
+                print(
+                    "  Non-interactive session detected - skipping update prompt. "
+                    "Set /amplihack:customize auto_update to always/never or update manually.\n",
+                    file=sys.stderr,
+                )
+                self.save_metric("version_prompt_skipped_non_interactive", True)
+                return
+
             # No preference - prompt user
             print("\n" + "=" * 70, file=sys.stderr)
             print("⚠️  Version Mismatch Detected", file=sys.stderr)
@@ -488,7 +503,13 @@ class SessionStartHook(HookProcessor):
             print("\nChoice (y/n/a/v): ", end="", file=sys.stderr, flush=True)
 
             # 30 second timeout for user response
-            ready, _, _ = select.select([sys.stdin], [], [], 30)
+            try:
+                ready, _, _ = select.select([sys.stdin], [], [], 30)
+            except (AttributeError, OSError, ValueError) as exc:
+                self.log(f"Interactive prompt unavailable - skipping update prompt: {exc}")
+                print("\n\n(non-interactive stdin unavailable - skipping update)\n", file=sys.stderr)
+                self.save_metric("version_prompt_skipped_non_interactive", True)
+                return
 
             if not ready:
                 print("\n\n(timeout - skipping update)\n", file=sys.stderr)

--- a/tests/unit/tools/version_check/test_session_start_noninteractive.py
+++ b/tests/unit/tools/version_check/test_session_start_noninteractive.py
@@ -1,0 +1,54 @@
+"""Regression tests for non-interactive session_start version prompts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(PROJECT_ROOT / ".claude" / "tools" / "amplihack" / "hooks"))
+sys.path.insert(0, str(PROJECT_ROOT / ".claude" / "tools" / "amplihack"))
+
+from session_start import SessionStartHook
+from version_checker import VersionInfo
+
+
+def _make_hook() -> SessionStartHook:
+    hook = SessionStartHook.__new__(SessionStartHook)
+    hook.project_root = PROJECT_ROOT
+    hook.log = MagicMock()
+    hook.save_metric = MagicMock()
+    return hook
+
+
+def test_check_version_mismatch_skips_prompt_for_noninteractive_stdin(capsys):
+    """Headless sessions should not block on select() waiting for input."""
+    hook = _make_hook()
+    version_info = VersionInfo(
+        package_commit="new123",
+        project_commit="old456",
+        is_mismatched=True,
+        package_path=PROJECT_ROOT / ".claude" / "tools" / "amplihack",
+        project_path=PROJECT_ROOT,
+    )
+
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = False
+
+    with patch("version_checker.check_version_mismatch", return_value=version_info):
+        with patch("update_prefs.load_update_preference", return_value=None):
+            with patch("update_engine.perform_update") as mock_update:
+                with patch("sys.stdin", fake_stdin):
+                    with patch(
+                        "select.select",
+                        side_effect=AssertionError(
+                            "select() should not run for non-interactive stdin"
+                        ),
+                    ):
+                        hook._check_version_mismatch()
+
+    stderr = capsys.readouterr().err
+    assert "Non-interactive session detected - skipping update prompt" in stderr
+    mock_update.assert_not_called()
+    hook.save_metric.assert_any_call("version_prompt_skipped_non_interactive", True)


### PR DESCRIPTION
## Summary
- skip version-mismatch prompts when session_start is running without an interactive TTY
- handle unavailable stdin/select failures defensively instead of hanging startup
- add regression coverage for the non-interactive path

## Validation
- /home/azureuser/src/amplihack-fix/.venv/bin/python -m pytest -q tests/unit/tools/version_check/test_session_start_noninteractive.py tests/hooks/test_session_start_strategies.py tests/test_session_start_integration.py tests/workflows/test_session_start_integration.py
