### PR TITLE
Fix Python version requirement: unify to 3.12+ across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ systematic software engineering.
 
 **📚 [View Full Documentation](https://rysweet.github.io/amplihack/)**
 
-**Requires**: Python 3.11+, Node.js 18+, git, [uv](https://docs.astral.sh/uv/).
+**Requires**: Python 3.12+, Node.js 18+, git, [uv](https://docs.astral.sh/uv/).
 macOS/Linux/WSL only.
 
 ```sh
@@ -71,7 +71,7 @@ high-quality code.
 
 - **Platform**: macOS, Linux, or Windows via WSL. Native Windows has
   [partial support](#windows-support).
-- **Runtime**: Python 3.11+, Node.js 18+
+- **Runtime**: Python 3.12+, Node.js 18+
 - **Tools**: git, npm, uv ([astral.sh/uv](https://docs.astral.sh/uv/))
 - **Recommended**: Rust/cargo ([rustup.rs](https://rustup.rs/)) — required for
   the Rust recipe runner
@@ -625,7 +625,7 @@ natively.
 **Installation on Windows native:**
 
 ```powershell
-# Requires Python 3.11+, Node.js 18+, git, uv
+# Requires Python 3.12+, Node.js 18+, git, uv
 uvx --from git+https://github.com/rysweet/amplihack amplihack copilot
 ```
 


### PR DESCRIPTION
Fixed documentation conflict where `README.md` specified Python 3.11+ while `CONTRIBUTING.md` specified Python 3.12+.

## Problem
Beginners encountered conflicting Python version requirements:
- **README.md**: Python 3.11+
- **CONTRIBUTING.md**: Python 3.12+

This left users uncertain about which version to install.

## Solution
Updated `README.md` to consistently require Python 3.12+ to match `CONTRIBUTING.md`.

**Changes:**
- Line 10: Python 3.11+ → Python 3.12+
- Line 74: Python 3.11+ → Python 3.12+
- Line 628: Python 3.11+ → Python 3.12+

## Result
All documentation now consistently requires Python 3.12+.

Closes #3190

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`