### PR TITLE
fix: include directory path in recipe discovery cache key (#3808)

### DIFF
--- a/src/amplihack/recipes/__init__.py
+++ b/src/amplihack/recipes/__init__.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from amplihack.recipes.agent_resolver import AgentNotFoundError, AgentResolver
 from amplihack.recipes.discovery import (
+    RecipeCache,
     RecipeInfo,
     check_upstream_changes,
     discover_recipes,
@@ -49,6 +50,7 @@ from amplihack.utils import _agent_binary_context
 __all__ = [
     "AgentNotFoundError",
     "AgentResolver",
+    "RecipeCache",
     "RecipeInfo",
     "RecipeParser",
     "Recipe",

--- a/src/amplihack/recipes/discovery.py
+++ b/src/amplihack/recipes/discovery.py
@@ -123,14 +123,84 @@ class RecipeInfo:
     sha256: str = ""
 
 
+def _qualified_key(search_dir: Path, name: str) -> str:
+    """Build a qualified cache key from a resolved directory and recipe name.
+
+    Format: ``<resolved_dir>:<name>``
+    """
+    return f"{search_dir}:{name}"
+
+
+class RecipeCache(dict):
+    """Dict of qualified-key → RecipeInfo with transparent bare-name fallback.
+
+    Recipes are stored under qualified keys (``<resolved_dir>:<recipe_name>``)
+    so that two recipes with the same ``name`` field in different directories
+    coexist without aliasing (fix #3808).
+
+    Bare recipe names (e.g. ``"default-workflow"``) resolve transparently via
+    ``__contains__`` and ``__getitem__`` to the **last-wins** (highest
+    precedence) match — preserving backward compatibility.
+
+    ``values()`` returns only one entry per recipe (no duplicates from the
+    bare-name layer).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # bare_name → qualified_key of the last-registered (highest-precedence) recipe
+        self._bare: dict[str, str] = {}
+
+    def _register(self, qualified_key: str, bare_name: str, info: RecipeInfo) -> None:
+        """Add a recipe with its qualified key and update the bare-name alias."""
+        self[qualified_key] = info
+        self._bare[bare_name] = qualified_key
+
+    # -- dict protocol overrides for bare-name fallback --
+
+    def __contains__(self, key: object) -> bool:
+        if super().__contains__(key):
+            return True
+        if isinstance(key, str) and key in self._bare:
+            return super().__contains__(self._bare[key])
+        return False
+
+    def __getitem__(self, key: str) -> RecipeInfo:
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            if key in self._bare:
+                return super().__getitem__(self._bare[key])
+            raise
+
+    def get(self, key: str, default: RecipeInfo | None = None) -> RecipeInfo | None:  # type: ignore[override]
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def qualified_keys(self) -> list[str]:
+        """Return only the qualified keys (not bare-name aliases)."""
+        return list(super().keys())
+
+    def bare_name_map(self) -> dict[str, str]:
+        """Return a copy of the bare-name → qualified-key mapping."""
+        return dict(self._bare)
+
+
 def discover_recipes(
     search_dirs: list[Path] | None = None,
-) -> dict[str, RecipeInfo]:
+) -> RecipeCache:
     """Find all recipe YAML files in the search directories.
 
-    Returns a dict mapping recipe name to RecipeInfo. When the same recipe
-    name appears in multiple directories, the last one wins (user recipes
-    override bundled ones).
+    Returns a :class:`RecipeCache` mapping qualified keys
+    (``<resolved_dir>:<name>``) to :class:`RecipeInfo`.  Bare recipe names
+    also work as lookup keys and resolve to the highest-precedence match
+    (last directory wins), preserving backward compatibility.
+
+    When the same recipe name appears in multiple directories, **both**
+    recipes are stored under distinct qualified keys.  The bare-name alias
+    always points to the last-wins version.
 
     Debug Logging
     -------------
@@ -146,23 +216,25 @@ def discover_recipes(
         search_dirs: Override the default search directories.
 
     Returns:
-        Dict of recipe name -> RecipeInfo.
+        RecipeCache of qualified key -> RecipeInfo (bare-name lookup supported).
     """
     dirs = search_dirs or _DEFAULT_SEARCH_DIRS
-    recipes: dict[str, RecipeInfo] = {}
+    recipes = RecipeCache()
 
     logger.debug("Searching for recipes in %d directories", len(dirs))
     for search_dir in dirs:
         if not search_dir.is_dir():
             logger.debug("  Skipping non-existent: %s", search_dir)
             continue
-        logger.debug("  Scanning: %s", search_dir)
+        resolved_dir = search_dir.resolve()
+        logger.debug("  Scanning: %s (resolved: %s)", search_dir, resolved_dir)
         dir_recipe_count = 0
         for yaml_path in sorted(search_dir.glob("*.yaml")):
             info = _load_recipe_info(yaml_path)
             if info is not None:
-                logger.debug("    Found: %s", info.name)
-                recipes[info.name] = info
+                qkey = _qualified_key(resolved_dir, info.name)
+                logger.debug("    Found: %s (key: %s)", info.name, qkey)
+                recipes._register(qkey, info.name, info)
                 dir_recipe_count += 1
         logger.debug("  Discovered %d recipes in %s", dir_recipe_count, search_dir)
 
@@ -175,7 +247,12 @@ def discover_recipes(
 
 
 def list_recipes(search_dirs: list[Path] | None = None) -> list[RecipeInfo]:
-    """Return a sorted list of all discovered recipes.
+    """Return a sorted, deduplicated list of all discovered recipes.
+
+    When a recipe name appears in multiple directories, each distinct
+    recipe (by path) is included.  Deduplication is by resolved path
+    so that the same file discovered via multiple search dirs is not
+    listed twice.
 
     Args:
         search_dirs: Override the default search directories.
@@ -183,7 +260,13 @@ def list_recipes(search_dirs: list[Path] | None = None) -> list[RecipeInfo]:
     Returns:
         List of RecipeInfo sorted by name.
     """
-    return sorted(discover_recipes(search_dirs).values(), key=lambda r: r.name)
+    seen_paths: set[Path] = set()
+    unique: list[RecipeInfo] = []
+    for info in discover_recipes(search_dirs).values():
+        if info.path not in seen_paths:
+            seen_paths.add(info.path)
+            unique.append(info)
+    return sorted(unique, key=lambda r: r.name)
 
 
 def verify_global_installation() -> dict[str, Any]:
@@ -237,17 +320,29 @@ def verify_global_installation() -> dict[str, Any]:
 def find_recipe(name: str, search_dirs: list[Path] | None = None) -> Path | None:
     """Find a recipe by name and return its file path.
 
-    Searches for ``{name}.yaml`` in each search directory. When multiple
-    directories contain the same recipe name, the last matching path wins
-    so resolution stays consistent with ``discover_recipes()``.
+    Supports two lookup modes:
+
+    * **Qualified name** (contains ``:``) — ``<dir_path>:<recipe_name>``.
+      Looks for ``<dir_path>/<recipe_name>.yaml`` directly.
+    * **Bare name** — searches each directory for ``{name}.yaml``.
+      When multiple directories contain the same recipe name, the last
+      matching path wins so resolution stays consistent with
+      ``discover_recipes()``.
 
     Args:
-        name: Recipe name (without .yaml extension).
+        name: Recipe name (bare) or qualified key (``dir:name``).
         search_dirs: Override the default search directories.
 
     Returns:
         Path to the recipe file, or None.
     """
+    # Qualified lookup: "dir_path:recipe_name"
+    if ":" in name:
+        dir_part, _, bare_name = name.rpartition(":")
+        candidate = Path(dir_part) / f"{bare_name}.yaml"
+        return candidate if candidate.is_file() else None
+
+    # Bare-name lookup: last-wins
     dirs = search_dirs or _DEFAULT_SEARCH_DIRS
     found: Path | None = None
     for search_dir in dirs:

--- a/tests/unit/recipes/test_discovery.py
+++ b/tests/unit/recipes/test_discovery.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from amplihack.recipes.discovery import (
+    RecipeCache,
     _PACKAGE_BUNDLE_DIR,
+    _qualified_key,
     check_upstream_changes,
     discover_recipes,
     find_recipe,
@@ -165,3 +167,133 @@ class TestUpstreamTracking:
         assert len(changes) == 1
         assert changes[0]["name"] == "test-recipe"
         assert changes[0]["status"] == "modified"
+
+
+class TestRecipeCacheAliasing:
+    """Tests for #3808: same-name recipes from different dirs must not alias."""
+
+    _RECIPE_YAML = "name: {name}\ndescription: from {origin}\nsteps: []\n"
+
+    def _make_recipe(self, directory: Path, name: str, origin: str) -> Path:
+        """Create a minimal recipe YAML in *directory*."""
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"{name}.yaml"
+        path.write_text(self._RECIPE_YAML.format(name=name, origin=origin))
+        return path
+
+    def test_same_name_recipes_coexist(self, tmp_path: Path) -> None:
+        """Two recipes with the same name in different dirs are both discoverable."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+
+        recipes = discover_recipes([dir_a, dir_b])
+
+        # Both qualified keys must exist
+        qkey_a = _qualified_key(dir_a.resolve(), "shared")
+        qkey_b = _qualified_key(dir_b.resolve(), "shared")
+        assert qkey_a in recipes, f"Missing qualified key for dir_a: {qkey_a}"
+        assert qkey_b in recipes, f"Missing qualified key for dir_b: {qkey_b}"
+
+        # They must be different RecipeInfo objects (different paths)
+        assert recipes[qkey_a].path != recipes[qkey_b].path
+
+        # Descriptions confirm they came from the right directories
+        assert recipes[qkey_a].description == "from dir_a"
+        assert recipes[qkey_b].description == "from dir_b"
+
+    def test_bare_name_returns_last_wins(self, tmp_path: Path) -> None:
+        """Bare-name lookup returns the recipe from the last search directory."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+
+        recipes = discover_recipes([dir_a, dir_b])
+
+        # Bare-name lookup must resolve to dir_b (last wins)
+        assert "shared" in recipes
+        assert recipes["shared"].description == "from dir_b"
+        assert recipes["shared"].path == (dir_b / "shared.yaml").resolve()
+
+    def test_qualified_key_returns_specific_recipe(self, tmp_path: Path) -> None:
+        """Qualified key returns the exact recipe from a specific directory."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+
+        recipes = discover_recipes([dir_a, dir_b])
+
+        qkey_a = _qualified_key(dir_a.resolve(), "shared")
+        info_a = recipes[qkey_a]
+        assert info_a.description == "from dir_a"
+        assert info_a.path == (dir_a / "shared.yaml").resolve()
+
+    def test_values_not_duplicated(self, tmp_path: Path) -> None:
+        """values() returns each unique recipe exactly once (no bare-name dupes)."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+        self._make_recipe(dir_a, "unique_a", "dir_a")
+
+        recipes = discover_recipes([dir_a, dir_b])
+        paths = [info.path for info in recipes.values()]
+
+        # No duplicate paths in values()
+        assert len(paths) == len(set(paths)), f"Duplicate values: {paths}"
+        # Must contain all 3 recipes
+        assert len(paths) == 3
+
+    def test_list_recipes_deduplicates(self, tmp_path: Path) -> None:
+        """list_recipes returns each recipe once even with overlapping dirs."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+        self._make_recipe(dir_a, "unique_a", "dir_a")
+
+        result = list_recipes([dir_a, dir_b])
+        names = [r.name for r in result]
+
+        # "shared" appears twice (two distinct paths) + "unique_a"
+        assert len(result) == 3
+        assert names.count("shared") == 2
+        assert "unique_a" in names
+
+    def test_find_recipe_qualified_lookup(self, tmp_path: Path) -> None:
+        """find_recipe with qualified name returns the specific directory's recipe."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+
+        qname = f"{dir_a.resolve()}:shared"
+        path = find_recipe(qname)
+        assert path is not None
+        assert path == dir_a / "shared.yaml"
+
+    def test_find_recipe_bare_name_last_wins(self, tmp_path: Path) -> None:
+        """find_recipe with bare name returns the last-wins match."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_recipe(dir_a, "shared", "dir_a")
+        self._make_recipe(dir_b, "shared", "dir_b")
+
+        path = find_recipe("shared", [dir_a, dir_b])
+        assert path == dir_b / "shared.yaml"
+
+    def test_recipe_cache_is_dict_subclass(self) -> None:
+        """RecipeCache is a dict subclass for backward compatibility."""
+        cache = RecipeCache()
+        assert isinstance(cache, dict)
+
+    def test_existing_bare_name_lookups_still_work(self) -> None:
+        """Existing bare-name lookups on bundled recipes still work (backward compat)."""
+        recipes = discover_recipes()
+        assert len(recipes) >= 10
+        assert "default-workflow" in recipes
+        assert "verification-workflow" in recipes
+        assert recipes["default-workflow"].name == "default-workflow"


### PR DESCRIPTION
## Problem

`discover_recipes()` used the bare recipe name as the dict key (`recipes[info.name] = info`), causing recipes with the same name in different search directories to silently alias each other — the last directory always overwrote earlier ones.

## Solution

Introduced `RecipeCache`, a `dict` subclass that stores recipes under qualified keys (`<resolved_dir>:<name>`) while supporting transparent bare-name fallback (last-wins precedence). This preserves full backward compatibility.

### Changes
- **`RecipeCache` class** — qualified keys prevent aliasing; bare-name `__contains__`/`__getitem__` provide backward compat
- **`discover_recipes()`** — returns `RecipeCache` instead of plain `dict`
- **`find_recipe()`** — supports qualified `dir:name` syntax for disambiguation
- **`list_recipes()`** — deduplicates by resolved path
- **9 new tests** — aliasing prevention, bare-name backward compat, qualified lookup, dedup, dict subclass contract

### Backward Compatibility
- All existing bare-name lookups (`recipes["default-workflow"]`) continue to work
- `isinstance(result, dict)` returns `True`
- `values()` returns no duplicates
- All 12 pre-existing discovery tests pass unchanged

Fixes #3808