### PR TITLE
fix: prevent cleanup-helper arg list overflow after parallel workstreams

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -467,6 +467,11 @@ steps:
       echo "---"
       AMPLIHACK_TREE_ID="$TREE_ID" AMPLIHACK_SESSION_DEPTH="$SESSION_DEPTH" \
         python3 .claude/skills/multitask/orchestrator.py "$WS_FILE"
+      # Clean up workstreams file now, before this step's output inflates
+      # the recipe context. Doing it here avoids the E2BIG error that
+      # occurs when a later bash step inherits megabytes of env vars
+      # from accumulated round_1_result (fix: cleanup-helper-arg-overflow).
+      rm -f "$WS_FILE" 2>/dev/null || true
     output: "round_1_result"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -623,12 +628,16 @@ steps:
     recipe: "investigation-workflow"
     output: "round_1_result"
 
-  # Cleanup temp workstreams file
+  # Cleanup temp workstreams file (best-effort fallback).
+  # Primary cleanup happens inside launch-parallel-round-1 before context
+  # bloat.  This step uses a glob instead of {{workstreams_file}} so it
+  # carries no template variables — reducing the env-var payload the Rust
+  # runner passes to bash.  The command is unconditionally successful so a
+  # cleanup failure never aborts the recipe (fix: cleanup-helper-arg-overflow).
   - id: "cleanup-helper"
     type: "bash"
     command: |
-      WS_FILE={{workstreams_file}}
-      [ -f "$WS_FILE" ] && rm -f "$WS_FILE"
+      rm -f /tmp/smart-orch-ws-*.json 2>/dev/null || true
       echo "ok"
     output: "cleanup_status"
 


### PR DESCRIPTION
## Problem

The `cleanup-helper` bash step in `smart-orchestrator.yaml` failed with:
```
Argument list too long (os error 7)
```

After parallel workstreams complete, the Rust recipe runner passes ALL accumulated context variables as `RECIPE_VAR_*` env vars to bash steps. With 3+ parallel workstreams, `round_1_result` alone can be megabytes, exceeding the Linux `execve()` argument list limit (~2MB).

## Fix

**1. Move primary cleanup into `launch-parallel-round-1`** (line 474)
- Deletes the workstreams file \*within\* the step that uses it, before the step's output inflates the recipe context
- At this point `round_1_result` hasn't been set yet, so env vars are small

**2. Simplify `cleanup-helper` to be a best-effort fallback**
- Removed `{{workstreams_file}}` template variable — uses a glob pattern instead (`/tmp/smart-orch-ws-*.json`)
- No template vars = smaller env-var payload from the Rust runner
- `|| true` ensures the step always exits 0 — cleanup failure never aborts the recipe

## Testing

- YAML validates: `python3 -c "import yaml; yaml.safe_load(open('...'))"`
- Existing recipe structure tests pass (the one pre-existing failure is unrelated)