### PR TITLE
fix: correct workstream_count routing and scope condition evaluation (#3570)

### DIFF
--- a/amplifier-bundle/recipes/investigation-workflow.yaml
+++ b/amplifier-bundle/recipes/investigation-workflow.yaml
@@ -143,7 +143,10 @@ steps:
 
   - id: "clarify-ambiguities"
     agent: "amplihack:ambiguity"
-    condition: "scope.has_ambiguities"
+    # Guard against scope being empty string (default) or non-dict when
+    # parse_json fails — dot-notation raises AttributeDoesNotExist on
+    # non-dict values. Short-circuit on falsy scope (fix #3570).
+    condition: "scope and scope['has_ambiguities']"
     prompt: |
       The scope definition identified ambiguities that need clarification.
 

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -193,8 +193,11 @@ steps:
           print(f"[dev-orchestrator] force_single_workstream=true — overriding {raw_count} workstreams to 1", file=sys.stderr)
       print(f"[dev-orchestrator] Classified as: {task_type} | Workstreams: {count} — starting execution...", file=sys.stderr)
 
-      # Output workstream count (captured by recipe runner)
-      print(count)
+      # Output workstream count (captured by recipe runner).
+      # Use sys.stdout.write to avoid trailing newline — the recipe runner
+      # stores step output as-is, and a trailing '\n' breaks exact string
+      # comparisons in downstream conditions (fix #3570).
+      sys.stdout.write(str(count))
       PYEOF
     output: "workstream_count"
 
@@ -332,8 +335,10 @@ steps:
     # NOTE: force_single_workstream may be Value::Bool(true) when set via CLI
     # --set (parse_context_value coerces "true" -> Bool). The condition evaluator
     # handles Bool/String cross-type coercion (fix #3069 in recipe-runner-rs).
+    # .strip() on workstream_count is load-bearing — bash step output may
+    # contain trailing whitespace/newlines (fix #3570).
     condition: |
-      'Development' in task_type and ((workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
+      'Development' in task_type and ((workstream_count.strip() == '1' or workstream_count.strip() == '') or force_single_workstream == 'true')
     recipe: "default-workflow"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically via context merging
@@ -342,8 +347,9 @@ steps:
 
   - id: "execute-single-round-1-investigation"
     type: "recipe"
+    # .strip() on workstream_count is load-bearing (fix #3570).
     condition: |
-      'Investigation' in task_type and ((workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
+      'Investigation' in task_type and ((workstream_count.strip() == '1' or workstream_count.strip() == '') or force_single_workstream == 'true')
     recipe: "investigation-workflow"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically via context merging
@@ -356,8 +362,9 @@ steps:
 
   - id: "create-workstreams-config"
     type: "bash"
+    # .strip() on workstream_count is load-bearing (fix #3570).
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
+      ('Development' in task_type or 'Investigation' in task_type) and workstream_count.strip() != '1' and workstream_count.strip() != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
       HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
       if [ ! -f "$HELPER_PATH" ]; then
@@ -399,8 +406,9 @@ steps:
 
   - id: "launch-parallel-round-1"
     type: "bash"
+    # .strip() on workstream_count is load-bearing (fix #3570).
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
+      ('Development' in task_type or 'Investigation' in task_type) and workstream_count.strip() != '1' and workstream_count.strip() != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
       REPO_PATH={{repo_path}}
       WS_FILE={{workstreams_file}}
@@ -467,8 +475,9 @@ steps:
   - id: "execute-single-fallback-blocked-development"
     type: "recipe"
     # Fires when blocked from spawning subworkstreams — adapts to single session
+    # .strip() on workstream_count is load-bearing (fix #3570).
     condition: |
-      'Development' in task_type and 'BLOCKED' in recursion_guard and workstream_count != '1' and workstream_count != ''
+      'Development' in task_type and 'BLOCKED' in recursion_guard and workstream_count.strip() != '1' and workstream_count.strip() != ''
     recipe: "default-workflow"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically.
@@ -477,8 +486,9 @@ steps:
   - id: "execute-single-fallback-blocked-investigation"
     type: "recipe"
     # Fires when blocked from spawning subworkstreams — adapts to single session
+    # .strip() on workstream_count is load-bearing (fix #3570).
     condition: |
-      'Investigation' in task_type and 'BLOCKED' in recursion_guard and workstream_count != '1' and workstream_count != ''
+      'Investigation' in task_type and 'BLOCKED' in recursion_guard and workstream_count.strip() != '1' and workstream_count.strip() != ''
     recipe: "investigation-workflow"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically.

--- a/tests/test_smart_orchestrator_decomposition.py
+++ b/tests/test_smart_orchestrator_decomposition.py
@@ -972,5 +972,64 @@ class TestSummarizeSkipCondition(unittest.TestCase):
         self.assertFalse(self._summarize_should_run('Development', ''))
 
 
+# ---------------------------------------------------------------------------
+# Regression test: trailing whitespace in workstream_count (fix #3570)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkstreamCountTrailingWhitespace(unittest.TestCase):
+    """Verify conditions route correctly when workstream_count has trailing whitespace.
+
+    Root cause of #3570: Python print() appends '\\n' and the recipe runner
+    stores step output as-is.  Old conditions compared workstream_count == '1'
+    which failed for '1\\n', causing misrouting to the parallel path even for
+    single-workstream tasks.
+    """
+
+    def _single_dev_condition(self, workstream_count, force_single="false"):
+        """Simulate execute-single-round-1-development condition (post-fix)."""
+        return (
+            "Development" in "Development"
+            and (
+                (workstream_count.strip() == "1" or workstream_count.strip() == "")
+                or force_single == "true"
+            )
+        )
+
+    def _parallel_condition(self, workstream_count, recursion_guard="ALLOWED", force_single="false"):
+        """Simulate create-workstreams-config / launch-parallel-round-1 condition (post-fix)."""
+        return (
+            workstream_count.strip() != "1"
+            and workstream_count.strip() != ""
+            and "ALLOWED" in recursion_guard
+            and force_single != "true"
+        )
+
+    def test_clean_single_routes_to_single(self):
+        self.assertTrue(self._single_dev_condition("1"))
+        self.assertFalse(self._parallel_condition("1"))
+
+    def test_trailing_newline_routes_to_single(self):
+        """The actual bug from #3570 — '1\\n' must route to single, not parallel."""
+        self.assertTrue(self._single_dev_condition("1\n"))
+        self.assertFalse(self._parallel_condition("1\n"))
+
+    def test_trailing_spaces_routes_to_single(self):
+        self.assertTrue(self._single_dev_condition("1  "))
+        self.assertFalse(self._parallel_condition("1  "))
+
+    def test_leading_whitespace_routes_to_single(self):
+        self.assertTrue(self._single_dev_condition("  1"))
+        self.assertFalse(self._parallel_condition("  1"))
+
+    def test_multi_workstream_with_newline_routes_to_parallel(self):
+        self.assertFalse(self._single_dev_condition("2\n"))
+        self.assertTrue(self._parallel_condition("2\n"))
+
+    def test_empty_routes_to_single(self):
+        self.assertTrue(self._single_dev_condition(""))
+        self.assertFalse(self._parallel_condition(""))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Fix trailing newline in `workstream_count` output that caused misrouting of single-workstream tasks to the parallel path, producing 0 config entries
- Add `.strip()` defense-in-depth to all 7 `workstream_count` condition comparisons in `smart-orchestrator.yaml`
- Fix `scope.has_ambiguities` dot-notation condition in `investigation-workflow.yaml` that failed when `parse_json` produced empty string

## Root Cause

`activate-workflow` used `print(count)` which appends `\n`. The recipe runner stores step output as-is. Downstream conditions compared `workstream_count == '1'`, which failed for `"1\n"`, misrouting single-workstream tasks to the parallel path where 0 config entries were produced — the error reported in #3570.

## Changes

| File | Change |
|------|--------|
| `smart-orchestrator.yaml` | `print(count)` → `sys.stdout.write(str(count))` |
| `smart-orchestrator.yaml` | Added `.strip()` to all 7 `workstream_count` conditions |
| `investigation-workflow.yaml` | `scope.has_ambiguities` → `scope and scope['has_ambiguities']` |
| `test_smart_orchestrator_decomposition.py` | 6 regression tests for trailing whitespace routing |

## Step 13: Local Testing Results

**Test Environment**: worktrees/fix-issue-3570, 2026-03-26
**Tests Executed**:

1. Simple: simpleeval `.strip()` conditions with `"1\n"` → 4/4 assertions passed ✅
2. Complex: `scope and scope['has_ambiguities']` with dict/string/empty → 4/4 passed ✅
3. Full test suite: 112 tests → All pass ✅

**Regressions**: None detected ✅
**Issues Found**: Reviewer identified 15+ similar dot-notation conditions in other recipes → Filed #3578 as follow-up

## Test plan

- [x] Run `pytest tests/test_smart_orchestrator_decomposition.py tests/test_orch_helper.py` — 112 pass
- [x] Verify `simpleeval` handles `.strip()` in `EvalWithCompoundTypes` conditions
- [x] Verify `scope and scope['has_ambiguities']` short-circuits on empty string
- [ ] E2E: Run `smart-orchestrator` recipe on a development task (requires recipe runner env)

Closes #3570

🤖 Generated with [Claude Code](https://claude.com/claude-code)