### PR TITLE
fix: validate HOOK_CONFIGS against hooks.json at startup (A/B test A, #3234)

### DIFF
--- a/src/amplihack/__init__.py
+++ b/src/amplihack/__init__.py
@@ -132,6 +132,144 @@ RUST_HOOK_MAP = {
     "pre_compact.py": "pre-compact",
 }
 
+def _resolve_hooks_json_path():
+    """Locate hooks.json on disk.
+
+    Search order:
+    1. Installed location: ~/.amplihack/.claude/tools/amplihack/hooks/hooks.json
+    2. Source repo location: <repo_root>/.claude/tools/amplihack/hooks/hooks.json
+
+    Returns:
+        Path to hooks.json, or None if not found.
+    """
+    installed = os.path.join(HOME, ".amplihack", ".claude", "tools", "amplihack", "hooks", "hooks.json")
+    if os.path.isfile(installed):
+        return installed
+
+    # Try repo-relative (for development / CI)
+    repo_candidate = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        ".claude", "tools", "amplihack", "hooks", "hooks.json",
+    )
+    if os.path.isfile(repo_candidate):
+        return repo_candidate
+
+    return None
+
+
+def validate_hook_configs_against_json(hooks_json_path=None):
+    """Validate HOOK_CONFIGS and RUST_HOOK_MAP against hooks.json.
+
+    hooks.json is the canonical source of truth for which hooks exist and their
+    event types, files, timeouts, and matchers.  This function detects divergence
+    so that mismatches are caught at startup rather than silently ignored.
+
+    Args:
+        hooks_json_path: Explicit path to hooks.json (used by tests).
+                         If None, auto-resolved via _resolve_hooks_json_path().
+
+    Returns:
+        Tuple of (valid: bool, errors: list[str]).
+        When valid is False, errors describes each mismatch found.
+
+    Raises:
+        Nothing — callers decide whether to warn or abort.
+    """
+    import json as _json
+
+    if hooks_json_path is None:
+        hooks_json_path = _resolve_hooks_json_path()
+
+    if hooks_json_path is None:
+        return True, []  # hooks.json not available (e.g. pip-installed wheel) — skip
+
+    try:
+        with open(hooks_json_path, encoding="utf-8") as f:
+            hooks_json = _json.load(f)
+    except Exception as exc:
+        return False, [f"Failed to read hooks.json at {hooks_json_path}: {exc}"]
+
+    errors = []
+
+    # --- 1. Validate HOOK_CONFIGS["amplihack"] against hooks.json ---
+    # Build a normalised set of (event_type, filename) from hooks.json
+    json_hooks = set()  # {(event_type, filename)}
+    json_details = {}   # {(event_type, filename): {timeout, matcher}}
+    for event_type, event_configs in hooks_json.items():
+        for config in event_configs:
+            for hook in config.get("hooks", []):
+                cmd = hook.get("command", "")
+                filename = os.path.basename(cmd)
+                json_hooks.add((event_type, filename))
+                json_details[(event_type, filename)] = {
+                    "timeout": hook.get("timeout"),
+                    "matcher": config.get("matcher"),
+                }
+
+    # Build the same set from HOOK_CONFIGS["amplihack"]
+    py_hooks = set()
+    py_details = {}
+    for entry in HOOK_CONFIGS.get("amplihack", []):
+        key = (entry["type"], entry["file"])
+        py_hooks.add(key)
+        py_details[key] = {
+            "timeout": entry.get("timeout"),
+            "matcher": entry.get("matcher"),
+        }
+
+    # Compare sets
+    in_json_not_py = json_hooks - py_hooks
+    in_py_not_json = py_hooks - json_hooks
+
+    for event_type, filename in sorted(in_json_not_py):
+        errors.append(
+            f"Hook ({event_type}, {filename}) present in hooks.json but missing from HOOK_CONFIGS"
+        )
+    for event_type, filename in sorted(in_py_not_json):
+        errors.append(
+            f"Hook ({event_type}, {filename}) present in HOOK_CONFIGS but missing from hooks.json"
+        )
+
+    # Compare details (timeout, matcher) for hooks present in both
+    for key in sorted(py_hooks & json_hooks):
+        py_d = py_details[key]
+        js_d = json_details[key]
+        if py_d["timeout"] != js_d["timeout"]:
+            errors.append(
+                f"Hook {key} timeout mismatch: HOOK_CONFIGS={py_d['timeout']}, hooks.json={js_d['timeout']}"
+            )
+        if py_d["matcher"] != js_d["matcher"]:
+            errors.append(
+                f"Hook {key} matcher mismatch: HOOK_CONFIGS={py_d['matcher']}, hooks.json={js_d['matcher']}"
+            )
+
+    # --- 2. Validate RUST_HOOK_MAP covers all amplihack hooks (except known Python-only) ---
+    # Every file in HOOK_CONFIGS["amplihack"] that has a Rust equivalent should be in RUST_HOOK_MAP.
+    # workflow_classification_reminder.py is explicitly Python-only, so we just verify
+    # that no file in HOOK_CONFIGS is completely absent from RUST_HOOK_MAP without explanation.
+    # (We don't enforce that every hook MUST have a Rust equivalent — only that files
+    #  listed in RUST_HOOK_MAP actually appear in HOOK_CONFIGS or hooks.json.)
+    for rust_file in RUST_HOOK_MAP:
+        # session_stop.py is Copilot-only, noted in the comment — skip it
+        if rust_file == "session_stop.py":
+            continue
+        found_in_configs = any(
+            entry["file"] == rust_file for entry in HOOK_CONFIGS.get("amplihack", [])
+        )
+        found_in_json = any(
+            os.path.basename(hook.get("command", "")) == rust_file
+            for configs in hooks_json.values()
+            for config in configs
+            for hook in config.get("hooks", [])
+        )
+        if not found_in_configs and not found_in_json:
+            errors.append(
+                f"RUST_HOOK_MAP contains '{rust_file}' which is absent from both HOOK_CONFIGS and hooks.json"
+            )
+
+    return len(errors) == 0, errors
+
+
 # Import from focused modules
 from .hook_verification import verify_hooks
 from .install import (
@@ -197,6 +335,7 @@ __all__ = [
     "ESSENTIAL_FILES",
     "RUNTIME_DIRS",
     "HOOK_CONFIGS",
+    "RUST_HOOK_MAP",
     "SETTINGS_TEMPLATE",
     # Installation
     "_local_install",
@@ -210,6 +349,7 @@ __all__ = [
     "update_hook_paths",
     # Hooks
     "verify_hooks",
+    "validate_hook_configs_against_json",
     # Uninstall
     "uninstall",
     "read_manifest",

--- a/src/amplihack/hook_verification.py
+++ b/src/amplihack/hook_verification.py
@@ -12,15 +12,23 @@ Public API (the "studs"):
 import os
 
 # Import constants from package root
-from . import HOME, HOOK_CONFIGS
+from . import HOME, HOOK_CONFIGS, validate_hook_configs_against_json
 
 # Hooks are installed to ~/.amplihack/.claude/ (not ~/.claude/)
 AMPLIHACK_CLAUDE_DIR = os.path.join(HOME, ".amplihack", ".claude")
 
 
 def verify_hooks():
-    """Verify that all hook files exist."""
+    """Verify that all hook files exist and configs match hooks.json."""
     all_exist = True
+
+    # Validate HOOK_CONFIGS / RUST_HOOK_MAP against hooks.json (canonical source)
+    valid, config_errors = validate_hook_configs_against_json()
+    if not valid:
+        all_exist = False
+        print("  HOOK_CONFIGS / RUST_HOOK_MAP diverged from hooks.json:")
+        for err in config_errors:
+            print(f"    - {err}")
 
     for hook_system, hooks in HOOK_CONFIGS.items():
         hooks_dir = os.path.join(AMPLIHACK_CLAUDE_DIR, "tools", hook_system, "hooks")

--- a/src/amplihack/settings.py
+++ b/src/amplihack/settings.py
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 
 # Import constants from package root
-from . import CLAUDE_DIR, HOME, HOOK_CONFIGS, RUST_HOOK_MAP
+from . import CLAUDE_DIR, HOME, HOOK_CONFIGS, RUST_HOOK_MAP, validate_hook_configs_against_json
 
 
 def write_json_atomic(path, data, indent=2):
@@ -390,6 +390,13 @@ def update_hook_paths(settings, hook_system, hooks_to_update, hooks_dir_path, ho
 
 def ensure_settings_json():
     """Ensure settings.json exists with proper hook configuration."""
+    # Validate HOOK_CONFIGS / RUST_HOOK_MAP against hooks.json before configuring
+    valid, config_errors = validate_hook_configs_against_json()
+    if not valid:
+        print("  WARNING: HOOK_CONFIGS / RUST_HOOK_MAP diverged from hooks.json:", file=sys.stderr)
+        for err in config_errors:
+            print(f"    - {err}", file=sys.stderr)
+
     settings_path = os.path.join(CLAUDE_DIR, "settings.json")
 
     # Detect UVX environment - if running from UVX, auto-approve settings modification

--- a/tests/hooks/test_hook_configs_source_of_truth.py
+++ b/tests/hooks/test_hook_configs_source_of_truth.py
@@ -1,0 +1,163 @@
+"""Tests for bug #3234: validate HOOK_CONFIGS and RUST_HOOK_MAP against hooks.json.
+
+Ensures the three sources of truth (HOOK_CONFIGS, RUST_HOOK_MAP, hooks.json)
+never silently diverge.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+
+def _hooks_json_path():
+    """Return the path to hooks.json in the repo."""
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        ".claude", "tools", "amplihack", "hooks", "hooks.json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: current codebase is internally consistent
+# ---------------------------------------------------------------------------
+
+def test_current_configs_match_hooks_json():
+    """HOOK_CONFIGS and RUST_HOOK_MAP must match hooks.json as-is."""
+    from amplihack import validate_hook_configs_against_json
+
+    path = _hooks_json_path()
+    if not os.path.isfile(path):
+        pytest.skip("hooks.json not found in repo tree")
+
+    valid, errors = validate_hook_configs_against_json(hooks_json_path=path)
+    assert valid, "HOOK_CONFIGS/RUST_HOOK_MAP diverge from hooks.json:\n" + "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Test: validation catches a hook added to hooks.json but not HOOK_CONFIGS
+# ---------------------------------------------------------------------------
+
+def test_detects_hook_in_json_not_in_configs(tmp_path):
+    """Adding a hook to hooks.json without updating HOOK_CONFIGS is caught."""
+    from amplihack import validate_hook_configs_against_json
+
+    path = _hooks_json_path()
+    if not os.path.isfile(path):
+        pytest.skip("hooks.json not found in repo tree")
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Inject an extra hook that HOOK_CONFIGS does not know about
+    data["NotifyAdmin"] = [
+        {"hooks": [{"type": "command", "command": "~/.amplihack/.claude/tools/amplihack/hooks/notify_admin.py", "timeout": 5}]}
+    ]
+
+    modified = tmp_path / "hooks.json"
+    modified.write_text(json.dumps(data, indent=2))
+
+    valid, errors = validate_hook_configs_against_json(hooks_json_path=str(modified))
+    assert not valid, "Should detect hook in hooks.json missing from HOOK_CONFIGS"
+    assert any("notify_admin.py" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Test: validation catches a hook in HOOK_CONFIGS but removed from hooks.json
+# ---------------------------------------------------------------------------
+
+def test_detects_hook_in_configs_not_in_json(tmp_path):
+    """Removing a hook from hooks.json without updating HOOK_CONFIGS is caught."""
+    from amplihack import validate_hook_configs_against_json
+
+    path = _hooks_json_path()
+    if not os.path.isfile(path):
+        pytest.skip("hooks.json not found in repo tree")
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Remove PreCompact from hooks.json
+    data.pop("PreCompact", None)
+
+    modified = tmp_path / "hooks.json"
+    modified.write_text(json.dumps(data, indent=2))
+
+    valid, errors = validate_hook_configs_against_json(hooks_json_path=str(modified))
+    assert not valid, "Should detect hook in HOOK_CONFIGS missing from hooks.json"
+    assert any("pre_compact.py" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Test: validation catches timeout mismatch
+# ---------------------------------------------------------------------------
+
+def test_detects_timeout_mismatch(tmp_path):
+    """Changing a timeout in hooks.json without updating HOOK_CONFIGS is caught."""
+    from amplihack import validate_hook_configs_against_json
+
+    path = _hooks_json_path()
+    if not os.path.isfile(path):
+        pytest.skip("hooks.json not found in repo tree")
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Alter the SessionStart timeout from 10 to 999
+    for config in data.get("SessionStart", []):
+        for hook in config.get("hooks", []):
+            hook["timeout"] = 999
+
+    modified = tmp_path / "hooks.json"
+    modified.write_text(json.dumps(data, indent=2))
+
+    valid, errors = validate_hook_configs_against_json(hooks_json_path=str(modified))
+    assert not valid, "Should detect timeout mismatch"
+    assert any("timeout mismatch" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Test: validation catches RUST_HOOK_MAP entry not in HOOK_CONFIGS or JSON
+# ---------------------------------------------------------------------------
+
+def test_detects_orphan_rust_hook_map_entry(tmp_path, monkeypatch):
+    """RUST_HOOK_MAP entry that is in neither HOOK_CONFIGS nor hooks.json is caught."""
+    import amplihack
+
+    path = _hooks_json_path()
+    if not os.path.isfile(path):
+        pytest.skip("hooks.json not found in repo tree")
+
+    # Temporarily add a bogus entry to RUST_HOOK_MAP
+    original = dict(amplihack.RUST_HOOK_MAP)
+    amplihack.RUST_HOOK_MAP["phantom_hook.py"] = "phantom-hook"
+    try:
+        valid, errors = amplihack.validate_hook_configs_against_json(hooks_json_path=path)
+        assert not valid, "Should detect orphan RUST_HOOK_MAP entry"
+        assert any("phantom_hook.py" in e for e in errors)
+    finally:
+        amplihack.RUST_HOOK_MAP.clear()
+        amplihack.RUST_HOOK_MAP.update(original)
+
+
+# ---------------------------------------------------------------------------
+# Test: missing hooks.json is gracefully skipped
+# ---------------------------------------------------------------------------
+
+def test_missing_hooks_json_is_not_an_error():
+    """When hooks.json is absent the validation should pass (not crash)."""
+    from amplihack import validate_hook_configs_against_json
+
+    valid, errors = validate_hook_configs_against_json(hooks_json_path="/nonexistent/hooks.json")
+    # A non-existent explicit path should report an error (can't read it)
+    assert not valid
+
+
+def test_auto_resolve_missing_gracefully(monkeypatch):
+    """When hooks.json cannot be auto-resolved, validation is skipped (pass)."""
+    import amplihack
+    monkeypatch.setattr(amplihack, "_resolve_hooks_json_path", lambda: None)
+    valid, errors = amplihack.validate_hook_configs_against_json()
+    assert valid
+    assert errors == []


### PR DESCRIPTION
## Summary

- Added `validate_hook_configs_against_json()` in `src/amplihack/__init__.py` that cross-checks `HOOK_CONFIGS` and `RUST_HOOK_MAP` against `hooks.json` (the canonical source of truth)
- Validation detects: missing/extra hooks, timeout mismatches, matcher mismatches, and orphan `RUST_HOOK_MAP` entries
- Integrated into `verify_hooks()` and `ensure_settings_json()` so divergence is caught at startup
- Added 7 tests covering: current consistency, added/removed hooks, timeout mismatches, orphan Rust entries, and graceful handling when `hooks.json` is absent

## Test plan

- [x] All 7 new tests pass (`tests/hooks/test_hook_configs_source_of_truth.py`)
- [x] Current HOOK_CONFIGS/RUST_HOOK_MAP/hooks.json are verified consistent
- [x] Validation catches injected divergence (extra hook, removed hook, timeout change, orphan RUST_HOOK_MAP entry)
- [ ] Verify no regressions in existing hook tests

Fixes #3234

🤖 Generated with [Claude Code](https://claude.com/claude-code)