### PR TITLE
docs: add Rust/cargo installation to WSL section

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -149,6 +149,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # git
 sudo apt install git
+
+# Rust/cargo (for recipe runner)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 #### After Installation
@@ -161,6 +164,7 @@ node --version
 npm --version
 uv --version
 git --version
+cargo --version
 ```
 
 ---


### PR DESCRIPTION
## Summary

Add missing Rust/cargo installation steps to the Windows Subsystem for Linux (WSL) Ubuntu section in PREREQUISITES.md.

## Changes

- Added Rust/cargo installation commands to the WSL Ubuntu section (lines ~145-149)
- Added cargo --version to the verification commands after WSL installation

## Why

This matches the existing Ubuntu/Debian Linux section which already includes Rust/cargo installation. Without this, WSL users who follow the installation guide will encounter a 'cargo: command not found' error when running the verification script.

Fixes #3192