### PR TITLE
fix: fail explicitly on stale workflow worktrees

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -723,7 +723,8 @@ steps:
   - id: "checkpoint-after-implementation"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}} && \
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "checkpoint-after-implementation" && \
+      cd {{worktree_setup.worktree_path}} && \
       echo "=== Checkpoint: Staging Implementation ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \
@@ -902,7 +903,8 @@ steps:
   - id: "checkpoint-after-review-feedback"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}} && \
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "checkpoint-after-review-feedback" && \
+      cd {{worktree_setup.worktree_path}} && \
       echo "=== Checkpoint: Staging Review Feedback ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \
@@ -1127,6 +1129,7 @@ steps:
   - id: "step-15-commit-push"
     type: "bash"
     command: |
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "step-15-commit-push" && \
       cd {{worktree_setup.worktree_path}} && \
       echo "=== Step 15: Commit and Push ===" && \
       echo "" && \
@@ -1164,6 +1167,7 @@ steps:
   - id: "step-16-create-draft-pr"
     type: "bash"
     command: |
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "step-16-create-draft-pr"
       cd {{worktree_setup.worktree_path}}
       echo "=== Step 16: Creating Draft PR ===" >&2
 
@@ -1509,6 +1513,7 @@ steps:
   - id: "step-18c-push-feedback-changes"
     type: "bash"
     command: |
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "step-18c-push-feedback-changes" && \
       cd {{worktree_setup.worktree_path}} && \
       echo "=== Pushing Review Feedback Changes ===" && \
       git add -A && \
@@ -1605,6 +1610,7 @@ steps:
     type: "bash"
     command: |
       echo "=== ZERO-BS VERIFICATION ===" && \
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "step-19c-zero-bs-verification" && \
       cd {{worktree_setup.worktree_path}} && \
       echo "" && \
       echo "Scanning for Zero-BS violations..." && \
@@ -1699,6 +1705,7 @@ steps:
   - id: "step-20b-push-cleanup"
     type: "bash"
     command: |
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "step-20b-push-cleanup" && \
       cd {{worktree_setup.worktree_path}} && \
       echo "=== Pushing Cleanup Changes ===" && \
       git add -A && \
@@ -1784,6 +1791,7 @@ steps:
   - id: "step-21-pr-ready"
     type: "bash"
     command: |
+      PYTHONPATH="${AMPLIHACK_HOME:?AMPLIHACK_HOME is required for worktree validation}/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m amplihack.recipes.worktree_guard --repo-path "{{repo_path}}" --worktree-path "{{worktree_setup.worktree_path}}" --step-id "step-21-pr-ready" && \
       cd {{worktree_setup.worktree_path}} && \
       echo "=== Step 20: Converting PR to Ready ===" && \
       echo "" && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "amplihack"
-version = "0.6.100"
+version = "0.6.101"
 description = "Amplifier bundle for agentic coding with comprehensive skills, recipes, and workflows"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/amplihack/recipes/rust_runner_copilot.py
+++ b/src/amplihack/recipes/rust_runner_copilot.py
@@ -91,22 +91,85 @@ def _normalize_copilot_cli_args(args: list[str]) -> list[str]:
 
 
 def _build_copilot_wrapper_source(real_binary: str) -> str:
-    module_path = Path(__file__).resolve()
     return f"""#!/usr/bin/env python3
-import importlib.util
 import subprocess
 import sys
 
 REAL_BINARY = {real_binary!r}
-MODULE_PATH = {str(module_path)!r}
+
+def _has_explicit_copilot_permission(token, *, category):
+    if category == "tool":
+        prefixes = ("--allow-all-tools", "--allow-tool", "--deny-tool")
+    elif category == "path":
+        prefixes = ("--allow-all-paths", "--allow-path", "--deny-path")
+    else:
+        raise ValueError(f"Unsupported Copilot permission category: {{category}}")
+
+    return any(token == prefix or token.startswith(f"{{prefix}}=") for prefix in prefixes)
+
+def _extract_copilot_prompt_parts(args):
+    normalized = []
+    system_prompt_parts = []
+    prompt_parts = []
+    saw_tool_permissions = False
+    saw_path_permissions = False
+    i = 0
+
+    while i < len(args):
+        token = args[i]
+        if token in {{"--system-prompt", "--append-system-prompt"}}:
+            if i + 1 < len(args):
+                system_prompt_parts.append(args[i + 1])
+            i += 2
+            continue
+        if token.startswith("--system-prompt=") or token.startswith("--append-system-prompt="):
+            _, _, value = token.partition("=")
+            if value:
+                system_prompt_parts.append(value)
+            i += 1
+            continue
+        if token in {{"-p", "--prompt"}}:
+            if i + 1 < len(args):
+                prompt_parts.append(args[i + 1])
+            i += 2
+            continue
+        if token.startswith("--prompt="):
+            _, _, value = token.partition("=")
+            if value:
+                prompt_parts.append(value)
+            i += 1
+            continue
+        if _has_explicit_copilot_permission(token, category="tool"):
+            saw_tool_permissions = True
+        if _has_explicit_copilot_permission(token, category="path"):
+            saw_path_permissions = True
+        normalized.append(token)
+        i += 1
+
+    return normalized, system_prompt_parts, prompt_parts, saw_tool_permissions, saw_path_permissions
 
 def normalize(args):
-    spec = importlib.util.spec_from_file_location("amplihack_rust_runner_copilot", MODULE_PATH)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Could not load compatibility module from {{MODULE_PATH}}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module._normalize_copilot_cli_args(args)
+    (
+        normalized,
+        system_prompt_parts,
+        prompt_parts,
+        saw_tool_permissions,
+        saw_path_permissions,
+    ) = _extract_copilot_prompt_parts(args)
+
+    prefix = []
+    if not saw_tool_permissions:
+        prefix.append("--allow-all-tools")
+    if not saw_path_permissions:
+        prefix.append("--allow-all-paths")
+
+    merged_parts = system_prompt_parts + prompt_parts
+    if merged_parts:
+        merged_prompt = "\\n\\n".join(part for part in merged_parts if part)
+        if merged_prompt:
+            normalized.extend(["-p", merged_prompt])
+
+    return prefix + normalized
 
 
 def main():

--- a/src/amplihack/recipes/worktree_guard.py
+++ b/src/amplihack/recipes/worktree_guard.py
@@ -1,0 +1,176 @@
+"""Explicit validation for workflow worktree paths."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class WorktreeEntry:
+    """A single entry from ``git worktree list --porcelain``."""
+
+    path: Path
+    prunable: bool
+
+
+def _format_entries(entries: list[WorktreeEntry]) -> str:
+    if not entries:
+        return "  (no registered worktrees found)"
+    return "\n".join(
+        f"  - {entry.path}{' [prunable]' if entry.prunable else ''}" for entry in entries
+    )
+
+
+def _die(
+    *, step_id: str, reason: str, repo_path: Path, worktree_path: Path, entries: list[WorktreeEntry]
+) -> "None":
+    print(
+        (
+            f"ERROR [{step_id}]: workflow worktree validation failed for '{worktree_path}'.\n"
+            f"Reason: {reason}\n"
+            "This workflow run has stale worktree bookkeeping. "
+            "Refusing to silently fall back to the repository root.\n"
+            f"Repository root: {repo_path}\n"
+            "Registered worktrees:\n"
+            f"{_format_entries(entries)}\n"
+            "Repair the missing/pruned worktree or rerun step-04-setup-worktree before continuing."
+        ),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+def _list_worktrees(repo_path: Path) -> list[WorktreeEntry]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            (
+                "ERROR: failed to enumerate git worktrees for "
+                f"'{repo_path}':\n{result.stderr.strip() or result.stdout.strip()}"
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    entries: list[WorktreeEntry] = []
+    current_path: Path | None = None
+    current_prunable = False
+
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if current_path is not None:
+                entries.append(WorktreeEntry(path=current_path, prunable=current_prunable))
+            current_path = None
+            current_prunable = False
+            continue
+
+        if line.startswith("worktree "):
+            if current_path is not None:
+                entries.append(WorktreeEntry(path=current_path, prunable=current_prunable))
+            current_path = Path(line.removeprefix("worktree ").strip()).resolve(strict=False)
+            current_prunable = False
+            continue
+
+        if line.startswith("prunable"):
+            current_prunable = True
+
+    if current_path is not None:
+        entries.append(WorktreeEntry(path=current_path, prunable=current_prunable))
+
+    return entries
+
+
+def validate_worktree_path(*, repo_path: str, worktree_path: str, step_id: str) -> Path:
+    """Return the validated worktree path or exit with an explicit error."""
+
+    repo_root = Path(repo_path).resolve(strict=False)
+    candidate = Path(worktree_path).resolve(strict=False)
+
+    if not repo_root.exists():
+        print(f"ERROR [{step_id}]: repository root does not exist: {repo_root}", file=sys.stderr)
+        raise SystemExit(1)
+    if not (repo_root / ".git").exists():
+        print(
+            f"ERROR [{step_id}]: repository root is not a git checkout: {repo_root}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    entries = _list_worktrees(repo_root)
+    matching_entry = next((entry for entry in entries if entry.path == candidate), None)
+
+    if not candidate.exists():
+        if matching_entry is not None and matching_entry.prunable:
+            reason = "git still tracks this worktree path, but it is marked prunable and missing on disk."
+        elif matching_entry is not None:
+            reason = "git still tracks this worktree path, but the directory is missing on disk."
+        else:
+            reason = "the expected worktree directory is missing and is not registered in git worktree metadata."
+        _die(
+            step_id=step_id,
+            reason=reason,
+            repo_path=repo_root,
+            worktree_path=candidate,
+            entries=entries,
+        )
+
+    if not candidate.is_dir():
+        _die(
+            step_id=step_id,
+            reason="the expected worktree path exists but is not a directory.",
+            repo_path=repo_root,
+            worktree_path=candidate,
+            entries=entries,
+        )
+
+    if matching_entry is None:
+        _die(
+            step_id=step_id,
+            reason="the directory exists, but git does not recognize it as a registered worktree for this repository.",
+            repo_path=repo_root,
+            worktree_path=candidate,
+            entries=entries,
+        )
+
+    if matching_entry.prunable:
+        _die(
+            step_id=step_id,
+            reason="git reports this worktree as prunable, which means bookkeeping is stale even though the path still exists.",
+            repo_path=repo_root,
+            worktree_path=candidate,
+            entries=entries,
+        )
+
+    return candidate
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for recipe bash steps."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-path", required=True)
+    parser.add_argument("--worktree-path", required=True)
+    parser.add_argument("--step-id", required=True)
+    args = parser.parse_args(argv)
+
+    validated = validate_worktree_path(
+        repo_path=args.repo_path,
+        worktree_path=args.worktree_path,
+        step_id=args.step_id,
+    )
+    print(validated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/recipes/test_default_workflow_worktree_guard.py
+++ b/tests/recipes/test_default_workflow_worktree_guard.py
@@ -1,0 +1,160 @@
+"""Regression tests for explicit default-workflow worktree validation."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+import yaml
+
+from amplihack.recipes.worktree_guard import validate_worktree_path
+
+RECIPE_PATH = Path("amplifier-bundle/recipes/default-workflow.yaml")
+GUARDED_STEPS = (
+    "checkpoint-after-implementation",
+    "checkpoint-after-review-feedback",
+    "step-15-commit-push",
+    "step-16-create-draft-pr",
+    "step-18c-push-feedback-changes",
+    "step-19c-zero-bs-verification",
+    "step-20b-push-cleanup",
+    "step-21-pr-ready",
+)
+
+
+@lru_cache(maxsize=1)
+def _workflow_steps() -> dict[str, dict]:
+    with RECIPE_PATH.open() as f:
+        data = yaml.safe_load(f)
+    return {step["id"]: step for step in data["steps"]}
+
+
+@pytest.fixture(scope="module")
+def workflow_steps() -> dict[str, dict]:
+    return _workflow_steps()
+
+
+def _run_bash(
+    script: str, cwd: Path, *, amplihack_home: Path, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {"PATH": os.environ["PATH"], "AMPLIHACK_HOME": str(amplihack_home)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["/bin/bash", "-c", script],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _render_step_command(command: str, replacements: dict[str, str]) -> str:
+    rendered = command
+    for key, value in replacements.items():
+        rendered = rendered.replace(key, value)
+    return rendered
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _init_repo_with_worktree(repo_path: Path) -> tuple[Path, str]:
+    _git("init", "-b", "main", cwd=repo_path)
+    _git("config", "user.name", "Test User", cwd=repo_path)
+    _git("config", "user.email", "tester@example.com", cwd=repo_path)
+    (repo_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git("add", "README.md", cwd=repo_path)
+    _git("commit", "-m", "init", cwd=repo_path)
+
+    branch_name = "feat/test-worktree-guard"
+    worktree_path = repo_path / "worktrees" / branch_name
+    _git("worktree", "add", "-b", branch_name, str(worktree_path), "HEAD", cwd=repo_path)
+    return worktree_path, branch_name
+
+
+class TestWorkflowGuardStructure:
+    """Structural checks to keep the visible-failure contract in place."""
+
+    @pytest.mark.parametrize("step_id", GUARDED_STEPS)
+    def test_guarded_steps_invoke_worktree_validation(
+        self, workflow_steps: dict[str, dict], step_id: str
+    ) -> None:
+        command = workflow_steps[step_id]["command"]
+        assert "python3 -m amplihack.recipes.worktree_guard" in command
+
+    def test_checkpoints_no_longer_silently_fall_back_to_repo_root(
+        self, workflow_steps: dict[str, dict]
+    ) -> None:
+        for step_id in ("checkpoint-after-implementation", "checkpoint-after-review-feedback"):
+            command = workflow_steps[step_id]["command"]
+            assert "2>/dev/null || cd {{repo_path}}" not in command
+
+
+class TestWorktreeGuardBehavior:
+    """Behavioral regression tests using real git worktrees."""
+
+    def test_validate_worktree_path_rejects_pruned_worktree(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        worktree_path, _branch_name = _init_repo_with_worktree(repo_path)
+        shutil.rmtree(worktree_path)
+
+        with pytest.raises(SystemExit) as excinfo:
+            validate_worktree_path(
+                repo_path=str(repo_path),
+                worktree_path=str(worktree_path),
+                step_id="step-15-commit-push",
+            )
+
+        captured = capsys.readouterr()
+        assert excinfo.value.code == 1
+        assert "stale worktree bookkeeping" in captured.err.lower()
+        assert "prunable" in captured.err.lower()
+        assert "step-15-commit-push" in captured.err
+
+    def test_step_15_fails_visibly_when_worktree_is_missing(
+        self, tmp_path: Path, workflow_steps: dict[str, dict]
+    ) -> None:
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        worktree_path, branch_name = _init_repo_with_worktree(repo_path)
+        shutil.rmtree(worktree_path)
+
+        rendered = _render_step_command(
+            workflow_steps["step-15-commit-push"]["command"],
+            {
+                "{{repo_path}}": str(repo_path),
+                "{{worktree_setup.worktree_path}}": str(worktree_path),
+                "{{task_description}}": "Fix stale worktree handling",
+                "{{issue_number}}": "3646",
+            },
+        )
+        amplihack_home = Path(__file__).resolve().parents[2]
+        result = _run_bash(
+            rendered,
+            repo_path,
+            amplihack_home=amplihack_home,
+            extra_env={"GIT_EDITOR": "true"},
+        )
+
+        combined = f"{result.stdout}\n{result.stderr}"
+        assert result.returncode != 0
+        assert "step-15-commit-push" in combined
+        assert "stale worktree bookkeeping" in combined.lower()
+        assert "prunable" in combined.lower()
+        assert "Commit and Push Complete" not in combined

--- a/tests/recipes/test_rust_runner_support.py
+++ b/tests/recipes/test_rust_runner_support.py
@@ -158,8 +158,10 @@ class TestNormalizeCopilotCliArgs:
 class TestCopilotCompatWrapperSource:
     """Tests for generated nested Copilot wrapper source."""
 
-    def test_wrapper_source_reuses_module_normalizer(self):
+    def test_wrapper_source_inlines_normalizer(self):
         source = _build_copilot_wrapper_source("/usr/bin/copilot")
 
-        assert "module._normalize_copilot_cli_args(args)" in source
+        assert "MODULE_PATH" not in source
+        assert "import importlib.util" not in source
+        assert "def _extract_copilot_prompt_parts(args):" in source
         assert "/usr/bin/copilot" in source


### PR DESCRIPTION
## Summary
- add explicit validation before every default-workflow bash step that relies on the tracked worktree path
- remove the silent checkpoint fallback from worktree to repo root
- inline the nested Copilot compatibility normalizer so deleted worktrees do not break wrapper imports
- add regression tests for pruned-worktree failure reporting and wrapper generation
- bump version to `0.6.101`

## Testing
- `PYTHONPATH=src /home/azureuser/src/amplihack/.venv/bin/python -m pytest -q tests/recipes/test_default_workflow_worktree_guard.py tests/recipes/test_rust_runner_support.py tests/recipes/test_git_push_idempotency.py`
- `PYTHONPATH=src /home/azureuser/src/amplihack/.venv/bin/python tests/gadugi/copilot_nested_compat_smoke.py`

## Notes
- `tests/recipes/test_worktree_step_quoting.py` still has two pre-existing failures on this branch for missing smart-orchestrator step ids (`execute-single-round-1`, `execute-single-fallback-blocked`); this change does not touch `smart-orchestrator.yaml`.
