### PR TITLE
fix: validate HOOK_CONFIGS against hooks.json at startup (A/B test B, #3234)

### DIFF
--- a/src/amplihack/__init__.py
+++ b/src/amplihack/__init__.py
@@ -14,6 +14,7 @@ Public API:
     - Main: main (CLI entry point)
 """
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -132,6 +133,161 @@ RUST_HOOK_MAP = {
     "pre_compact.py": "pre-compact",
 }
 
+def _resolve_hooks_json_path():
+    """Locate the canonical hooks.json file.
+
+    Search order:
+    1. Installed location: ~/.amplihack/.claude/tools/amplihack/hooks/hooks.json
+    2. Source tree (development): relative to this file
+
+    Returns:
+        Path to hooks.json, or None if not found.
+    """
+    installed = Path(HOME) / ".amplihack" / ".claude" / "tools" / "amplihack" / "hooks" / "hooks.json"
+    if installed.exists():
+        return installed
+
+    # Development: hooks.json lives in the source tree
+    source = Path(__file__).resolve().parent.parent.parent / ".claude" / "tools" / "amplihack" / "hooks" / "hooks.json"
+    if source.exists():
+        return source
+
+    return None
+
+
+def validate_hook_configs_against_json(hooks_json_path=None):
+    """Validate HOOK_CONFIGS and RUST_HOOK_MAP against hooks.json.
+
+    hooks.json is the canonical source of truth for hook definitions.
+    This function checks that HOOK_CONFIGS (used by the Python installer)
+    and RUST_HOOK_MAP (used by the Rust hook engine) are consistent with it.
+
+    Args:
+        hooks_json_path: Path to hooks.json. If None, auto-discovered.
+
+    Returns:
+        Tuple of (is_valid: bool, errors: list[str]).
+        When is_valid is False, errors contains human-readable descriptions
+        of every divergence found.
+
+    Raises:
+        Nothing — returns errors instead of raising.
+    """
+    errors = []
+
+    if hooks_json_path is None:
+        hooks_json_path = _resolve_hooks_json_path()
+
+    if hooks_json_path is None:
+        errors.append("hooks.json not found — cannot validate HOOK_CONFIGS")
+        return (False, errors)
+
+    try:
+        with open(hooks_json_path, encoding="utf-8") as f:
+            hooks_json = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        errors.append(f"Failed to read hooks.json at {hooks_json_path}: {exc}")
+        return (False, errors)
+
+    # --- Build a normalised view from hooks.json ---
+    # hooks.json structure: { "EventType": [ { "hooks": [ { "command": "...file.py", ... } ] } ] }
+    json_hooks_by_type = {}  # event_type -> list of basenames
+    for event_type, event_configs in hooks_json.items():
+        basenames = []
+        for config in event_configs:
+            for hook in config.get("hooks", []):
+                command = hook.get("command", "")
+                basename = os.path.basename(command)
+                if basename:
+                    basenames.append(basename)
+        if basenames:
+            json_hooks_by_type[event_type] = sorted(basenames)
+
+    # --- Check 1: HOOK_CONFIGS["amplihack"] must match hooks.json ---
+    config_hooks_by_type = {}  # event_type -> list of filenames
+    for hook_info in HOOK_CONFIGS.get("amplihack", []):
+        event_type = hook_info["type"]
+        config_hooks_by_type.setdefault(event_type, []).append(hook_info["file"])
+    for key in config_hooks_by_type:
+        config_hooks_by_type[key] = sorted(config_hooks_by_type[key])
+
+    # Compare event types present
+    json_event_types = set(json_hooks_by_type.keys())
+    config_event_types = set(config_hooks_by_type.keys())
+
+    missing_in_config = json_event_types - config_event_types
+    extra_in_config = config_event_types - json_event_types
+
+    for event_type in sorted(missing_in_config):
+        errors.append(
+            f"HOOK_CONFIGS['amplihack'] is missing event type '{event_type}' "
+            f"that exists in hooks.json"
+        )
+
+    for event_type in sorted(extra_in_config):
+        errors.append(
+            f"HOOK_CONFIGS['amplihack'] has event type '{event_type}' "
+            f"not present in hooks.json"
+        )
+
+    # Compare hook files within shared event types
+    for event_type in sorted(json_event_types & config_event_types):
+        json_files = json_hooks_by_type[event_type]
+        config_files = config_hooks_by_type[event_type]
+
+        if json_files != config_files:
+            errors.append(
+                f"HOOK_CONFIGS['amplihack'] event '{event_type}' has files "
+                f"{config_files} but hooks.json has {json_files}"
+            )
+
+    # --- Check 2: Every amplihack hook file (except workflow_classification_reminder.py)
+    #     should have a RUST_HOOK_MAP entry ---
+    # workflow_classification_reminder.py is documented as Python-only.
+    PYTHON_ONLY_HOOKS = {"workflow_classification_reminder.py"}
+    all_amplihack_files = {h["file"] for h in HOOK_CONFIGS.get("amplihack", [])}
+
+    for hook_file in sorted(all_amplihack_files - PYTHON_ONLY_HOOKS):
+        if hook_file not in RUST_HOOK_MAP:
+            errors.append(
+                f"RUST_HOOK_MAP is missing entry for '{hook_file}' "
+                f"(present in HOOK_CONFIGS['amplihack'])"
+            )
+
+    # Check that RUST_HOOK_MAP doesn't reference files absent from
+    # both HOOK_CONFIGS['amplihack'] and the known Copilot-only set.
+    COPILOT_ONLY_HOOKS = {"session_stop.py"}  # documented in RUST_HOOK_MAP comment
+    for rust_file in sorted(RUST_HOOK_MAP.keys()):
+        if rust_file not in all_amplihack_files and rust_file not in COPILOT_ONLY_HOOKS:
+            errors.append(
+                f"RUST_HOOK_MAP has entry for '{rust_file}' which is not in "
+                f"HOOK_CONFIGS['amplihack'] and not a known Copilot-only hook"
+            )
+
+    return (len(errors) == 0, errors)
+
+
+def _validate_hooks_on_startup():
+    """Run hook config validation at startup and warn on divergence.
+
+    This is called at module import time. It logs warnings to stderr
+    but does not raise — divergence is a configuration bug, not a
+    runtime crash.
+    """
+    is_valid, errors = validate_hook_configs_against_json()
+    if not is_valid:
+        print(
+            "WARNING: HOOK_CONFIGS/RUST_HOOK_MAP diverged from hooks.json:",
+            file=sys.stderr,
+        )
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+
+
+# Validate at import time — catches divergence early.
+_validate_hooks_on_startup()
+
+
 # Import from focused modules
 from .hook_verification import verify_hooks
 from .install import (
@@ -197,6 +353,7 @@ __all__ = [
     "ESSENTIAL_FILES",
     "RUNTIME_DIRS",
     "HOOK_CONFIGS",
+    "validate_hook_configs_against_json",
     "SETTINGS_TEMPLATE",
     # Installation
     "_local_install",

--- a/tests/hooks/test_hook_config_divergence.py
+++ b/tests/hooks/test_hook_config_divergence.py
@@ -1,0 +1,195 @@
+"""Tests for HOOK_CONFIGS / RUST_HOOK_MAP validation against hooks.json.
+
+Bug #3234: HOOK_CONFIGS and RUST_HOOK_MAP are duplicated sources of truth
+with no validation against hooks.json. These tests verify that the new
+validate_hook_configs_against_json() function catches every divergence type.
+"""
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _hooks_json_path():
+    """Return the path to the canonical hooks.json used in the repo."""
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    return repo_root / ".claude" / "tools" / "amplihack" / "hooks" / "hooks.json"
+
+
+def _load_hooks_json():
+    path = _hooks_json_path()
+    assert path.exists(), f"hooks.json not found at {path}"
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — validate_hook_configs_against_json with real data
+# ---------------------------------------------------------------------------
+
+class TestValidateHookConfigsReal:
+    """Validate the ACTUAL HOOK_CONFIGS / RUST_HOOK_MAP against hooks.json."""
+
+    def test_current_configs_are_valid(self):
+        """HOOK_CONFIGS and RUST_HOOK_MAP must match hooks.json right now."""
+        from amplihack import validate_hook_configs_against_json
+
+        is_valid, errors = validate_hook_configs_against_json(
+            hooks_json_path=_hooks_json_path()
+        )
+        assert is_valid, (
+            "HOOK_CONFIGS/RUST_HOOK_MAP diverged from hooks.json:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    def test_hooks_json_event_types_match_hook_configs(self):
+        """Every event type in hooks.json must appear in HOOK_CONFIGS['amplihack']."""
+        from amplihack import HOOK_CONFIGS
+
+        hooks_json = _load_hooks_json()
+        json_events = set(hooks_json.keys())
+        config_events = {h["type"] for h in HOOK_CONFIGS["amplihack"]}
+
+        assert json_events == config_events, (
+            f"Event type mismatch.\n"
+            f"  In hooks.json only: {json_events - config_events}\n"
+            f"  In HOOK_CONFIGS only: {config_events - json_events}"
+        )
+
+    def test_rust_hook_map_covers_all_non_python_only_hooks(self):
+        """RUST_HOOK_MAP must have an entry for every amplihack hook
+        except the documented Python-only ones."""
+        from amplihack import HOOK_CONFIGS, RUST_HOOK_MAP
+
+        python_only = {"workflow_classification_reminder.py"}
+        all_files = {h["file"] for h in HOOK_CONFIGS["amplihack"]}
+
+        missing = (all_files - python_only) - set(RUST_HOOK_MAP.keys())
+        assert not missing, f"RUST_HOOK_MAP missing entries for: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — validate_hook_configs_against_json with synthetic data
+# ---------------------------------------------------------------------------
+
+class TestValidateHookConfigsSynthetic:
+    """Use crafted hooks.json files to prove every divergence type is caught."""
+
+    def _write_hooks_json(self, tmp_path, data):
+        p = tmp_path / "hooks.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        return p
+
+    def test_missing_hooks_json_reports_error(self, tmp_path):
+        from amplihack import validate_hook_configs_against_json
+
+        is_valid, errors = validate_hook_configs_against_json(
+            hooks_json_path=tmp_path / "nonexistent.json"
+        )
+        assert not is_valid
+        assert any("Failed to read" in e or "not found" in e for e in errors)
+
+    def test_invalid_json_reports_error(self, tmp_path):
+        from amplihack import validate_hook_configs_against_json
+
+        bad = tmp_path / "hooks.json"
+        bad.write_text("{invalid json", encoding="utf-8")
+
+        is_valid, errors = validate_hook_configs_against_json(hooks_json_path=bad)
+        assert not is_valid
+        assert any("Failed to read" in e for e in errors)
+
+    def test_extra_event_in_json_caught(self, tmp_path):
+        """hooks.json has an event type not in HOOK_CONFIGS."""
+        from amplihack import HOOK_CONFIGS, validate_hook_configs_against_json
+
+        # Build a hooks.json that matches current HOOK_CONFIGS + one extra
+        hooks_json = _load_hooks_json()
+        hooks_json["NotifyUser"] = [
+            {"hooks": [{"type": "command", "command": "notify.py"}]}
+        ]
+        p = self._write_hooks_json(tmp_path, hooks_json)
+
+        is_valid, errors = validate_hook_configs_against_json(hooks_json_path=p)
+        assert not is_valid
+        assert any("missing event type 'NotifyUser'" in e for e in errors)
+
+    def test_extra_event_in_config_caught(self, tmp_path):
+        """HOOK_CONFIGS has an event type not in hooks.json."""
+        from amplihack import validate_hook_configs_against_json
+
+        # Remove an event from hooks.json
+        hooks_json = _load_hooks_json()
+        del hooks_json["PreCompact"]
+        p = self._write_hooks_json(tmp_path, hooks_json)
+
+        is_valid, errors = validate_hook_configs_against_json(hooks_json_path=p)
+        assert not is_valid
+        assert any("'PreCompact'" in e and "not present in hooks.json" in e for e in errors)
+
+    def test_file_mismatch_within_event_caught(self, tmp_path):
+        """Same event type but different hook files."""
+        from amplihack import validate_hook_configs_against_json
+
+        hooks_json = _load_hooks_json()
+        # Replace a hook file in SessionStart
+        for config in hooks_json["SessionStart"]:
+            for hook in config.get("hooks", []):
+                hook["command"] = "~/.amplihack/.claude/tools/amplihack/hooks/wrong_hook.py"
+        p = self._write_hooks_json(tmp_path, hooks_json)
+
+        is_valid, errors = validate_hook_configs_against_json(hooks_json_path=p)
+        assert not is_valid
+        assert any("SessionStart" in e for e in errors)
+
+    def test_valid_hooks_json_passes(self, tmp_path):
+        """Current hooks.json should pass validation (sanity check)."""
+        from amplihack import validate_hook_configs_against_json
+
+        is_valid, errors = validate_hook_configs_against_json(
+            hooks_json_path=_hooks_json_path()
+        )
+        assert is_valid
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Integration test — startup warning
+# ---------------------------------------------------------------------------
+
+class TestStartupValidation:
+    """Verify _validate_hooks_on_startup emits warnings on divergence."""
+
+    def test_startup_warns_on_divergence(self, capsys):
+        from amplihack import _validate_hooks_on_startup
+
+        # Patch to force a divergence
+        with patch(
+            "amplihack.validate_hook_configs_against_json",
+            return_value=(False, ["fake divergence error"]),
+        ):
+            _validate_hooks_on_startup()
+
+        captured = capsys.readouterr()
+        assert "diverged from hooks.json" in captured.err
+        assert "fake divergence error" in captured.err
+
+    def test_startup_silent_when_valid(self, capsys):
+        from amplihack import _validate_hooks_on_startup
+
+        with patch(
+            "amplihack.validate_hook_configs_against_json",
+            return_value=(True, []),
+        ):
+            _validate_hooks_on_startup()
+
+        captured = capsys.readouterr()
+        assert "diverged" not in captured.err


### PR DESCRIPTION
## Summary

- Added `validate_hook_configs_against_json()` in `src/amplihack/__init__.py` that checks `HOOK_CONFIGS` and `RUST_HOOK_MAP` against the canonical `hooks.json` at import time
- Catches: missing/extra event types, file mismatches within events, missing `RUST_HOOK_MAP` entries, and stale Rust map entries
- Emits warnings to stderr on divergence (does not crash — configuration bugs should be visible, not fatal)
- Added 11 tests covering real-data validation, synthetic divergence scenarios, and startup warning behavior

## Test plan

- [x] All 11 new tests pass (`tests/hooks/test_hook_config_divergence.py`)
- [x] Current `HOOK_CONFIGS`/`RUST_HOOK_MAP` are validated against `hooks.json` and pass
- [ ] Verify no stderr warnings appear during normal `import amplihack`
- [ ] Intentionally break `HOOK_CONFIGS` and confirm warning is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)