### PR TITLE
fix: agent steps run from worktree, not repo root

### DIFF
--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -538,6 +538,7 @@ steps:
 
   - id: "step3-setup-worktree"
     agent: "amplihack:worktree-manager"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Setup git worktree and branch for isolated development:
 
@@ -672,6 +673,7 @@ steps:
 
   - id: "step4-design-round1-architect"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 1: Independent Design (Architect)
 
@@ -709,6 +711,7 @@ steps:
 
   - id: "step4-design-round1-api"
     agent: "amplihack:api-designer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 1: Independent Design (API Designer)
 
@@ -746,6 +749,7 @@ steps:
 
   - id: "step4-design-round1-database"
     agent: "amplihack:database"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 1: Independent Design (Database)
 
@@ -783,6 +787,7 @@ steps:
 
   - id: "step4-design-round1-security"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 1: Independent Design (Security)
 
@@ -824,6 +829,7 @@ steps:
 
   - id: "step4-design-round1-tester"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 1: Independent Design (Tester)
 
@@ -863,6 +869,7 @@ steps:
 
   - id: "step4-design-round2-cross-examination"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 2: Cross-Examination
 
@@ -911,6 +918,7 @@ steps:
 
   - id: "step4-design-round3-consensus"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       MANDATORY ARCHITECTURE DEBATE - ROUND 3: Consensus Building
 
@@ -981,6 +989,7 @@ steps:
 
   - id: "step4-write-tests"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Write comprehensive failing tests based on consensus design (TDD):
 
@@ -1028,6 +1037,7 @@ steps:
   - id: "step5-standard-implementation"
     condition: "is_critical_code == 'false'"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Implement the solution following the consensus design:
 
@@ -1064,6 +1074,7 @@ steps:
   - id: "step5-nversion-identify-critical"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Identify critical code sections for N-Version programming:
 
@@ -1098,6 +1109,7 @@ steps:
   - id: "step5-nversion-builder1-conservative"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       N-VERSION IMPLEMENTATION - Version 1: CONSERVATIVE Approach
 
@@ -1130,6 +1142,7 @@ steps:
   - id: "step5-nversion-builder2-pragmatic"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       N-VERSION IMPLEMENTATION - Version 2: PRAGMATIC Approach
 
@@ -1162,6 +1175,7 @@ steps:
   - id: "step5-nversion-builder3-minimalist"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       N-VERSION IMPLEMENTATION - Version 3: MINIMALIST Approach
 
@@ -1194,6 +1208,7 @@ steps:
   - id: "step5-nversion-compare"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       N-VERSION COMPARISON: Evaluate all implementations
 
@@ -1240,6 +1255,7 @@ steps:
   - id: "step5-nversion-synthesize"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       N-VERSION SYNTHESIS: Create final implementation
 
@@ -1262,6 +1278,7 @@ steps:
   - id: "step5-nversion-vote"
     condition: "is_critical_code == 'true'"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       N-VERSION CONSENSUS VOTE: Final approval for critical code
 
@@ -1300,6 +1317,7 @@ steps:
 
   - id: "step6-panel-cleanup"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL REVIEW - Cleanup Agent
 
@@ -1339,6 +1357,7 @@ steps:
 
   - id: "step6-panel-optimizer"
     agent: "amplihack:optimizer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL REVIEW - Optimizer Agent
 
@@ -1376,6 +1395,7 @@ steps:
 
   - id: "step6-panel-reviewer"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL REVIEW - Reviewer Agent
 
@@ -1414,6 +1434,7 @@ steps:
 
   - id: "step6-panel-patterns"
     agent: "amplihack:patterns"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL REVIEW - Patterns Agent
 
@@ -1450,6 +1471,7 @@ steps:
 
   - id: "step6-panel-consensus"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL CONSENSUS - Refactoring Approval
 
@@ -1495,6 +1517,7 @@ steps:
 
   - id: "step6-apply-refactoring"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Apply consensus-approved refactoring:
 
@@ -1532,6 +1555,7 @@ steps:
   - id: "step7-fix-issues"
     condition: "test_results.tests_run == 'true'"
     agent: "amplihack:pre-commit-diagnostic"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Diagnose and fix any test or pre-commit failures:
 
@@ -1560,6 +1584,7 @@ steps:
 
   - id: "step8-local-testing"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Perform mandatory local testing:
 
@@ -1720,6 +1745,7 @@ steps:
 
   - id: "step11-pr-review-reviewer"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL PR REVIEW - Reviewer Agent
 
@@ -1750,6 +1776,7 @@ steps:
 
   - id: "step11-pr-review-security"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL PR REVIEW - Security Agent
 
@@ -1780,6 +1807,7 @@ steps:
 
   - id: "step11-pr-review-optimizer"
     agent: "amplihack:optimizer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL PR REVIEW - Optimizer Agent
 
@@ -1807,6 +1835,7 @@ steps:
 
   - id: "step11-pr-review-patterns"
     agent: "amplihack:patterns"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL PR REVIEW - Patterns Agent
 
@@ -1834,6 +1863,7 @@ steps:
 
   - id: "step11-pr-review-tester"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL PR REVIEW - Tester Agent
 
@@ -1863,6 +1893,7 @@ steps:
 
   - id: "step11-pr-review-consensus"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       EXPERT PANEL CONSENSUS - PR Review Approval
 
@@ -1909,6 +1940,7 @@ steps:
   - id: "step12-implement-feedback"
     condition: "pr_review_consensus.final_verdict == 'needs_work'"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Implement required changes from PR review:
 
@@ -1950,6 +1982,7 @@ steps:
 
   - id: "step13-philosophy-reviewer"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       PHILOSOPHY COMPLIANCE - Reviewer Agent
 
@@ -1976,6 +2009,7 @@ steps:
 
   - id: "step13-philosophy-patterns"
     agent: "amplihack:patterns"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       PHILOSOPHY COMPLIANCE - Patterns Agent
 
@@ -2003,6 +2037,7 @@ steps:
 
   - id: "step13-philosophy-cleanup"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       PHILOSOPHY COMPLIANCE - Cleanup Agent
 
@@ -2029,6 +2064,7 @@ steps:
 
   - id: "step13-philosophy-guardian"
     agent: "amplihack:philosophy-guardian"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       PHILOSOPHY GUARDIAN - Final Validation
 
@@ -2088,6 +2124,7 @@ steps:
   - id: "step14-diagnose-ci"
     condition: "ci_status.ci_checked == 'true'"
     agent: "amplihack:ci-diagnostic-workflow"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Diagnose any CI failures:
 
@@ -2113,6 +2150,7 @@ steps:
 
   - id: "step14-verify-mergeable"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       Verify PR is mergeable:
 
@@ -2159,6 +2197,7 @@ steps:
 
   - id: "step15-final-cleanup"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       FINAL QUALITY PANEL - Cleanup Agent
 
@@ -2187,6 +2226,7 @@ steps:
 
   - id: "step15-final-reviewer"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       FINAL QUALITY PANEL - Reviewer Agent
 
@@ -2215,6 +2255,7 @@ steps:
 
   - id: "step15-final-patterns"
     agent: "amplihack:patterns"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       FINAL QUALITY PANEL - Patterns Agent
 
@@ -2244,6 +2285,7 @@ steps:
 
   - id: "step15-final-consensus"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       FINAL QUALITY CONSENSUS - Unanimous Approval Required
 

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -538,6 +538,7 @@ steps:
   # ==========================================================================
   - id: "step-05-architecture"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5: Research and Design - Architecture
 
@@ -561,6 +562,7 @@ steps:
 
   - id: "step-05b-api-design"
     agent: "amplihack:api-designer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5b: API Design (if applicable)
 
@@ -578,6 +580,7 @@ steps:
 
   - id: "step-05c-database-design"
     agent: "amplihack:database"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5c: Database Design (if applicable)
 
@@ -595,6 +598,7 @@ steps:
 
   - id: "step-05d-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5d: Security Requirements Review
 
@@ -614,6 +618,7 @@ steps:
 
   - id: "step-05e-design-consolidation"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5e: Design Consolidation
 
@@ -667,6 +672,7 @@ steps:
   # ==========================================================================
   - id: "step-06-documentation"
     agent: "amplihack:documentation-writer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6: Retcon Documentation Writing
 
@@ -688,6 +694,7 @@ steps:
 
   - id: "step-06b-documentation-review"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6b: Documentation Review
 
@@ -704,6 +711,7 @@ steps:
 
   - id: "step-06c-documentation-refinement"
     agent: "amplihack:documentation-writer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6c: Documentation Refinement
 
@@ -719,6 +727,7 @@ steps:
   # ==========================================================================
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -748,6 +757,7 @@ steps:
   # ==========================================================================
   - id: "step-08-implement"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -777,6 +787,7 @@ steps:
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -819,6 +830,7 @@ steps:
   # ==========================================================================
   - id: "step-09-refactor"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 9: Refactor and Simplify
 
@@ -847,6 +859,7 @@ steps:
 
   - id: "step-09b-optimize"
     agent: "amplihack:optimizer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 9b: Performance Optimization
 
@@ -867,6 +880,7 @@ steps:
   # ==========================================================================
   - id: "step-10-pre-commit-review"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 10: Review Pass Before Commit
 
@@ -898,6 +912,7 @@ steps:
 
   - id: "step-10b-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 10b: Security Review
 
@@ -917,6 +932,7 @@ steps:
 
   - id: "step-10c-philosophy-check"
     agent: "amplihack:philosophy-guardian"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 10c: Philosophy Compliance Check
 
@@ -938,6 +954,7 @@ steps:
   # ==========================================================================
   - id: "step-11-incorporate-feedback"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 11: Assess Review Feedback
 
@@ -955,6 +972,7 @@ steps:
 
   - id: "step-11b-implement-feedback"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 11b: Implement Review Feedback
 
@@ -999,6 +1017,7 @@ steps:
   - id: "step-12-run-precommit"
     fatal: false
     agent: "amplihack:pre-commit-diagnostic"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 12: Run Tests and Pre-commit Hooks
 
@@ -1036,6 +1055,7 @@ steps:
   # ==========================================================================
   - id: "step-13-local-testing"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 13: Mandatory Outside-In Testing (CANNOT BE SKIPPED)
 
@@ -1118,6 +1138,7 @@ steps:
   # ==========================================================================
   - id: "step-14-bump-version"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 14: Bump Version in pyproject.toml (MANDATORY - DO NOT SKIP)
 
@@ -1356,6 +1377,7 @@ steps:
   # ==========================================================================
   - id: "step-16b-outside-in-fix-loop"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 16b: Outside-In Testing and Fix Loop (MANDATORY)
 
@@ -1463,6 +1485,7 @@ steps:
 
   - id: "step-17b-reviewer-agent"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17b: Comprehensive Code Review (MANDATORY)
 
@@ -1490,6 +1513,7 @@ steps:
 
   - id: "step-17c-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17c: Security Review (MANDATORY)
 
@@ -1513,6 +1537,7 @@ steps:
 
   - id: "step-17d-philosophy-guardian"
     agent: "amplihack:philosophy-guardian"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17d: Philosophy Guardian Review (MANDATORY)
 
@@ -1536,6 +1561,7 @@ steps:
 
   - id: "step-17e-address-blocking-issues"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17e: Address Blocking Issues (MANDATORY)
 
@@ -1578,6 +1604,7 @@ steps:
   # ==========================================================================
   - id: "step-18a-analyze-feedback"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 18a: Analyze Review Feedback (MANDATORY)
 
@@ -1595,6 +1622,7 @@ steps:
 
   - id: "step-18b-implement-feedback"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 18b: Implement Review Feedback (MANDATORY)
 
@@ -1689,6 +1717,7 @@ steps:
   # ==========================================================================
   - id: "step-19a-philosophy-check"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 19a: Philosophy Compliance Review (MANDATORY)
 
@@ -1708,6 +1737,7 @@ steps:
 
   - id: "step-19b-patterns-check"
     agent: "amplihack:patterns"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 19b: Pattern Compliance Review (MANDATORY)
 
@@ -1790,6 +1820,7 @@ steps:
   - id: "step-20-final-cleanup"
     fatal: false
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 20: Final Cleanup and Verification
 
@@ -1860,6 +1891,7 @@ steps:
   # ==========================================================================
   - id: "step-20c-quality-audit"
     agent: "amplihack:core:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 20c: Quality Audit Loop
 
@@ -1963,6 +1995,7 @@ steps:
   # ==========================================================================
   - id: "step-22-ensure-mergeable"
     agent: "amplihack:ci-diagnostic-workflow"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 21: Ensure PR is Mergeable (TASK COMPLETION POINT)
 


### PR DESCRIPTION
75 agent steps across default-workflow and consensus-workflow now run from the dedicated worktree. Prevents hollow-context execution and parallel workflow conflicts.