### PR TITLE
docs: fix pip install recommendation to use uvx in AUTO_MODE.md

### DIFF
--- a/docs/AUTO_MODE.md
+++ b/docs/AUTO_MODE.md
@@ -45,10 +45,14 @@ Auto mode supports an optional interactive terminal UI that displays real-time p
 The UI feature requires the Rich library. Install it with:
 
 ```bash
-# Install with optional UI dependencies
-pip install 'amplihack[ui]'
+# For uvx / uv tool install users (recommended):
+uv tool install --reinstall 'amplihack[ui]'
+# or, to add Rich to an existing uv tool installation:
+uv tool install --reinstall amplihack --with 'rich>=13.0.0'
 
-# Or install Rich directly
+# For pip users:
+pip install 'amplihack[ui]'
+# or:
 pip install 'rich>=13.0.0'
 ```
 
@@ -68,9 +72,9 @@ If you use the `--ui` flag without Rich installed, auto mode will display a help
    Error: No module named 'rich'
 
    To enable TUI mode, install Rich:
+     uv tool install --reinstall 'amplihack[ui]'
+   or (pip):
      pip install 'amplihack[ui]'
-   or:
-     pip install rich>=13.0.0
 
    Continuing in non-UI mode...
 ```


### PR DESCRIPTION
## Summary

Fixes #3433

AUTO_MODE.md recommended `pip install` for Rich/UI dependencies, but most users install amplihack via `uvx` or `uv tool install`. The `pip install` commands install into a different Python environment, so `--ui` would still fail.

## Changes

- Added `uv tool install` commands as the recommended approach for uv users
- Kept `pip install` commands as a secondary option for pip-based installations
- Updated the error message example to show uv-first instructions