### PR TITLE
docs: clarify claude-trace is recommended not required

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -367,7 +367,7 @@ This requires explicit opt-in for security.
 npm install -g @mariozechner/claude-trace
 ```
 
-**Note:** This is a **required dependency** as of the simplified implementation. Install it during initial setup.
+**Note:** This is a **recommended dependency** for debugging. It will be installed automatically on first use if not present.
 
 **Documentation:** Part of claude-code ecosystem (https://github.com/mariozechner/claude-trace)
 
@@ -559,7 +559,7 @@ echo "For installation instructions, see docs/PREREQUISITES.md"
 After installing all prerequisites:
 
 1. **Verify installation:** Run `amplihack` to check all tools are detected
-2. **Install claude-trace (optional):** Automatically installed on first use
+2. **Install claude-trace (recommended):** Automatically installed on first use
 3. **Configure git:** Set up your name and email
 4. **Start using AmplihHack:** See README.md for usage instructions
 


### PR DESCRIPTION
## Summary

Fixed documentation contradiction about claude-trace dependency.

### Changes
- Changed 'required dependency' to 'recommended dependency' in installation section
- Changed '(optional)' to '(recommended)' in Next Steps section  
- Clarified it auto-installs if not present

### Fixes
Closes #3191