### PR TITLE
fix(code-atlas): scanner no longer misclassifies platform.system() (#3328)

### DIFF
--- a/scripts/atlas/python/runtime_topology.py
+++ b/scripts/atlas/python/runtime_topology.py
@@ -93,17 +93,28 @@ def _extract_subprocess_calls(tree: ast.Module, filepath: str) -> list[dict]:
         # Check direct match
         matched = None
         for pattern in _SUBPROCESS_PATTERNS:
-            if call_name == pattern or call_name.endswith("." + pattern.split(".")[-1]) and pattern.split(".")[0] in call_name:
+            if call_name == pattern:
+                matched = pattern
+                break
+            # Match fully-qualified call names like `module.os.system`
+            # by verifying the full pattern (e.g. "os.system") appears at the end
+            if call_name.endswith("." + pattern):
                 matched = pattern
                 break
 
         # Also check for bare function name matches (e.g., after `from subprocess import run`)
         if not matched:
             bare = call_name.split(".")[-1]
-            for pattern in _SUBPROCESS_PATTERNS:
-                if bare == pattern.split(".")[-1] and bare in {"run", "Popen", "call", "check_output", "check_call", "system", "popen"}:
-                    matched = pattern
-                    break
+            # Only match bare names when the call has no module qualifier
+            # (i.e. it was imported directly: `from subprocess import run`)
+            # or the qualifier matches the expected module.
+            # Skip bare matching for names that collide with stdlib
+            # (e.g. `system` can be platform.system, not just os.system).
+            if "." not in call_name:
+                for pattern in _SUBPROCESS_PATTERNS:
+                    if bare == pattern.split(".")[-1] and bare in {"run", "Popen", "call", "check_output", "check_call", "system", "popen"}:
+                        matched = pattern
+                        break
 
         if not matched:
             continue


### PR DESCRIPTION
## Summary
- Fixes false positive where `platform.system()` was reported as `os.system()` subprocess call in Layer 4 runtime topology scanner
- Root cause: qualified-name matching used `endswith(".system")` which matched any `*.system()` call, and bare-name fallback matched `"system"` even with a module prefix present
- Fixed both matching paths: qualified names now check the full pattern suffix, bare names only match when no module qualifier exists

## Test plan
- [x] Verified `platform.system()` is no longer flagged, `os.system()` still is
- [x] Verified bare `system()` (from `from os import system`) still detected
- [x] Verified all other subprocess patterns (`subprocess.run`, `Popen`, etc.) still detected
- [x] Full atlas pipeline (`run_all.py`) completes with 0 `platform.system` false positives (202 legitimate calls detected)

Fixes #3328

🤖 Generated with [Claude Code](https://claude.com/claude-code)