### PR TITLE
docs: align user-facing launcher commands

### DIFF
--- a/docs/AUTO_MODE.md
+++ b/docs/AUTO_MODE.md
@@ -26,10 +26,10 @@ amplihack claude --auto --max-turns 20 -- -p "refactor the API module"
 
 # With interactive UI (requires Rich library)
 amplihack claude --auto --ui -- -p "implement user authentication"
-
-# Alias: launch command also supports auto mode
-amplihack launch --auto -- -p "fix all failing tests"
 ```
+
+The legacy `amplihack launch` alias also supports `--auto`, but user-facing
+examples should prefer `amplihack claude`.
 
 ### Interactive UI Mode (`--ui`)
 

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -81,7 +81,7 @@ claude --version
 amplihack
 
 # Launch Claude Code with amplihack agents
-amplihack launch
+amplihack claude
 ```
 
 ## Next Steps

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -6,6 +6,8 @@ Guide fer migratin' from per-project `~/.amplihack/.claude/` installations t' th
 
 This guide helps ye transition from copyin' `~/.amplihack/.claude/` into each project t' usin' the global plugin at `~/.amplihack/.claude/`.
 
+**Command note:** This guide uses `amplihack claude` in examples. `amplihack launch` still works as a compatibility alias, but `claude` be the preferred explicit command in user-facing docs.
+
 **Migration Path:**
 
 ```
@@ -60,9 +62,9 @@ Before (Per-Project)              After (Plugin)
 amplihack plugin install
 
 # All projects use plugin automatically
-cd ~/project1 && amplihack launch  # Uses plugin
-cd ~/project2 && amplihack launch  # Uses same plugin
-cd ~/project3 && amplihack launch  # Still uses plugin
+cd ~/project1 && amplihack claude  # Uses plugin
+cd ~/project2 && amplihack claude  # Uses same plugin
+cd ~/project3 && amplihack claude  # Still uses plugin
 ```
 
 ### Keep Per-Project Mode
@@ -78,8 +80,8 @@ cd ~/project3 && amplihack launch  # Still uses plugin
 
 ```bash
 # Each project has own .claude/
-cd ~/project1 && amplihack launch  # Uses project1/.claude/
-cd ~/project2 && amplihack launch  # Uses project2/.claude/
+cd ~/project1 && amplihack claude  # Uses project1/.claude/
+cd ~/project2 && amplihack claude  # Uses project2/.claude/
 ```
 
 ## Migration Methods
@@ -167,7 +169,7 @@ amplihack plugin install
 ```bash
 cd ~/new-test-project
 # No .claude/ directory here
-amplihack launch
+amplihack claude
 ```
 
 Plugin be used automatically (no local `~/.amplihack/.claude/` exists).
@@ -183,7 +185,7 @@ amplihack mode migrate-to-plugin
 
 ```bash
 # Run typical workflow
-amplihack launch -- -p "implement simple feature"
+amplihack claude -- -p "implement simple feature"
 
 # Verify agents work
 # Verify commands work
@@ -228,7 +230,7 @@ amplihack mode migrate-to-plugin
 ```bash
 cd ~/custom-project
 # Leave .claude/ directory intact
-amplihack launch  # Uses local .claude/ (precedence)
+amplihack claude  # Uses local .claude/ (precedence)
 ```
 
 **Mode Detection:**
@@ -339,7 +341,7 @@ Plugin: amplihack
 
 ```bash
 cd ~/project
-amplihack launch -- -p "analyze src/file.py"
+amplihack claude -- -p "analyze src/file.py"
 ```
 
 Verify:
@@ -353,10 +355,10 @@ Verify:
 
 ```bash
 cd ~/project1
-amplihack launch -- -p "quick test"
+amplihack claude -- -p "quick test"
 
 cd ~/project2
-amplihack launch -- -p "quick test"
+amplihack claude -- -p "quick test"
 ```
 
 Both should use same plugin.

--- a/docs/PROFILE_MANAGEMENT.md
+++ b/docs/PROFILE_MANAGEMENT.md
@@ -4,9 +4,11 @@ Amplihack's profile system filters which components get staged during installati
 
 ## How It Works
 
-Profiles control **file staging** - which files get copied to `~/.amplihack/.claude/` when you run `amplihack install` or `amplihack launch`. Claude Code sees only the filtered files (no runtime awareness needed).
+Profiles control **file staging** - which files get staged when you run `amplihack install` or `amplihack claude`. Claude Code sees only the filtered files (no runtime awareness needed).
 
 **Key Principle**: Profile switching happens OUTSIDE Claude Code. To change profiles, you must exit Claude, set a new profile, and restart.
+
+User-facing docs use `amplihack claude` as the explicit launcher. `amplihack launch` still works as a compatibility alias.
 
 ## Quick Start
 
@@ -19,7 +21,7 @@ amplihack install
 # Result: Only 9/32 agents copied (72% reduction)
 
 # Or launch with profile filtering
-amplihack launch
+amplihack claude
 # Result: Only 9/32 agents staged to working directory
 ```
 
@@ -94,9 +96,9 @@ amplihack install
 export AMPLIHACK_PROFILE=amplihack://profiles/coding
 
 # 2. Install or launch
-amplihack install  # Stages to ~/.claude/
+amplihack install  # Stages filtered files globally
 # OR
-amplihack launch   # Stages to ./claude/ in working directory
+amplihack claude   # Stages filtered files for this working directory
 
 # 3. Claude Code sees only filtered components
 # (no profile awareness - just sees what files exist)
@@ -104,7 +106,7 @@ amplihack launch   # Stages to ./claude/ in working directory
 # 4. To switch profiles: Exit Claude, change profile, restart
 exit  # Exit Claude
 export AMPLIHACK_PROFILE=amplihack://profiles/research
-amplihack launch
+amplihack claude
 ```
 
 ## Creating Custom Profiles

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,6 +19,10 @@ Complete command-line reference for the `amplihack` top-level command.
 amplihack [--version] [--help] <subcommand> [<args>]
 ```
 
+Running `amplihack` with no subcommand launches Claude Code directly. In
+user-facing docs, prefer the explicit `amplihack claude` form;
+`amplihack launch` remains a compatibility alias.
+
 ---
 
 ## Global Flags
@@ -45,13 +49,25 @@ The version string comes from the `__version__` attribute in `amplihack/__init__
 
 ## Subcommands
 
-| Subcommand | Description                                                                      |
-| ---------- | -------------------------------------------------------------------------------- |
-| `launch`   | Start an interactive amplihack session (default when called with no subcommand). |
-| `recipe`   | Run, list, validate, and inspect workflow recipes.                               |
-| `memory`   | Manage the amplihack memory backend.                                             |
-| `plugin`   | Install, uninstall, and list amplihack plugins.                                  |
-| `version`  | Alias for `--version`. Prints version and exits.                                 |
+| Subcommand   | Description                                                                      |
+| ------------ | -------------------------------------------------------------------------------- |
+| `version`    | Show amplihack version.                                                          |
+| `install`    | Install amplihack agents and tools to `~/.claude`.                               |
+| `uninstall`  | Remove amplihack agents and tools from `~/.claude`.                              |
+| `update`     | Update amplihack, delegating to the Rust CLI when one is installed.              |
+| `claude`     | Launch Claude Code. Preferred explicit launcher in user-facing docs.             |
+| `launch`     | Compatibility alias for `claude`; `amplihack` with no subcommand also launches Claude Code. |
+| `RustyClawd` | Launch RustyClawd (Rust implementation).                                         |
+| `copilot`    | Launch GitHub Copilot CLI.                                                       |
+| `codex`      | Launch OpenAI Codex CLI.                                                         |
+| `amplifier`  | Launch Microsoft Amplifier with amplihack bundle.                                |
+| `uvx-help`   | Get help with UVX deployment.                                                    |
+| `plugin`     | Install, uninstall, and list amplihack plugins.                                  |
+| `memory`     | Manage the amplihack memory backend.                                             |
+| `new`        | Generate a new goal-seeking agent.                                               |
+| `recipe`     | Run, list, validate, and inspect workflow recipes.                               |
+| `mode`       | Claude installation mode commands.                                               |
+| `fleet`      | Manage coding agents across VMs.                                                 |
 
 See the documentation for each subcommand:
 
@@ -94,12 +110,23 @@ amplihack --version
 # amplihack 0.9.2
 ```
 
-### Launch an interactive session
+### Launch an interactive Claude session
+
+Prefer `amplihack claude` in user-facing docs. `amplihack launch` remains
+supported as a compatibility alias.
 
 ```bash
-amplihack launch
+amplihack claude
 # or simply:
 amplihack
+# compatibility alias:
+amplihack launch
+```
+
+### Launch an interactive Copilot session
+
+```bash
+amplihack copilot
 ```
 
 ### Run a workflow recipe non-interactively
@@ -112,7 +139,7 @@ amplihack recipe run default-workflow \
 ### Enable blarify code indexing for a session
 
 ```bash
-AMPLIHACK_ENABLE_BLARIFY=1 amplihack launch
+AMPLIHACK_ENABLE_BLARIFY=1 amplihack claude
 ```
 
 ---

--- a/tests/docs/test_command_surface_documentation.py
+++ b/tests/docs/test_command_surface_documentation.py
@@ -1,0 +1,213 @@
+"""Contract tests for user-facing CLI command documentation.
+
+These tests pin the intended command surface for interactive entrypoints:
+
+- `amplihack claude` is the preferred explicit Claude launcher in user-facing docs
+- `amplihack copilot` is the explicit Copilot launcher
+- `amplihack launch` remains an alias in the CLI, but should not be taught as the
+  primary command in setup/guide-style documentation
+
+The suite protects the preferred public command surface from future docs drift.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+USER_FACING_GUIDES = (
+    REPO_ROOT / "docs" / "CLAUDE_CODE_SETUP.md",
+    REPO_ROOT / "docs" / "PROFILE_MANAGEMENT.md",
+    REPO_ROOT / "docs" / "MIGRATION_GUIDE.md",
+    REPO_ROOT / "docs" / "AUTO_MODE.md",
+)
+
+CLI_REFERENCE = REPO_ROOT / "docs" / "reference" / "cli.md"
+
+
+@dataclass(frozen=True)
+class CommandOccurrence:
+    line_number: int
+    text: str
+
+
+class DocCommandSurface:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def read(self) -> str:
+        if not self.path.exists():
+            raise FileNotFoundError(f"Documentation file not found: {self.path}")
+        return self.path.read_text(encoding="utf-8")
+
+    def command_examples(self, command: str) -> list[CommandOccurrence]:
+        occurrences: list[CommandOccurrence] = []
+        in_code_block = False
+
+        for line_number, line in enumerate(self.read().splitlines(), start=1):
+            if line.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+
+            if in_code_block and command in line:
+                occurrences.append(CommandOccurrence(line_number=line_number, text=line.strip()))
+
+        return occurrences
+
+    def prose_mentions(self, phrase: str) -> list[CommandOccurrence]:
+        occurrences: list[CommandOccurrence] = []
+        in_code_block = False
+
+        for line_number, line in enumerate(self.read().splitlines(), start=1):
+            if line.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+
+            if not in_code_block and phrase in line:
+                occurrences.append(CommandOccurrence(line_number=line_number, text=line.strip()))
+
+        return occurrences
+
+
+def _relative(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def _format_occurrences(occurrences: list[CommandOccurrence]) -> str:
+    return ", ".join(f"L{item.line_number}: {item.text}" for item in occurrences)
+
+
+class TestDocCommandSurfaceHelpers:
+    def test_command_examples_only_report_fenced_code_blocks(self, tmp_path: Path):
+        markdown = tmp_path / "guide.md"
+        markdown.write_text(
+            "\n".join(
+                [
+                    "Use `amplihack launch` only when discussing aliases.",
+                    "",
+                    "```bash",
+                    "amplihack claude",
+                    "```",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        surface = DocCommandSurface(markdown)
+
+        assert surface.command_examples("amplihack launch") == []
+        assert surface.command_examples("amplihack claude") == [
+            CommandOccurrence(line_number=4, text="amplihack claude")
+        ]
+
+    def test_prose_mentions_ignore_code_fences(self, tmp_path: Path):
+        markdown = tmp_path / "guide.md"
+        markdown.write_text(
+            "\n".join(
+                [
+                    "Compatibility alias: `amplihack launch` still works.",
+                    "",
+                    "```bash",
+                    "amplihack launch",
+                    "```",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        surface = DocCommandSurface(markdown)
+
+        assert surface.prose_mentions("amplihack launch") == [
+            CommandOccurrence(
+                line_number=1,
+                text="Compatibility alias: `amplihack launch` still works.",
+            )
+        ]
+
+    def test_missing_doc_raises_clear_file_not_found_error(self, tmp_path: Path):
+        missing = tmp_path / "missing.md"
+
+        with pytest.raises(FileNotFoundError, match="Documentation file not found"):
+            DocCommandSurface(missing).read()
+
+
+class TestCommandSurfaceContract:
+    def test_top_level_help_lists_documented_interactive_entrypoints(self):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(REPO_ROOT / "src")
+        result = subprocess.run(
+            [sys.executable, "-m", "amplihack", "--help"],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "launch" in result.stdout
+        assert "claude" in result.stdout
+        assert "copilot" in result.stdout
+
+    def test_claude_code_setup_uses_claude_not_launch(self):
+        surface = DocCommandSurface(REPO_ROOT / "docs" / "CLAUDE_CODE_SETUP.md")
+
+        assert surface.command_examples("amplihack claude"), (
+            "docs/CLAUDE_CODE_SETUP.md should show `amplihack claude` in its verification example"
+        )
+        assert not surface.command_examples("amplihack launch"), (
+            "docs/CLAUDE_CODE_SETUP.md should not teach `amplihack launch` anymore"
+        )
+
+    @pytest.mark.parametrize("doc_path", USER_FACING_GUIDES, ids=_relative)
+    def test_user_facing_guides_do_not_teach_launch_as_primary_command(self, doc_path: Path):
+        surface = DocCommandSurface(doc_path)
+        launch_examples = surface.command_examples("amplihack launch")
+
+        assert not launch_examples, (
+            f"{_relative(doc_path)} still teaches `amplihack launch` in a code block: "
+            f"{_format_occurrences(launch_examples)}"
+        )
+
+    def test_cli_reference_documents_alias_context_and_explicit_entrypoints(self):
+        surface = DocCommandSurface(CLI_REFERENCE)
+
+        assert surface.command_examples("amplihack claude"), (
+            "docs/reference/cli.md should document the explicit Claude launcher"
+        )
+        assert surface.command_examples("amplihack copilot"), (
+            "docs/reference/cli.md should document the explicit Copilot launcher"
+        )
+        assert surface.command_examples("amplihack launch"), (
+            "docs/reference/cli.md should mention the legacy alias when documenting command parity"
+        )
+        assert surface.prose_mentions("compatibility alias"), (
+            "docs/reference/cli.md must explain that `launch` is an alias, not the preferred form"
+        )
+
+    def test_plain_amplihack_default_command_is_not_misclassified_as_launch(self, tmp_path: Path):
+        markdown = tmp_path / "guide.md"
+        markdown.write_text(
+            "\n".join(
+                [
+                    "```bash",
+                    "amplihack",
+                    "amplihack claude",
+                    "```",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        surface = DocCommandSurface(markdown)
+
+        assert surface.command_examples("amplihack launch") == []


### PR DESCRIPTION
## Summary
- align the user-facing Claude launcher docs to prefer `amplihack claude`
- keep `amplihack launch` documented only as a compatibility alias in the CLI reference
- add a docs contract test so setup-style guides do not regress back to the legacy command

Fixes #3842.

## Validation
- `PYTHONPATH=src pytest tests/docs/test_command_surface_documentation.py -q`
- `PYTHONPATH=src pytest tests/docs -q` *(expected unrelated baseline failures in `tests/docs/test_documentation_structure.py`: broken links, orphaned docs, and navigation-depth checks already failing outside this change)*
