### PR TITLE
feat(recipe): add progress reporting banners and progress file lifecycle

### DIFF
--- a/src/amplihack/recipes/rust_runner.py
+++ b/src/amplihack/recipes/rust_runner.py
@@ -13,6 +13,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -264,6 +265,11 @@ def _build_rust_env() -> dict[str, str]:
 
 def _execute_rust_command(cmd: list[str], *, name: str, progress: bool) -> RecipeResult:
     """Run the Rust binary and parse its JSON output into a ``RecipeResult``."""
+    print(
+        f"[recipe-runner] Launching recipe '{name}' (pid {os.getpid()})...",
+        file=sys.stderr,
+        flush=True,
+    )
     return execute_rust_command(cmd, name=name, progress=progress, env_builder=_build_rust_env)
 
 
@@ -290,6 +296,19 @@ def _cleanup_context_spill_dir(tmp_dir: Path) -> None:
 # Public entry point ---------------------------------------------------------
 
 
+def _cleanup_progress_file(recipe_name: str) -> None:
+    """Remove the progress file for a completed recipe run (best-effort)."""
+    try:
+        stem = (
+            Path(recipe_name).stem if ("/" in recipe_name or os.sep in recipe_name) else recipe_name
+        )
+        safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", stem)[:64]
+        path = Path(tempfile.gettempdir()) / f"amplihack-progress-{safe_name}-{os.getpid()}.json"
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def run_recipe_via_rust(
     name: str,
     user_context: dict[str, Any] | None = None,
@@ -300,6 +319,7 @@ def run_recipe_via_rust(
     progress: bool = False,
 ) -> RecipeResult:
     """Execute a recipe using the Rust binary."""
+    print(f"[recipe-runner] Preparing recipe '{name}'...", file=sys.stderr, flush=True)
     binary = _find_rust_binary()
     effective_recipe_dirs = _resolve_effective_recipe_dirs(recipe_dirs, working_dir=working_dir)
     resolved_name = _resolve_recipe_target(
@@ -330,3 +350,4 @@ def run_recipe_via_rust(
         return _execute_rust_command(cmd, name=name, progress=progress)
     finally:
         _cleanup_context_spill_dir(tmp_dir)
+        _cleanup_progress_file(name)

--- a/tests/recipes/test_rust_runner.py
+++ b/tests/recipes/test_rust_runner.py
@@ -1,0 +1,337 @@
+"""Tests for rust_runner.py — startup banners and progress file lifecycle.
+
+Covers:
+- Preparing/launching banners emitted to stderr
+- Progress file cleanup on completion
+- get_recipe_progress() reading from progress files
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amplihack.recipes.rust_runner import (
+    _cleanup_progress_file,
+    run_recipe_via_rust,
+)
+from amplihack.recipes.rust_runner_execution import _write_progress_file
+
+
+@pytest.fixture(autouse=True)
+def _mock_runner_version_check():
+    """Keep tests focused on banners/progress, not version gating."""
+    with patch(
+        "amplihack.recipes.rust_runner.runner_binary.raise_for_runner_version",
+        return_value=None,
+    ):
+        yield
+
+
+def _make_rust_output(*, success: bool = True) -> str:
+    return json.dumps(
+        {
+            "recipe_name": "test-recipe",
+            "success": success,
+            "step_results": [
+                {"step_id": "s1", "status": "Completed", "output": "ok", "error": ""},
+            ],
+            "context": {"result": "done"},
+        }
+    )
+
+
+class TestStartupBanners:
+    """Verify that run_recipe_via_rust emits [recipe-runner] banners to stderr."""
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary",
+        return_value="/usr/bin/recipe-runner-rs",
+    )
+    @patch("subprocess.run")
+    def test_preparing_banner_emitted(self, mock_run, mock_find):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_make_rust_output(), stderr=""
+        )
+
+        captured = io.StringIO()
+        with patch.object(sys, "stderr", captured):
+            run_recipe_via_rust("my-recipe")
+
+        output = captured.getvalue()
+        assert "[recipe-runner] Preparing recipe 'my-recipe'..." in output
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary",
+        return_value="/usr/bin/recipe-runner-rs",
+    )
+    @patch("subprocess.run")
+    def test_launching_banner_emitted(self, mock_run, mock_find):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_make_rust_output(), stderr=""
+        )
+
+        captured = io.StringIO()
+        with patch.object(sys, "stderr", captured):
+            run_recipe_via_rust("my-recipe")
+
+        output = captured.getvalue()
+        assert "[recipe-runner] Launching recipe 'my-recipe'" in output
+        assert f"(pid {os.getpid()})" in output
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary",
+        return_value="/usr/bin/recipe-runner-rs",
+    )
+    @patch("subprocess.run")
+    def test_banners_appear_before_execution(self, mock_run, mock_find):
+        """Both banners should appear: Preparing first, then Launching."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_make_rust_output(), stderr=""
+        )
+
+        captured = io.StringIO()
+        with patch.object(sys, "stderr", captured):
+            run_recipe_via_rust("my-recipe")
+
+        output = captured.getvalue()
+        preparing_pos = output.index("[recipe-runner] Preparing")
+        launching_pos = output.index("[recipe-runner] Launching")
+        assert preparing_pos < launching_pos
+
+
+class TestProgressFileLifecycle:
+    """Verify progress file creation, reading, and cleanup."""
+
+    def test_write_and_read_progress_file(self, tmp_path):
+        """_write_progress_file creates a readable JSON file."""
+        pid = os.getpid()
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            path = _write_progress_file(
+                "smart-orchestrator",
+                current_step=3,
+                total_steps=10,
+                step_name="step-03-build",
+                elapsed_seconds=12.5,
+                status="running",
+                pid=pid,
+            )
+
+        assert path.exists()
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["recipe_name"] == "smart-orchestrator"
+        assert payload["current_step"] == 3
+        assert payload["total_steps"] == 10
+        assert payload["step_name"] == "step-03-build"
+        assert payload["status"] == "running"
+        assert payload["pid"] == pid
+
+    def test_cleanup_progress_file_removes_file(self, tmp_path):
+        """_cleanup_progress_file removes the progress file."""
+        pid = os.getpid()
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            path = _write_progress_file(
+                "test-recipe",
+                current_step=1,
+                total_steps=5,
+                step_name="s1",
+                elapsed_seconds=1.0,
+                status="completed",
+                pid=pid,
+            )
+            assert path.exists()
+
+            _cleanup_progress_file("test-recipe")
+
+        assert not path.exists()
+
+    def test_cleanup_progress_file_noop_when_missing(self):
+        """_cleanup_progress_file does not raise when file is already gone."""
+        # Should not raise
+        _cleanup_progress_file("nonexistent-recipe-xyz")
+
+    def test_write_progress_file_catches_oserror(self, tmp_path):
+        """_write_progress_file is best-effort and catches OSError."""
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value="/nonexistent/impossible/path",
+        ):
+            # Should not raise — catches OSError internally
+            path = _write_progress_file(
+                "test-recipe",
+                current_step=1,
+                total_steps=1,
+                step_name="s1",
+                elapsed_seconds=0.0,
+                status="running",
+            )
+            # Path is returned but may not exist
+            assert isinstance(path, Path)
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary",
+        return_value="/usr/bin/recipe-runner-rs",
+    )
+    @patch("subprocess.run")
+    def test_progress_file_cleaned_on_success(self, mock_run, mock_find, tmp_path):
+        """run_recipe_via_rust cleans up the progress file after completion."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_make_rust_output(), stderr=""
+        )
+
+        pid = os.getpid()
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            # Pre-create a progress file to verify it gets cleaned
+            _write_progress_file(
+                "test-recipe",
+                current_step=1,
+                total_steps=1,
+                step_name="s1",
+                elapsed_seconds=1.0,
+                status="running",
+                pid=pid,
+            )
+            run_recipe_via_rust("test-recipe")
+
+        progress_files = list(tmp_path.glob("amplihack-progress-test_recipe-*.json"))
+        assert len(progress_files) == 0
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary",
+        return_value="/usr/bin/recipe-runner-rs",
+    )
+    @patch("subprocess.run")
+    def test_progress_file_cleaned_on_failure(self, mock_run, mock_find, tmp_path):
+        """Progress file is cleaned even when the recipe fails."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="error: boom"
+        )
+
+        pid = os.getpid()
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            _write_progress_file(
+                "test-recipe",
+                current_step=1,
+                total_steps=1,
+                step_name="s1",
+                elapsed_seconds=1.0,
+                status="running",
+                pid=pid,
+            )
+            with pytest.raises(RuntimeError):
+                run_recipe_via_rust("test-recipe")
+
+        progress_files = list(tmp_path.glob("amplihack-progress-test_recipe-*.json"))
+        assert len(progress_files) == 0
+
+
+class TestGetRecipeProgress:
+    """Tests for get_recipe_progress() in dev_intent_router.
+
+    The dev_intent_router lives under .claude/tools/ (not a regular Python
+    package), so we load it via importlib.util.spec_from_file_location.
+    """
+
+    @staticmethod
+    def _load_router():
+        import importlib.util
+
+        router_path = (
+            Path(__file__).resolve().parents[2]
+            / ".claude"
+            / "tools"
+            / "amplihack"
+            / "hooks"
+            / "dev_intent_router.py"
+        )
+        if not router_path.exists():
+            pytest.skip(f"dev_intent_router.py not found at {router_path}")
+        spec = importlib.util.spec_from_file_location("dev_intent_router", str(router_path))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_returns_none_when_no_files(self, tmp_path):
+        router = self._load_router()
+
+        with patch.object(router._tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = router.get_recipe_progress("nonexistent-recipe")
+
+        assert result is None
+
+    def test_reads_most_recent_progress_file(self, tmp_path):
+        """get_recipe_progress reads the latest progress file."""
+        router = self._load_router()
+
+        # Write a progress file via the execution module
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            _write_progress_file(
+                "smart-orchestrator",
+                current_step=5,
+                total_steps=10,
+                step_name="step-05-build",
+                elapsed_seconds=30.0,
+                status="running",
+                pid=os.getpid(),
+            )
+
+        # Read it via get_recipe_progress
+        with patch.object(router._tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = router.get_recipe_progress("smart-orchestrator")
+
+        assert result is not None
+        assert result["current_step"] == 5
+        assert result["step_name"] == "step-05-build"
+        assert result["status"] == "running"
+
+    def test_returns_expected_schema(self, tmp_path):
+        """get_recipe_progress returns a dict with the expected keys."""
+        router = self._load_router()
+
+        with patch(
+            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+            return_value=str(tmp_path),
+        ):
+            _write_progress_file(
+                "default-workflow",
+                current_step=2,
+                total_steps=5,
+                step_name="step-02",
+                elapsed_seconds=8.0,
+                status="completed",
+                pid=os.getpid(),
+            )
+
+        with patch.object(router._tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = router.get_recipe_progress("default-workflow")
+
+        assert result is not None
+        assert set(result.keys()) == {
+            "current_step",
+            "total_steps",
+            "step_name",
+            "elapsed_seconds",
+            "status",
+        }

--- a/tests/recipes/test_rust_runner_execution.py
+++ b/tests/recipes/test_rust_runner_execution.py
@@ -448,6 +448,12 @@ class TestProgressStreaming:
     )
     @patch("subprocess.Popen")
     def test_progress_mode_writes_progress_file(self, mock_popen, mock_find, tmp_path):
+        """Verify that progress markers in stderr cause progress files to be written.
+
+        Note: run_recipe_via_rust cleans up the progress file on completion,
+        so we intercept _write_progress_file to capture what was written.
+        """
+
         class FakePopen:
             def __init__(self, stdout: str, stderr: str, returncode: int = 0):
                 self.stdout = io.StringIO(stdout)
@@ -462,19 +468,34 @@ class TestProgressStreaming:
             stderr="▶ classify-and-decompose (agent)\n✓ classify-and-decompose\n",
         )
 
-        with patch(
-            "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
-            return_value=str(tmp_path),
+        written_payloads: list[dict] = []
+        original_write = _write_progress_file
+
+        def capture_write(*args, **kwargs):
+            path = original_write(*args, **kwargs)
+            if path.exists():
+                written_payloads.append(json.loads(path.read_text(encoding="utf-8")))
+            return path
+
+        with (
+            patch(
+                "amplihack.recipes.rust_runner_execution.tempfile.gettempdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "amplihack.recipes.rust_runner_execution._write_progress_file",
+                side_effect=capture_write,
+            ),
         ):
             run_recipe_via_rust("smart-orchestrator", progress=True)
 
-        progress_files = list(tmp_path.glob("amplihack-progress-smart_orchestrator-*.json"))
-        assert len(progress_files) == 1
-        payload = json.loads(progress_files[0].read_text(encoding="utf-8"))
-        assert payload["recipe_name"] == "smart-orchestrator"
-        assert payload["current_step"] == 1
-        assert payload["step_name"] == "classify-and-decompose"
-        assert payload["status"] == "completed"
+        assert len(written_payloads) >= 1
+        # The last payload should be the "completed" state
+        last = written_payloads[-1]
+        assert last["recipe_name"] == "smart-orchestrator"
+        assert last["current_step"] == 1
+        assert last["step_name"] == "classify-and-decompose"
+        assert last["status"] == "completed"
 
 
 class TestProgressFiles:


### PR DESCRIPTION
## Summary

- Emit `[recipe-runner] Preparing recipe '<name>'...` and `[recipe-runner] Launching recipe '<name>' (pid N)...` banners to stderr so parent sessions can observe subprocess activity
- Add `_cleanup_progress_file()` to remove progress files on recipe completion (best-effort, catches OSError)
- Update existing progress file test to capture writes before cleanup removes the file

Redo of closed PR #3473.

## Files changed (commit-only)

| File | Change |
|------|--------|
| `src/amplihack/recipes/rust_runner.py` | Preparing/Launching banners, `_cleanup_progress_file()`, cleanup in finally block |
| `tests/recipes/test_rust_runner.py` | **New** - 12 tests: banners (3), progress file lifecycle (6), get_recipe_progress integration (3) |
| `tests/recipes/test_rust_runner_execution.py` | Updated `test_progress_mode_writes_progress_file` to intercept writes before cleanup |

No changes to `models.py`, `parser.py`, `pyproject.toml`, `uv.lock`, or any YAML recipe files.

## What already existed (no changes needed)

- `_write_progress_file()` and `_stream_process_output_with_progress()` in `rust_runner_execution.py`
- `get_recipe_progress()` in `dev_intent_router.py`

## Test evidence

```
tests/recipes/test_rust_runner.py ............                           [ 34%]
tests/recipes/test_rust_runner_execution.py .......................      [100%]
============================== 35 passed in 0.14s ==============================
```

All pre-commit hooks pass (ruff, pyright, ruff-format, secrets detection, print statement check).

## Test plan

- [x] `uv run python -m pytest tests/recipes/test_rust_runner.py -x -q` -- 12 pass
- [x] `uv run python -m pytest tests/recipes/test_rust_runner_execution.py -x -q` -- 23 pass
- [x] Pre-commit hooks green
- [x] `git diff-tree --name-only -r HEAD` shows only 3 files
- [ ] CI green
- [ ] qa-team tests
- [ ] quality-audit 3 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)