### PR TITLE
Add Rust/cargo installation to WSL section

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -144,6 +144,10 @@ WSL is detected automatically and will show appropriate Linux-based installation
 sudo apt update
 sudo apt install nodejs npm
 
+# Rust and cargo
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+
 # uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
@@ -159,6 +163,7 @@ Restart your WSL terminal to ensure all tools are in your PATH:
 # Close and reopen your WSL terminal, then verify:
 node --version
 npm --version
+cargo --version
 uv --version
 git --version
 ```


### PR DESCRIPTION
Added missing Rust/cargo installation steps to the WSL section in `PREREQUISITES.md`.

## Problem
The prerequisites table lists `cargo` (Rust package manager) as a required tool with minimum version 1.70+, but the WSL installation section omitted it entirely. Beginners following WSL instructions would install Node.js, npm, uv, and git successfully, but then fail the verification script when it checks for `cargo`.

## Solution
Added Rust/cargo installation to the WSL section:

**Installation:**
```bash
# Rust and cargo
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
source $HOME/.cargo/env
```

**Verification:**
Added `cargo --version` to the verification steps.

## Result
WSL section now matches the Ubuntu/Debian Linux section and includes all required tools.

Closes #3192

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`