### PR TITLE
fix: add safety guards to recipe condition expressions

### DIFF
--- a/amplifier-bundle/recipes/investigation-workflow.yaml
+++ b/amplifier-bundle/recipes/investigation-workflow.yaml
@@ -286,7 +286,7 @@ steps:
 
   - id: "historical-research"
     agent: "amplihack:knowledge-archaeologist"
-    condition: "strategy.historical_context_needed"
+    condition: "strategy and strategy.historical_context_needed"
     prompt: |
       Research historical context for this investigation.
 
@@ -406,7 +406,7 @@ steps:
 
   - id: "deep-dive-specialist"
     agent: "amplihack:security"
-    condition: "strategy.parallel_deployment.specialist_agent"
+    condition: "strategy and strategy.parallel_deployment and strategy.parallel_deployment.specialist_agent"
     prompt: |
       Conduct a SPECIALIST deep dive for this investigation.
 
@@ -776,7 +776,7 @@ steps:
 
   - id: "update-patterns"
     type: "bash"
-    condition: "patterns_analysis.patterns_discovered"
+    condition: "patterns_analysis and patterns_analysis.patterns_discovered"
     command: |
       # Output status - actual file updates handled by synthesis agent
       echo '{"patterns_updated": true, "patterns_path": "{{patterns_path}}", "investigation_type": "{{investigation_type}}"}'

--- a/amplifier-bundle/recipes/n-version-workflow.yaml
+++ b/amplifier-bundle/recipes/n-version-workflow.yaml
@@ -445,7 +445,7 @@ steps:
   # Novel approaches, creative solutions, optimization opportunities
   # ==========================================================================
   - id: "version-4-innovative"
-    condition: "num_versions >= 4"
+    condition: "int(num_versions) >= 4"
     agent: "amplihack:builder"
     prompt: |
       Implement this task using an INNOVATIVE approach.
@@ -508,7 +508,7 @@ steps:
   # Optimize for speed, efficiency, resource usage
   # ==========================================================================
   - id: "version-5-performance"
-    condition: "num_versions >= 5"
+    condition: "int(num_versions) >= 5"
     agent: "amplihack:builder"
     prompt: |
       Implement this task using a PERFORMANCE-FOCUSED approach.
@@ -572,7 +572,7 @@ steps:
   # Rotates to conservative for balance
   # ==========================================================================
   - id: "version-6-additional"
-    condition: "num_versions >= 6"
+    condition: "int(num_versions) >= 6"
     agent: "amplihack:builder"
     prompt: |
       Implement this task with fresh perspective (second conservative pass).
@@ -682,7 +682,7 @@ steps:
   # STEP 12: TEST EXECUTION - VERSION 4 (conditional)
   # ==========================================================================
   - id: "test-version-4"
-    condition: "num_versions >= 4"
+    condition: "int(num_versions) >= 4"
     agent: "amplihack:tester"
     prompt: |
       Execute tests for Version 4 (Innovative approach).
@@ -700,7 +700,7 @@ steps:
   # STEP 13: TEST EXECUTION - VERSION 5 (conditional)
   # ==========================================================================
   - id: "test-version-5"
-    condition: "num_versions >= 5"
+    condition: "int(num_versions) >= 5"
     agent: "amplihack:tester"
     prompt: |
       Execute tests for Version 5 (Performance-focused approach).
@@ -718,7 +718,7 @@ steps:
   # STEP 14: TEST EXECUTION - VERSION 6 (conditional)
   # ==========================================================================
   - id: "test-version-6"
-    condition: "num_versions >= 6"
+    condition: "int(num_versions) >= 6"
     agent: "amplihack:tester"
     prompt: |
       Execute tests for Version 6.
@@ -1034,7 +1034,7 @@ steps:
   # Architect designs the hybrid solution
   # ==========================================================================
   - id: "synthesis-design"
-    condition: "selection_decision.final_selection.type == 'hybrid'"
+    condition: "selection_decision and selection_decision.final_selection and selection_decision.final_selection.type == 'hybrid'"
     agent: "amplihack:architect"
     prompt: |
       Design the HYBRID SYNTHESIS combining best parts of multiple versions.

--- a/amplifier-bundle/recipes/qa-workflow.yaml
+++ b/amplifier-bundle/recipes/qa-workflow.yaml
@@ -75,7 +75,7 @@ steps:
   # Answer directly and clearly (only if classified as Q&A)
   # ==========================================================================
   - id: "provide-response"
-    condition: "classification.is_qa == True"
+    condition: "classification and classification.is_qa == 'true'"
     agent: "amplihack:architect"
     prompt: |
       Answer this question directly and clearly:
@@ -98,7 +98,7 @@ steps:
   # Verify answer fully addresses question or suggest escalation
   # ==========================================================================
   - id: "escalation-check"
-    condition: "classification.is_qa == True"
+    condition: "classification and classification.is_qa == 'true'"
     agent: "amplihack:architect"
     mode: "REVIEW"
     prompt: |
@@ -136,7 +136,7 @@ steps:
   # Compile the response when question was classified as Q&A
   # ==========================================================================
   - id: "compile-output-qa"
-    condition: "classification.is_qa == True"
+    condition: "classification and classification.is_qa == 'true'"
     type: "bash"
     parse_json: true
     command: |
@@ -148,7 +148,7 @@ steps:
   # When question was NOT Q&A, report escalation needed
   # ==========================================================================
   - id: "compile-output-escalation"
-    condition: "classification.is_qa != True"
+    condition: "classification and classification.is_qa != 'true'"
     type: "bash"
     parse_json: true
     command: |


### PR DESCRIPTION
Fixes condition evaluation bugs across three recipe files:

- **investigation-workflow.yaml**: Add falsy guards for dot-notation access (`strategy.X` → `strategy and strategy.X`)
- **qa-workflow.yaml**: Fix `== True` / `!= True` bool comparisons to string `'true'`, add dict guards
- **n-version-workflow.yaml**: Wrap string `num_versions` in `int()` for numeric comparisons, add guard for nested `selection_decision.final_selection.type`

Same class of bugs as #3606.