### PR TITLE
fix(code-atlas): remove fast mode, fix relationship mapping

### DIFF
--- a/scripts/atlas/blarify_bridge.py
+++ b/scripts/atlas/blarify_bridge.py
@@ -50,14 +50,8 @@ class BlarifyBridge:
         self.root = root.resolve()
         self.graph = None
 
-    def build(self, hierarchy_only: bool = False) -> "BlarifyBridge":
-        """Build the blarify graph for the project.
-
-        Args:
-            hierarchy_only: If False (default), full build with LSP reference
-                resolution. Gives CALLS, IMPORTS, INSTANTIATES, USES, INHERITS
-                relationships. Slower (minutes for large codebases) but much richer.
-                If True, fast build with definitions only (1-2s).
+    def build(self) -> "BlarifyBridge":
+        """Build the blarify graph for the project (full build with LSP references).
 
         Returns:
             self, for chaining.
@@ -84,10 +78,7 @@ class BlarifyBridge:
             project_files_iterator=iterator,
         )
 
-        if hierarchy_only:
-            self.graph = creator.build_hierarchy_only()
-        else:
-            self.graph = creator.build()
+        self.graph = creator.build()
 
         return self
 
@@ -360,7 +351,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Blarify bridge: extract definitions from code")
     parser.add_argument("root", help="Project root directory")
-    parser.add_argument("--full", action="store_true", help="Full build (with LSP references)")
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
@@ -368,10 +358,9 @@ if __name__ == "__main__":
         print(f"ERROR: {root} is not a directory", file=sys.stderr)
         sys.exit(1)
 
-    mode = "full (with LSP)" if args.full else "hierarchy only"
-    print(f"Building blarify graph for {root} ({mode})...")
+    print(f"Building blarify graph for {root} (full with LSP)...")
     bridge = BlarifyBridge(root)
-    bridge.build(hierarchy_only=not args.full)
+    bridge.build()
 
     defs = bridge.get_all_definitions()
     print(f"Total definitions: {len(defs)}")

--- a/scripts/atlas/python/ast_bindings.py
+++ b/scripts/atlas/python/ast_bindings.py
@@ -29,12 +29,11 @@ from scripts.atlas.common import (
 )
 
 
-def _extract_blarify_definitions(root: Path, hierarchy_only: bool = False) -> tuple[list[dict], list[dict], dict[str, int]]:
+def _extract_blarify_definitions(root: Path) -> tuple[list[dict], list[dict], dict[str, int]]:
     """Extract definitions from all languages using blarify.
 
     Args:
         root: Project root directory.
-        hierarchy_only: If True, skip LSP reference resolution (fast mode).
 
     Returns:
         Tuple of (non_python_definitions, all_relationships, relationship_summary).
@@ -47,7 +46,7 @@ def _extract_blarify_definitions(root: Path, hierarchy_only: bool = False) -> tu
         from scripts.atlas.blarify_bridge import BlarifyBridge
 
         bridge = BlarifyBridge(root)
-        bridge.build(hierarchy_only=hierarchy_only)
+        bridge.build()
 
         all_defs = bridge.to_layer2_definitions()
         all_rels = bridge.get_relationships()
@@ -61,10 +60,9 @@ def _extract_blarify_definitions(root: Path, hierarchy_only: bool = False) -> tu
         print(f"  Blarify: {len(all_defs)} total defs ({lang_summary})")
         print(f"  Blarify: {len(non_python_defs)} non-Python defs for merge")
         if rel_summary.get("total", 0) > 0:
-            code_rels = {k: v for k, v in rel_summary.items()
-                         if k in ("CALLS", "IMPORTS", "INSTANTIATES", "USES", "INHERITS")}
-            rel_parts = ", ".join(f"{k}={v}" for k, v in sorted(code_rels.items()))
-            print(f"  Blarify: {rel_summary['total']} relationships ({rel_parts})")
+            # Show all relationship types found (not just code references)
+            type_parts = ", ".join(f"{k}={v}" for k, v in sorted(rel_summary.items()) if k != "total")
+            print(f"  Blarify: {rel_summary['total']} relationships ({type_parts})")
 
         return non_python_defs, all_rels, rel_summary
 
@@ -73,7 +71,7 @@ def _extract_blarify_definitions(root: Path, hierarchy_only: bool = False) -> tu
         return [], [], {}
 
 
-def extract(manifest: dict, root: Path, hierarchy_only: bool = False) -> dict:
+def extract(manifest: dict, root: Path) -> dict:
     """Extract layer 2 data by parsing all Python files and non-Python via blarify.
 
     Phase 1 (blarify): Extract definitions from ALL languages via tree-sitter.
@@ -84,7 +82,6 @@ def extract(manifest: dict, root: Path, hierarchy_only: bool = False) -> dict:
     Args:
         manifest: Loaded manifest dict.
         root: Project root directory.
-        hierarchy_only: If True, use fast hierarchy-only blarify build.
 
     Returns:
         Layer 2 data dict matching the spec schema.
@@ -93,7 +90,7 @@ def extract(manifest: dict, root: Path, hierarchy_only: bool = False) -> dict:
     py_files = [f for f in manifest["files"] if f["extension"] == ".py"]
 
     # --- Phase 1: Blarify (all languages) ---
-    blarify_defs, blarify_rels, blarify_rel_summary = _extract_blarify_definitions(root, hierarchy_only=hierarchy_only)
+    blarify_defs, blarify_rels, blarify_rel_summary = _extract_blarify_definitions(root)
 
     # --- Phase 2: Python ast.parse() ---
     all_definitions = []
@@ -434,14 +431,10 @@ def extract(manifest: dict, root: Path, hierarchy_only: bool = False) -> dict:
     }
 
     # Include blarify relationship summary as a top-level section
+    # Map all relationship types from blarify (uppercase) to lowercase output keys
     if blarify_rel_summary:
         result["blarify_relationships"] = {
-            "calls": blarify_rel_summary.get("CALLS", 0),
-            "imports": blarify_rel_summary.get("IMPORTS", 0),
-            "instantiates": blarify_rel_summary.get("INSTANTIATES", 0),
-            "uses": blarify_rel_summary.get("USES", 0),
-            "inherits": blarify_rel_summary.get("INHERITS", 0),
-            "total": blarify_rel_summary.get("total", 0),
+            k.lower(): v for k, v in blarify_rel_summary.items()
         }
 
     return result
@@ -514,8 +507,6 @@ def main():
     parser = argparse.ArgumentParser(description="Layer 2: AST+LSP Symbol Bindings")
     parser.add_argument("--root", required=True, help="Project root directory")
     parser.add_argument("--output", required=True, help="Output directory for JSON files")
-    parser.add_argument("--fast", action="store_true",
-                        help="Use hierarchy-only blarify mode (faster, no LSP relationships)")
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
@@ -536,7 +527,7 @@ def main():
         print(f"Manifest: {manifest['total_files']} files")
 
     # Extract layer 2
-    layer_data = extract(manifest, root, hierarchy_only=args.fast)
+    layer_data = extract(manifest, root)
 
     # Write output
     out_path = write_layer_json("layer2_ast_bindings", layer_data, output_dir)
@@ -556,9 +547,9 @@ def main():
     brel = layer_data.get("blarify_relationships")
     if brel and brel.get("total", 0) > 0:
         parts = []
-        for key in ("calls", "imports", "instantiates", "uses", "inherits"):
-            if brel.get(key, 0) > 0:
-                parts.append(f"{key}={brel[key]}")
+        for key, val in sorted(brel.items()):
+            if key != "total" and val > 0:
+                parts.append(f"{key}={val}")
         print(f"  Blarify relationships: {brel['total']} ({', '.join(parts)})")
 
     if layer_data["files_failed_parse"]:

--- a/scripts/atlas/python/user_journeys.py
+++ b/scripts/atlas/python/user_journeys.py
@@ -275,10 +275,7 @@ def _enrich_call_graph_from_blarify(
         import os
 
         bridge = BlarifyBridge(root)
-        # Use hierarchy_only=True here since we only need the call graph data
-        # that was already computed during layer2. Re-doing full LSP would be slow.
-        # Instead, try to get cached relationships.
-        bridge.build(hierarchy_only=True)
+        bridge.build()
         rels = bridge.get_relationships()
         calls = [r for r in rels if r.get("type") == "CALLS"]
 

--- a/scripts/atlas/render.py
+++ b/scripts/atlas/render.py
@@ -196,7 +196,8 @@ class AtlasRenderer:
                 lines.append(f'    <div class="atlas-coverage__bar" '
                              f'style="width:{pct}%"></div>')
                 lines.append(f"    </div>")
-                lines.append(f"    <small>{pct}% coverage</small>")
+                coverage_label = self._coverage_label(layer_def, data, pct)
+                lines.append(f"    <small>{coverage_label}</small>")
                 lines.append("")
 
             # Summary stats
@@ -1210,12 +1211,21 @@ class AtlasRenderer:
             # Directories covered
             return 100.0 if data.get("directories") else None
         elif num == 2:
-            # Files analyzed vs total
+            # Files analyzed at AST level vs total files in the manifest.
+            # For multi-language repos, only Python files get full AST analysis,
+            # so coverage reflects what fraction of ALL code files are analyzed.
             analyzed = data.get("files_analyzed", 0)
-            if analyzed > 0:
+            if analyzed <= 0:
+                return None
+            # Use layer 1 total file count if available for accurate coverage
+            layer1 = self.layers.get("layer1_repo_surface", {})
+            total_files = self._layer1_total_files(layer1)
+            if total_files > 0:
                 failed = len(data.get("files_failed_parse", []))
-                return ((analyzed - failed) / analyzed) * 100
-            return None
+                return ((analyzed - failed) / total_files) * 100
+            # Last fallback: analyzed/analyzed (Python-only view)
+            failed = len(data.get("files_failed_parse", []))
+            return ((analyzed - failed) / analyzed) * 100
         elif num == 7:
             packages = data.get("packages", [])
             return 100.0 if packages else None
@@ -1228,6 +1238,37 @@ class AtlasRenderer:
 
         # Generic: has data = 100%, no data = None
         return 100.0 if data and data != {} else None
+
+    @staticmethod
+    def _layer1_total_files(layer1: dict) -> int:
+        """Get the total file count from layer 1 data.
+
+        Tries completeness.manifest_total first, falls back to summing
+        language file counts.
+        """
+        completeness = layer1.get("completeness", {})
+        total = completeness.get("manifest_total", 0)
+        if total > 0:
+            return total
+        languages = layer1.get("languages", {})
+        return sum(info.get("file_count", 0) for info in languages.values())
+
+    def _coverage_label(self, layer_def: dict, data: dict, pct: int) -> str:
+        """Build a human-readable coverage label for a layer card.
+
+        For layer 2, shows "N/M files analyzed (X%)" so multi-language repos
+        don't misleadingly claim 100% when only Python files are parsed.
+        """
+        num = layer_def["num"]
+        if num == 2:
+            analyzed = data.get("files_analyzed", 0)
+            failed = len(data.get("files_failed_parse", []))
+            effective = analyzed - failed
+            layer1 = self.layers.get("layer1_repo_surface", {})
+            total_files = self._layer1_total_files(layer1)
+            if total_files > 0 and total_files != effective:
+                return f"{effective}/{total_files} files analyzed ({pct}%)"
+        return f"{pct}% coverage"
 
     def _format_summary_stats(self, layer_def: dict, summary: dict) -> list[str]:
         """Format summary stats as compact text items."""

--- a/scripts/atlas/run_all.py
+++ b/scripts/atlas/run_all.py
@@ -72,8 +72,6 @@ def main():
     parser = argparse.ArgumentParser(description="Run all atlas extraction layers")
     parser.add_argument("--root", required=True, help="Project root directory")
     parser.add_argument("--output", required=True, help="Output directory for all JSON files")
-    parser.add_argument("--fast", action="store_true",
-                        help="Use hierarchy-only mode for blarify (faster, no LSP relationships)")
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
@@ -84,8 +82,6 @@ def main():
     python_dir = scripts_dir / "python"
 
     common_args = ["--root", str(root), "--output", str(output_dir)]
-    # --fast is only passed to layer scripts that support it (ast_bindings.py)
-    blarify_args = common_args + (["--fast"] if args.fast else [])
     total_start = time.monotonic()
     timings: list[tuple[str, float]] = []
 
@@ -100,25 +96,23 @@ def main():
     timings.append(("manifest", manifest_elapsed))
 
     # --- Phase 2: layer1, layer2, layer4 ---
-    mode_label = "fast (hierarchy-only)" if args.fast else "full (with LSP)"
-    print(f"\nPhase 2: layer1, layer2, layer4 [{mode_label}]")
-    # Layer 2 with full LSP can take several minutes; increase timeout accordingly
-    layer2_timeout = 120 if args.fast else 600
+    print("\nPhase 2: layer1, layer2, layer4 [full (with LSP)]")
+    layer2_timeout = 600
 
-    # layer1: repo surface (no --fast support)
+    # layer1: repo surface
     ok, elapsed = run_layer(str(python_dir / "repo_surface.py"), common_args, "layer1_repo_surface")
     timings.append(("layer1_repo_surface", elapsed))
     if not ok:
         _abort("layer1_repo_surface", timings, total_start)
 
-    # layer2: ast bindings (supports --fast for hierarchy-only blarify)
-    ok, elapsed = run_layer(str(python_dir / "ast_bindings.py"), blarify_args,
+    # layer2: ast bindings (full LSP build)
+    ok, elapsed = run_layer(str(python_dir / "ast_bindings.py"), common_args,
                             "layer2_ast_bindings", timeout=layer2_timeout)
     timings.append(("layer2_ast_bindings", elapsed))
     if not ok:
         _abort("layer2_ast_bindings", timings, total_start)
 
-    # layer4: runtime topology (no --fast support)
+    # layer4: runtime topology
     layer4_script = python_dir / "runtime_topology.py"
     if layer4_script.exists():
         ok, elapsed = run_layer(str(layer4_script), common_args, "layer4_runtime_topology")
@@ -159,7 +153,7 @@ def main():
     # --- Phase 5: layer8 ---
     print("\nPhase 5: layer8")
     layer8_script = str(python_dir / "user_journeys.py")
-    ok, elapsed = run_layer(layer8_script, common_args, "layer8_user_journeys")
+    ok, elapsed = run_layer(layer8_script, common_args, "layer8_user_journeys", timeout=600)
     timings.append(("layer8_user_journeys", elapsed))
     if not ok:
         _abort("layer8_user_journeys", timings, total_start)


### PR DESCRIPTION
## Summary

Three fixes from azlin friction testing:

1. **Remove --fast mode** — atlas always does full LSP analysis, no shortcuts
2. **Fix relationship type mapping** — was showing calls=0 despite 3,567 actual CALLS relationships
3. **Fix coverage claim** — shows "18/785 files (2.3%)" instead of misleading "100%"

## Test: azlin (full LSP, 397s)
- 13,897 relationships (3,567 CALLS, 649 IMPORTS, 1,410 INSTANTIATES)
- 605 definitions (TS=500, Python=63, JS=22, C#=20)
- 12 PASS, 3 WARN, 0 FAIL

Friction report filed as #3321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)