### PR TITLE
fix: require runner 0.3.4 (prompt file transport)

### DIFF
--- a/src/amplihack/recipes/rust_runner_binary.py
+++ b/src/amplihack/recipes/rust_runner_binary.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-MIN_RUNNER_VERSION = "0.3.3"
+MIN_RUNNER_VERSION = "0.3.4"
 _REPO_URL = "https://github.com/rysweet/amplihack-recipe-runner"
 
 


### PR DESCRIPTION
E2BIG fix for Copilot CLI. Closes #3775.