### PR TITLE
fix: require recipe-runner-rs 0.2.9 (context-via-file)

### DIFF
--- a/src/amplihack/recipes/rust_runner_binary.py
+++ b/src/amplihack/recipes/rust_runner_binary.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-MIN_RUNNER_VERSION = "0.2.8"
+MIN_RUNNER_VERSION = "0.2.9"
 _REPO_URL = "https://github.com/rysweet/amplihack-recipe-runner"
 
 


### PR DESCRIPTION
Bumps MIN_RUNNER_VERSION to 0.2.9. Auto-update will install the new binary with file-based context passing on next amplihack startup. Closes #3738.