### PR TITLE
fix(workflows): stop mutating PR branches for version bumps

### DIFF
--- a/.github/workflows/VERSION_WORKFLOWS.md
+++ b/.github/workflows/VERSION_WORKFLOWS.md
@@ -6,7 +6,7 @@ This document explains the automated version management system for the amplihack
 
 The repository uses a multi-layer approach to ensure that every merge to `main` increments the version number:
 
-1. **PR-level auto-fix** (optional): `version-check.yml`
+1. **PR-level advisory check** (optional): `version-check.yml`
 2. **Merge-level auto-bump** (safety net): `auto-version-on-merge.yml`
 3. **Auto-tagging**: `version-tag.yml`
 
@@ -21,11 +21,11 @@ The repository uses a multi-layer approach to ensure that every merge to `main` 
 **Behavior**:
 
 - Checks if the PR has bumped the version compared to `main`
-- If not bumped, automatically commits a patch version bump to the PR branch
-- Comments on the PR to notify the author
+- If not bumped, emits an advisory warning and step summary
+- Does **not** commit or push changes to the PR branch
 - Allows manual override for minor/major version bumps
 
-**Note**: This is a convenience feature to help developers remember to bump versions. Even if skipped, the merge-level workflow (below) will ensure version is bumped.
+**Note**: This is a convenience signal to help developers remember to bump versions. Even if skipped, the merge-level workflow (below) will ensure version is bumped.
 
 ### 2. Auto Version on Merge (auto-version-on-merge.yml)
 
@@ -82,7 +82,7 @@ To manually bump to a specific version:
 
 1. Edit the `version` field in `pyproject.toml` to your desired version
 2. Commit and push to your PR branch
-3. The workflows will detect the manual bump and skip auto-bumping
+3. The workflows will detect the manual bump and skip merge-time auto-bumping
 
 **Examples**:
 
@@ -104,7 +104,7 @@ To manually bump to a specific version:
 1. Developer creates PR
 2. version-check.yml runs
    ├─ If version bumped: ✅ Pass
-   └─ If not bumped: Auto-bump patch in PR
+   └─ If not bumped: Advisory warning only (no branch mutation)
 3. PR merged to main
 4. auto-version-on-merge.yml runs
    ├─ Check if version bumped in merge
@@ -134,7 +134,7 @@ To manually bump to a specific version:
 1. **PR-level** (`version-check.yml`):
    - Developer convenience
    - Immediate feedback
-   - Allows manual override before merge
+   - Keeps PR diffs clean by avoiding automation commits on contributor branches
 
 2. **Merge-level** (`auto-version-on-merge.yml`):
    - Safety net - ensures version is ALWAYS bumped

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,7 +1,7 @@
-# Version Bump Check with Auto-Fix (PR-level)
-# Ensures that all PRs to main branch bump the version in pyproject.toml
-# Automatically bumps patch version if not bumped by the author
-# Note: Version will also be auto-bumped on merge if not done in PR (see auto-version-on-merge.yml)
+# Version Bump Check (PR-level, advisory only)
+# Checks whether PRs to main bump the version in pyproject.toml.
+# This workflow does not mutate contributor branches.
+# Merge-time auto-version-on-merge.yml remains the safety net if no manual bump is present.
 
 name: Version Check
 
@@ -16,16 +16,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write # Allow auto-fix to commit version bump
-  pull-requests: write # Allow commenting on PR
+  contents: read
 
 jobs:
   check-version-bump:
     name: Check Version Bump
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    outputs:
-      needs-bump: ${{ steps.check.outcome != 'success' }}
 
     steps:
       - name: Checkout PR branch
@@ -33,7 +30,6 @@ jobs:
         with:
           # Fetch full history so we can compare with main branch
           fetch-depth: 0
-          # Use token for auto-fix to work
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
@@ -60,50 +56,13 @@ jobs:
           echo "The version in pyproject.toml has been properly bumped."
           echo "This PR is ready for review and merge."
 
-  auto-fix-version:
-    name: Auto-Fix Version Bump
-    needs: check-version-bump
-    if: needs.check-version-bump.outputs.needs-bump == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Configure Git
+      - name: Advisory message
+        if: steps.check.outcome != 'success'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Auto-bump version
-        id: bump
-        run: |
-          echo "🔧 Automatically bumping patch version..."
-          python scripts/auto_bump_version.py
-
-      - name: Commit and push version bump
-        run: |
-          git add pyproject.toml
-          git commit -m "[skip ci] chore: Auto-bump patch version"
-          git push
-
-      - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🤖 **Auto-fixed version bump**\n\nThe version in `pyproject.toml` has been automatically bumped to the next patch version.\n\nIf you need a minor or major version bump instead, please update `pyproject.toml` manually and push the change.'
-            })
+          echo "::warning::Version was not bumped in this PR. This workflow is advisory-only and will not modify the branch. If this PR merges without a manual bump, auto-version-on-merge.yml will bump main."
+          {
+            echo "### Advisory: version not bumped in PR"
+            echo ""
+            echo "This workflow no longer auto-commits version bumps onto PR branches."
+            echo "If this change merges without a manual version bump, \`auto-version-on-merge.yml\` will apply the patch bump on \`main\`."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- make `version-check.yml` advisory-only for PRs to `main`
- stop auto-committing `pyproject.toml` version bumps onto contributor branches
- update `.github/workflows/VERSION_WORKFLOWS.md` to match the non-mutating behavior and the existing merge-time safety net

## Why
The current PR-time workflow can inject an unrelated `pyproject.toml` change onto otherwise clean PR branches, which blocks the no-unrelated-changes merge criterion. The repository already has `auto-version-on-merge.yml` as the merge-time safety net, so PR-time branch mutation is redundant.

## Validation
- YAML parse of `.github/workflows/version-check.yml`
  - `YAML_OK`
- `uv run pytest tests/unit/test_auto_bump_version.py -q`
  - `14 passed`
