### PR TITLE
fix(security): replace bare eval() with simpleeval in recipe conditions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "neo4j>=5.25.0", # Neo4j graph database (blarify vendored code imports)
     "jedi-language-server>=0.43.1", # Jedi LSP for Python code intelligence
     "docker>=7.1.0", # Docker client for blarify containers
+    "simpleeval>=0.9.13", # Safe expression evaluator for recipe conditions (replaces bare eval)
     "packaging>=21.0", # Semantic version comparison for auto-update
     "tomli>=2.0.0; python_version < '3.11'", # TOML parser for Python <3.11
     "amplihack-agent-eval @ git+https://github.com/rysweet/amplihack-agent-eval.git@d7a28a552bed6e8daa752e465475024b281913f6", # Eval framework

--- a/src/amplihack/recipes/models.py
+++ b/src/amplihack/recipes/models.py
@@ -11,6 +11,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from simpleeval import EvalWithCompoundTypes  # type: ignore[import-untyped]
+
 log = logging.getLogger(__name__)
 
 
@@ -66,11 +68,11 @@ class Step:
         # Coerce booleans to lowercase strings so recipe conditions like
         # ``== 'true'`` work.  Keep numbers as-is for numeric comparisons.
         eval_ctx: dict[str, Any] = {
-            k: str(v).lower() if isinstance(v, bool) else v
-            for k, v in context.items()
+            k: str(v).lower() if isinstance(v, bool) else v for k, v in context.items()
         }
         try:
-            return bool(eval(self.condition.strip(), {"__builtins__": {}}, eval_ctx))  # noqa: S307
+            evaluator = EvalWithCompoundTypes(names=eval_ctx)
+            return bool(evaluator.eval(self.condition.strip()))
         except Exception as exc:
             log.warning(
                 "Step condition %r could not be evaluated: %s — defaulting to True (step will run)",

--- a/tests/unit/recipes/test_models.py
+++ b/tests/unit/recipes/test_models.py
@@ -9,7 +9,7 @@ enables safe string conversion so callers can do str(result)[:500] without error
 
 from __future__ import annotations
 
-from amplihack.recipes.models import RecipeResult, StepResult, StepStatus
+from amplihack.recipes.models import RecipeResult, Step, StepResult, StepStatus, StepType
 
 
 class TestStepResultStr:
@@ -82,12 +82,10 @@ class TestRecipeResultStr:
 class TestEvaluateCondition:
     """Tests for Step.evaluate_condition() — condition evaluation with type coercion."""
 
-    def _step(self, condition: str) -> "Step":
-        from amplihack.recipes.models import Step, StepType
+    def _step(self, condition: str) -> Step:
         return Step(id="test", step_type=StepType.BASH, condition=condition)
 
     def test_no_condition_returns_true(self) -> None:
-        from amplihack.recipes.models import Step, StepType
         step = Step(id="test", step_type=StepType.BASH, condition=None)
         assert step.evaluate_condition({}) is True
 
@@ -137,3 +135,19 @@ class TestEvaluateCondition:
         step = self._step("force == 'true' and count >= 2")
         assert step.evaluate_condition({"force": True, "count": 3}) is True
         assert step.evaluate_condition({"force": False, "count": 3}) is False
+
+    def test_in_operator(self) -> None:
+        step = self._step("'API' in description")
+        assert step.evaluate_condition({"description": "Build an API"}) is True
+        assert step.evaluate_condition({"description": "Build a CLI"}) is False
+
+    def test_import_blocked(self) -> None:
+        """simpleeval must block __import__ — no code execution via conditions."""
+        step = self._step("__import__('os').system('echo pwned')")
+        # Should not execute os.system; returns True (default on eval failure)
+        assert step.evaluate_condition({}) is True
+
+    def test_open_blocked(self) -> None:
+        """simpleeval must block open() — no file access via conditions."""
+        step = self._step("open('/etc/passwd').read()")
+        assert step.evaluate_condition({}) is True

--- a/uv.lock
+++ b/uv.lock
@@ -196,6 +196,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "rich" },
+    { name = "simpleeval" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
@@ -294,6 +295,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'dev'", specifier = ">=13.0.0" },
     { name = "rich", marker = "extra == 'ui'", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "simpleeval", specifier = ">=0.9.13" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tree-sitter", specifier = ">=0.23.2" },
     { name = "tree-sitter-c-sharp", specifier = ">=0.23.1" },
@@ -3136,6 +3138,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
     { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
     { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
+]
+
+[[package]]
+name = "simpleeval"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace unsafe `eval()` in `Step.evaluate_condition()` with `simpleeval.EvalWithCompoundTypes` to eliminate arbitrary code execution risk from recipe condition strings
- Add `simpleeval>=0.9.13` to project dependencies
- Add security regression tests verifying `__import__()` and `open()` are blocked by the new evaluator

Closes #3485

## Changes

| File | Change |
|------|--------|
| `src/amplihack/recipes/models.py` | Replace `eval()` with `EvalWithCompoundTypes`, remove `# noqa: S307` |
| `pyproject.toml` | Add `simpleeval>=0.9.13` dependency |
| `uv.lock` | Lock file updated (simpleeval v1.0.7 added) |
| `tests/unit/recipes/test_models.py` | Add 3 security tests (`test_in_operator`, `test_import_blocked`, `test_open_blocked`); consolidate imports |

## Test plan

- [x] All 24 existing + new tests pass (`pytest tests/unit/recipes/test_models.py` — 24/24)
- [x] Boolean coercion (`True` -> `'true'`) still works
- [x] Numeric comparisons (`count >= 4`) still work
- [x] `is None` checks still work
- [x] `in` operator works (`'API' in description`)
- [x] `__import__('os').system(...)` is blocked (returns True via default-on-error)
- [x] `open('/etc/passwd').read()` is blocked
- [x] `amplihack-memory-lib` version unchanged at v0.2.0 in uv.lock
- [x] Pre-commit hooks pass (ruff, ruff-format, pyright, detect-secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)