### PR TITLE
fix: mark non-critical workflow steps as fatal: false

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -994,6 +994,7 @@ steps:
   # STEP 12: RUN TESTS AND PRE-COMMIT HOOKS
   # ==========================================================================
   - id: "step-12-run-precommit"
+    fatal: false
     agent: "amplihack:pre-commit-diagnostic"
     prompt: |
       # Step 12: Run Tests and Pre-commit Hooks
@@ -1784,6 +1785,7 @@ steps:
   # STEP 20: FINAL CLEANUP AND VERIFICATION
   # ==========================================================================
   - id: "step-20-final-cleanup"
+    fatal: false
     agent: "amplihack:cleanup"
     prompt: |
       # Step 20: Final Cleanup and Verification
@@ -1815,6 +1817,7 @@ steps:
     output: "final_cleanup"
 
   - id: "step-20b-push-cleanup"
+    fatal: false
     type: "bash"
     command: |
       cd "{{worktree_setup.worktree_path}}" && \
@@ -1920,6 +1923,7 @@ steps:
   # Convert draft PR to ready-for-review.
   # ==========================================================================
   - id: "step-21-pr-ready"
+    fatal: false
     type: "bash"
     command: |
       cd "{{worktree_setup.worktree_path}}" && \
@@ -1983,6 +1987,7 @@ steps:
     output: "ci_status"
 
   - id: "step-22b-final-status"
+    fatal: false
     type: "bash"
     command: |
       cd "{{repo_path}}" && \

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -668,6 +668,7 @@ steps:
   # runner passes to bash.  The command is unconditionally successful so a
   # cleanup failure never aborts the recipe (fix: cleanup-helper-arg-overflow).
   - id: "cleanup-helper"
+    fatal: false
     type: "bash"
     command: |
       rm -f /tmp/smart-orch-ws-*.json 2>/dev/null || true

--- a/src/amplihack/recipes/rust_runner_binary.py
+++ b/src/amplihack/recipes/rust_runner_binary.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-MIN_RUNNER_VERSION = "0.2.9"
+MIN_RUNNER_VERSION = "0.2.10"
 _REPO_URL = "https://github.com/rysweet/amplihack-recipe-runner"
 
 


### PR DESCRIPTION
Pre-commit, cleanup, and status-check steps no longer kill 2-hour workflows. Requires recipe-runner-rs 0.2.10. Closes #3739.