### PR TITLE
Fix contradiction: clarify claude-trace is required, not optional

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -557,7 +557,7 @@ echo "For installation instructions, see docs/PREREQUISITES.md"
 After installing all prerequisites:
 
 1. **Verify installation:** Run `amplihack` to check all tools are detected
-2. **Install claude-trace (optional):** Automatically installed on first use
+2. **Install claude-trace (required):** Follow installation steps in Prerequisites section above
 3. **Configure git:** Set up your name and email
 4. **Start using AmplihHack:** See README.md for usage instructions
 


### PR DESCRIPTION
Fixed documentation contradiction in `PREREQUISITES.md` where `claude-trace` was described as both required and optional.

## Problem
The document contained contradictory statements:
- **Line 368**: "This is a **required dependency**"
- **Line 560**: "Install claude-trace **(optional)**"

This confused beginners about whether claude-trace needs to be installed.

## Solution
Updated line 560 in the "Next Steps" section to align with the main documentation:

**Before:**
> Install claude-trace (optional): Automatically installed on first use

**After:**
> Install claude-trace (required): Follow installation steps in Prerequisites section above

## Result
Documentation now consistently states that claude-trace is a required dependency.

Closes #3191

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`