### PR TITLE
docs: specify LearningAgent module split

### DIFF
--- a/docs/GOAL_SEEKING_AGENTS.md
+++ b/docs/GOAL_SEEKING_AGENTS.md
@@ -33,6 +33,15 @@ The system provides a single `GoalSeekingAgent` base class that works identicall
 
 **Core design**: The `GoalSeekingAgent` ABC defines the interface. All SDK implementations delegate learning and answering to a shared `LearningAgent` instance, which contains the eval intelligence: LLM-based fact extraction, intent detection, retrieval strategy selection, and answer synthesis. This means every SDK gets the same quality of fact extraction and question answering regardless of the underlying LLM provider.
 
+### LearningAgent contributor docs
+
+Use these pages when you are working on the refactored `LearningAgent` internals:
+
+- [Understanding the LearningAgent module architecture](concepts/learning-agent-module-architecture.md)
+- [LearningAgent module reference](reference/learning-agent-module-reference.md)
+- [How to maintain and extend the refactored LearningAgent](howto/maintain-learning-agent-modules.md)
+- [Tutorial: trace the refactored LearningAgent end to end](tutorials/learning-agent-refactor-tutorial.md)
+
 ---
 
 ## Quick Start

--- a/docs/concepts/learning-agent-module-architecture.md
+++ b/docs/concepts/learning-agent-module-architecture.md
@@ -1,0 +1,209 @@
+---
+title: Understanding the LearningAgent Module Architecture
+description: How the refactored LearningAgent splits ingestion, retrieval, temporal reasoning, and synthesis while preserving the existing public API.
+last_updated: 2026-03-30
+review_schedule: quarterly
+owner: goal-seeking
+doc_type: explanation
+related:
+  - ../GOAL_SEEKING_AGENTS.md
+  - ../reference/learning-agent-module-reference.md
+  - ../howto/maintain-learning-agent-modules.md
+  - ../tutorials/learning-agent-refactor-tutorial.md
+---
+
+# Understanding the LearningAgent Module Architecture
+
+The refactored `LearningAgent` keeps the same caller-facing behavior while replacing the old monolith with focused internal modules.
+
+From the outside, generated agents, eval harnesses, and direct imports continue to use the same `LearningAgent` methods. Internally, the agent is now organized around stable ownership boundaries: ingestion, retrieval, intent detection, temporal reasoning, code synthesis, knowledge utilities, and answer synthesis.
+
+## Why the split exists
+
+The refactor solves four maintenance problems in the original single-file implementation:
+
+- Too many responsibilities in one file made reviews noisy.
+- Retrieval, temporal reasoning, and synthesis logic were tightly interleaved.
+- Tests were forced into one large compatibility bucket.
+- Small changes risked accidental regressions in unrelated paths.
+
+The module split keeps the behavior intact while making it obvious where new logic belongs.
+
+## Compatibility model
+
+The compatibility rules are strict:
+
+- `src/amplihack/agents/goal_seeking/learning_agent.py` remains the primary import path.
+- `LearningAgent` remains directly importable for existing callers.
+- `GoalSeekingAgent` continues to delegate learning and answering work to `LearningAgent`.
+- The public methods stay unchanged:
+  - `learn_from_content`
+  - `answer_question`
+  - `answer_question_agentic`
+  - `get_memory_stats`
+  - `flush_memory`
+  - `close`
+- `src/amplihack/agents/goal_seeking/__init__.py` continues to import `LearningAgent` for backward compatibility without promoting it into `__all__`.
+
+## The eight-module layout
+
+The refactor centers on eight named modules. These are the contributor-facing ownership boundaries.
+
+| Module | Responsibility | Typical reasons to edit it |
+| --- | --- | --- |
+| `learning_agent.py` | Thin facade, construction, action registration, lifecycle, retry helpers | Constructor behavior, shared state, public method delegation |
+| `learning_ingestion.py` | Content ingestion, fact extraction, batching, storage | Learning flow, source labels, summary concept maps |
+| `answer_synthesizer.py` | LLM answer synthesis and completeness evaluation | Prompt assembly, final answer wording, gap-filling refinement |
+| `retrieval_strategies.py` | Retrieval planning and retrieval implementations | Entity lookup, concept lookup, aggregation retrieval, fallbacks |
+| `intent_detector.py` | Query intent classification | Intent labels, routing metadata, math/temporal flags |
+| `temporal_reasoning.py` | Temporal state tracking and transition chains | Change-over-time questions, direct temporal lookups |
+| `code_synthesis.py` | LLM-driven code generation for hard temporal calculations | Generated Python snippets and temporal index computation |
+| `knowledge_utils.py` | Shared helpers for arithmetic, entity handling, fact validation | Math precomputation, knowledge explanations, fact verification |
+
+Private helper files may exist when needed to keep the main ownership modules reviewable. Those helpers support the eight modules above; they do not replace them as contributor entry points.
+
+## Shared state stays in the facade
+
+The refactor deliberately avoids a new runtime-state object. `learning_agent.py` remains the one place that owns process-wide state and construction-time wiring.
+
+The shared state that stays on `LearningAgent` includes:
+
+- `self.memory`
+- `self.model`
+- `self.agent_name`
+- `self.use_hierarchical`
+- `self.loop`
+- `self.executor`
+- `self._thread_local`
+- `self._pre_snapshot_facts`
+- `self.prompt_variant`
+- `self._variant_system_prompt`
+
+This keeps the internal modules focused on behavior, not lifecycle.
+
+## Dependency direction
+
+Imports move in one direction only:
+
+1. **Leaf behavior**
+   - `intent_detector.py`
+   - `temporal_reasoning.py`
+   - `code_synthesis.py`
+   - `knowledge_utils.py`
+2. **Stateful pipelines**
+   - `learning_ingestion.py`
+   - `retrieval_strategies.py`
+3. **Orchestration**
+   - `answer_synthesizer.py`
+4. **Public facade**
+   - `learning_agent.py`
+
+Lower layers do not import higher layers. The facade assembles everything.
+
+## How learning flows through the modules
+
+`learn_from_content()` still looks like one operation to callers, but the work is now easier to follow:
+
+```mermaid
+flowchart TD
+    A[learn_from_content] --> B[learning_agent.py facade]
+    B --> C[learning_ingestion.prepare_fact_batch]
+    C --> D[temporal metadata detection]
+    C --> E[LLM fact extraction]
+    C --> F[summary concept map generation]
+    B --> G[learning_ingestion.store_fact_batch]
+    G --> H[memory backend]
+    H --> I[get_memory_stats / later retrieval]
+```
+
+Key properties:
+
+- content truncation and source-label derivation live with ingestion
+- temporal metadata detection stays near storage preparation
+- batch preparation and batch storage stay together so the data contract is obvious
+
+## How answering flows through the modules
+
+The read path is now explicitly staged:
+
+```mermaid
+flowchart TD
+    A[answer_question] --> B[learning_agent.py facade]
+    B --> C[intent_detector]
+    C --> D[retrieval_strategies]
+    D --> E[knowledge_utils math helpers]
+    D --> F[temporal_reasoning]
+    F --> G[code_synthesis]
+    D --> H[answer_synthesizer]
+    H --> I[store Q and A if enabled]
+    I --> J[final answer]
+```
+
+That flow matters because each stage answers a different question:
+
+- **Intent detector**: what kind of question is this?
+- **Retrieval strategies**: what facts should we bring back?
+- **Knowledge utilities**: do we need deterministic arithmetic first?
+- **Temporal reasoning**: is there a chronological chain to compute?
+- **Code synthesis**: do we need generated code for a hard temporal lookup?
+- **Answer synthesizer**: how do we turn the facts into a final answer?
+
+## Agentic answering still builds on single-shot answering
+
+`answer_question_agentic()` remains additive rather than divergent.
+
+It still:
+
+1. runs the standard single-shot pipeline first
+2. evaluates answer completeness
+3. retrieves more facts only when specific gaps exist
+4. re-synthesizes from the original answer plus additional evidence
+
+That means the refactor preserves the existing design rule: agentic mode should not score worse than the single-shot baseline.
+
+## Test layout after the split
+
+The old `test_learning_agent.py` monolith is replaced by module-aligned test files:
+
+| Test file | Primary scope |
+| --- | --- |
+| `tests/agents/goal_seeking/test_learning_agent_core.py` | facade construction, retry helpers, lifecycle |
+| `tests/agents/goal_seeking/test_learning_agent_ingestion.py` | batch prep, storage, source labels, temporal metadata |
+| `tests/agents/goal_seeking/test_learning_agent_retrieval.py` | retrieval strategies, aggregation, fallbacks |
+| `tests/agents/goal_seeking/test_learning_agent_temporal.py` | temporal parsing, transition chains, generated temporal code |
+
+The existing broader behavior tests remain in place:
+
+- `test_math_intent.py`
+- `test_agentic_answer_mode.py`
+- `test_goal_seeking_agent.py`
+
+## Maintenance guardrails
+
+The refactor keeps a few hard boundaries in place:
+
+- each primary extracted module stays small enough to review comfortably
+- `learning_agent.py` stays intentionally thin
+- no circular imports
+- no dead imports
+- public method signatures stay stable
+- new helper logic goes to the owning module, not back into the facade
+
+## When to touch each layer
+
+Use this rule of thumb before editing:
+
+- change **classification** logic in `intent_detector.py`
+- change **time-aware interpretation** in `temporal_reasoning.py`
+- change **deterministic computation** in `code_synthesis.py` or `knowledge_utils.py`
+- change **fact extraction or storage** in `learning_ingestion.py`
+- change **which facts are retrieved** in `retrieval_strategies.py`
+- change **how final answers are phrased or refined** in `answer_synthesizer.py`
+- change **construction, lifecycle, or compatibility wiring** in `learning_agent.py`
+
+## Related reading
+
+- Start with the [Goal-Seeking Agents overview](../GOAL_SEEKING_AGENTS.md) for the broader system.
+- Use the [LearningAgent module reference](../reference/learning-agent-module-reference.md) for the exact public API and file ownership map.
+- Use [How to maintain and extend the refactored LearningAgent](../howto/maintain-learning-agent-modules.md) when making changes.
+- Follow the [LearningAgent refactor tutorial](../tutorials/learning-agent-refactor-tutorial.md) for an end-to-end walkthrough.

--- a/docs/howto/maintain-learning-agent-modules.md
+++ b/docs/howto/maintain-learning-agent-modules.md
@@ -1,0 +1,232 @@
+---
+title: How to maintain and extend the refactored LearningAgent
+description: Task-oriented guidance for choosing the right module, changing behavior safely, and validating the split LearningAgent implementation.
+last_updated: 2026-03-30
+review_schedule: quarterly
+owner: goal-seeking
+doc_type: howto
+related:
+  - ../GOAL_SEEKING_AGENTS.md
+  - ../concepts/learning-agent-module-architecture.md
+  - ../reference/learning-agent-module-reference.md
+  - ../tutorials/learning-agent-refactor-tutorial.md
+---
+
+# How to maintain and extend the refactored LearningAgent
+
+This guide shows how to change the refactored `LearningAgent` without rebuilding a monolith by accident.
+
+## Prerequisites
+
+- [ ] You know whether your change affects learning, retrieval, temporal reasoning, or synthesis.
+- [ ] You have read the [LearningAgent module architecture](../concepts/learning-agent-module-architecture.md).
+- [ ] You are preserving the existing `LearningAgent` public methods.
+
+## 1. Choose the owning module first
+
+Pick the destination before touching code.
+
+| If you are changing... | Edit... |
+| --- | --- |
+| question classification or routing metadata | `intent_detector.py` |
+| temporal parsing or transition chain logic | `temporal_reasoning.py` |
+| generated Python for temporal lookups | `code_synthesis.py` |
+| arithmetic helpers or fact validation | `knowledge_utils.py` |
+| batch extraction or storage | `learning_ingestion.py` |
+| which facts are retrieved | `retrieval_strategies.py` |
+| final answer wording or completeness scoring | `answer_synthesizer.py` |
+| construction, lifecycle, or compatibility wiring | `learning_agent.py` |
+
+If more than one row applies, start with the lowest-level module and keep the facade changes minimal.
+
+## 2. Keep the facade thin
+
+Use `learning_agent.py` only for:
+
+- construction
+- shared state
+- action registration
+- lifecycle
+- delegation to owner modules
+
+Do not move new business logic back into the facade just because it is already imported there.
+
+## 3. Add behavior in the owner module
+
+For example, to add a new retrieval strategy:
+
+1. extend `retrieval_strategies.py`
+2. reuse helpers from `knowledge_utils.py` or `temporal_reasoning.py` if needed
+3. keep `answer_synthesizer.py` focused on answer generation, not retrieval
+4. expose the new path by delegation, not by bypassing the facade
+
+For example, to tune an intent:
+
+1. update the label or metadata in `intent_detector.py`
+2. keep the retrieval branch selection in `answer_synthesizer.py` or `retrieval_strategies.py`
+3. add or update tests in the matching test file
+
+## 4. Preserve the public API
+
+The following signatures must stay callable:
+
+```python
+async def learn_from_content(self, content: str) -> dict[str, Any]
+async def answer_question(
+    self,
+    question: str,
+    question_level: str = "L1",
+    return_trace: bool = False,
+    _skip_qanda_store: bool = False,
+    _force_simple: bool = False,
+) -> str | tuple[str, ReasoningTrace | None]
+async def answer_question_agentic(
+    self,
+    question: str,
+    max_iterations: int = 3,
+    return_trace: bool = False,
+) -> str | tuple[str, ReasoningTrace | None]
+def get_memory_stats(self) -> dict[str, Any]
+def flush_memory(self) -> None
+def close(self) -> None
+```
+
+Also preserve these compatibility expectations:
+
+- `LearningAgent` still imports from `learning_agent.py`
+- `GoalSeekingAgent` callers do not need code changes
+- `__init__.py` behavior stays backward compatible
+
+## 5. Update the module-aligned tests
+
+Put the test next to the responsibility you changed.
+
+| Change type | Test file |
+| --- | --- |
+| constructor or lifecycle | `test_learning_agent_core.py` |
+| ingestion or storage | `test_learning_agent_ingestion.py` |
+| retrieval logic | `test_learning_agent_retrieval.py` |
+| temporal or generated-code logic | `test_learning_agent_temporal.py` |
+| intent or arithmetic behavior | `test_math_intent.py` |
+| answer refinement behavior | `test_agentic_answer_mode.py` |
+| top-level agent compatibility | `test_goal_seeking_agent.py` |
+
+## 6. Run focused validation
+
+Run the goal-seeking checks from the repository root:
+
+```bash
+uv run ruff check src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run pyright src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run python -m pytest tests/agents/goal_seeking/
+```
+
+If you only changed one area, run its module-aligned tests first and then run the full goal-seeking test suite.
+
+## Configuration tasks
+
+### Configure a specific model
+
+Pass `model` when constructing the agent:
+
+```python
+from amplihack.agents.goal_seeking.learning_agent import LearningAgent
+
+agent = LearningAgent(
+    agent_name="release-notes",
+    model="claude-opus-4-6",
+)
+```
+
+If you omit `model`, `LearningAgent` falls back to `EVAL_MODEL`.
+
+### Enable hierarchical memory
+
+```python
+from pathlib import Path
+
+from amplihack.agents.goal_seeking.learning_agent import LearningAgent
+
+agent = LearningAgent(
+    agent_name="timeline-analyst",
+    storage_path=Path("./memory"),
+    use_hierarchical=True,
+)
+```
+
+When hierarchical mode is enabled, the agent stores richer provenance and temporal metadata through the cognitive or hierarchical memory adapters.
+
+### Use a prompt variant
+
+```python
+from amplihack.agents.goal_seeking.learning_agent import LearningAgent
+
+agent = LearningAgent(
+    agent_name="variant-check",
+    prompt_variant=3,
+)
+```
+
+Use prompt variants for evaluation or controlled experiments. The refactor does not change the prompt-variant interface.
+
+## Common maintenance patterns
+
+### Add a new temporal shortcut
+
+Edit `temporal_reasoning.py` when the answer can be derived from stored transitions without full synthesis.
+
+Use this when:
+
+- the query asks for latest, earliest, before, after, or delta-style answers
+- the answer is deterministic from stored state changes
+
+### Add a new aggregation retrieval
+
+Edit `retrieval_strategies.py` when the question is about:
+
+- counts
+- unique entities
+- list-all enumerations
+- meta-memory summaries
+
+Keep factual aggregation separate from final narrative synthesis.
+
+### Change answer wording
+
+Edit `answer_synthesizer.py` when you are changing:
+
+- prompt templates
+- completeness evaluation criteria
+- how retrieved facts are combined into final prose
+
+Do not move answer-formatting rules into retrieval code.
+
+## Troubleshooting
+
+### Circular imports appear after extraction
+
+**Symptom**: importing `LearningAgent` pulls higher-level modules back into leaf modules.
+
+**Fix**:
+
+1. move the helper to the lower-level owner module
+2. keep `learning_agent.py` as the importer of last resort
+3. avoid leaf modules importing the facade
+
+### The facade starts growing again
+
+**Symptom**: new helper methods accumulate in `learning_agent.py`.
+
+**Fix**: move the helper to the responsible module and delegate from the facade.
+
+### A new test does not have an obvious home
+
+**Symptom**: a test touches multiple modules.
+
+**Fix**: place it with the module that owns the behavior being asserted. Use higher-level compatibility tests only when the behavior is genuinely cross-cutting.
+
+## See also
+
+- [LearningAgent module reference](../reference/learning-agent-module-reference.md)
+- [LearningAgent module architecture](../concepts/learning-agent-module-architecture.md)
+- [Tutorial: trace the refactored LearningAgent end to end](../tutorials/learning-agent-refactor-tutorial.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,6 +156,11 @@ Understand the philosophy and architecture behind amplihack.
 - [Unified Staging Architecture](concepts/unified-staging-architecture.md) - How .claude/ staging works across all commands
 - [Framework Injection Architecture](concepts/framework-injection-architecture.md) - How AMPLIHACK.md injection works
 - [Unified Distributed Cognitive Memory](concepts/unified-distributed-cognitive-memory.md) - Planned architecture for deterministic cluster-wide memory retrieval
+- [Goal-Seeking Agents](GOAL_SEEKING_AGENTS.md) - Overview of generated agents and the shared LearningAgent engine
+- [LearningAgent Module Architecture](concepts/learning-agent-module-architecture.md) - How the refactored LearningAgent is split into focused modules
+- [LearningAgent Refactor Tutorial](tutorials/learning-agent-refactor-tutorial.md) - Walk through learning, retrieval, and temporal answering in the split module design
+- [Maintain the Refactored LearningAgent](howto/maintain-learning-agent-modules.md) - Contributor workflow for changing ingestion, retrieval, temporal logic, and synthesis
+- [LearningAgent Module Reference](reference/learning-agent-module-reference.md) - Public API, configuration knobs, ownership map, and validation commands
 - [How to Use Blarify Code Graph](howto/blarify-code-graph.md) - Enable, query, and configure
 - [Enable Blarify Code Indexing](howto/enable-blarify.md) - `AMPLIHACK_ENABLE_BLARIFY`, non-interactive skip, staleness detection
 - [Blarify Architecture](blarify_architecture.md) - Understanding the Blarify integration

--- a/docs/reference/goal-seeking-agents-quick-reference.md
+++ b/docs/reference/goal-seeking-agents-quick-reference.md
@@ -231,7 +231,11 @@ my_agent/
 ## Related Documentation
 
 - **Tutorial**: [Goal-Seeking Agent Tutorial](../tutorials/GOAL_SEEKING_AGENT_TUTORIAL.md)
+- **Tutorial**: [LearningAgent Refactor Walkthrough](../tutorials/learning-agent-refactor-tutorial.md)
 - **How-To**: [Goal Agent Generator Guide](../GOAL_AGENT_GENERATOR_GUIDE.md)
+- **How-To**: [Maintain the Refactored LearningAgent](../howto/maintain-learning-agent-modules.md)
 - **Reference**: [Eval System Architecture](../EVAL_SYSTEM_ARCHITECTURE.md)
+- **Reference**: [LearningAgent Module Reference](./learning-agent-module-reference.md)
 - **Explanation**: [Comprehensive Guide](../GOAL_SEEKING_AGENTS.md)
+- **Explanation**: [LearningAgent Module Architecture](../concepts/learning-agent-module-architecture.md)
 - **SDK Guide**: [SDK Adapters Guide](../SDK_ADAPTERS_GUIDE.md)

--- a/docs/reference/learning-agent-module-reference.md
+++ b/docs/reference/learning-agent-module-reference.md
@@ -1,0 +1,298 @@
+---
+title: LearningAgent Module Reference
+description: Public API, configuration surface, file ownership, and validation references for the refactored LearningAgent.
+last_updated: 2026-03-30
+review_schedule: quarterly
+owner: goal-seeking
+doc_type: reference
+related:
+  - ../GOAL_SEEKING_AGENTS.md
+  - ../concepts/learning-agent-module-architecture.md
+  - ../howto/maintain-learning-agent-modules.md
+  - ../tutorials/learning-agent-refactor-tutorial.md
+---
+
+# LearningAgent Module Reference
+
+## Overview
+
+`LearningAgent` is the shared goal-seeking engine responsible for:
+
+- learning facts from content
+- retrieving knowledge from memory
+- reasoning about temporal changes
+- synthesizing final answers with an LLM
+
+The refactor preserves the existing public API while moving implementation details into focused modules.
+
+## Compatibility imports
+
+| Import | Status | Notes |
+| --- | --- | --- |
+| `from amplihack.agents.goal_seeking.learning_agent import LearningAgent` | Primary compatibility path | Stable import path for direct callers |
+| `from amplihack.agents.goal_seeking import LearningAgent` | Supported for backward compatibility | Import works even though `LearningAgent` is not added to `__all__` |
+| `from amplihack.agents.goal_seeking import GoalSeekingAgent` | Preferred public entry point | `GoalSeekingAgent` delegates learning and answering work to `LearningAgent` |
+
+## Constructor
+
+```python
+LearningAgent(
+    agent_name: str = "learning_agent",
+    model: str | None = None,
+    storage_path: Path | None = None,
+    use_hierarchical: bool = False,
+    prompt_variant: int | None = None,
+    **kwargs: Any,
+)
+```
+
+### Constructor parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `agent_name` | `str` | `"learning_agent"` | Memory namespace and runtime identity |
+| `model` | `str \| None` | `None` | Explicit LLM model override |
+| `storage_path` | `Path \| None` | `None` | Custom memory storage location |
+| `use_hierarchical` | `bool` | `False` | Use cognitive or hierarchical memory adapters instead of the flat retriever |
+| `prompt_variant` | `int \| None` | `None` | Load a synthesis prompt variant instead of the default prompt |
+| `**kwargs` | `Any` | - | Reserved compatibility surface for callers and wrappers |
+
+## Public methods
+
+### `learn_from_content`
+
+```python
+async def learn_from_content(self, content: str) -> dict[str, Any]
+```
+
+Extracts facts from content, attaches source and temporal metadata, stores the resulting facts, and optionally stores a summary concept map.
+
+**Returns**
+
+| Key | Meaning |
+| --- | --- |
+| `facts_extracted` | Number of facts extracted from the content |
+| `facts_stored` | Number of facts written to memory |
+| `content_summary` | Short summary of the learned content |
+
+### `answer_question`
+
+```python
+async def answer_question(
+    self,
+    question: str,
+    question_level: str = "L1",
+    return_trace: bool = False,
+    _skip_qanda_store: bool = False,
+    _force_simple: bool = False,
+) -> str | tuple[str, ReasoningTrace | None]
+```
+
+Runs the standard answer pipeline:
+
+1. detect intent
+2. select retrieval strategy
+3. perform math or temporal preprocessing when needed
+4. synthesize the final answer
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `question` | `str` | required | Question to answer |
+| `question_level` | `str` | `"L1"` | Difficulty hint for prompt selection and synthesis style |
+| `return_trace` | `bool` | `False` | Return a `ReasoningTrace` alongside the answer |
+| `_skip_qanda_store` | `bool` | `False` | Internal flag used to skip writing Q and A history facts |
+| `_force_simple` | `bool` | `False` | Internal flag used to force exhaustive simple retrieval in fallback cases |
+
+### `answer_question_agentic`
+
+```python
+async def answer_question_agentic(
+    self,
+    question: str,
+    max_iterations: int = 3,
+    return_trace: bool = False,
+) -> str | tuple[str, ReasoningTrace | None]
+```
+
+Runs the single-shot answer pipeline first, checks completeness, searches for missing facts, and re-synthesizes only when that adds information.
+
+### `get_memory_stats`
+
+```python
+def get_memory_stats(self) -> dict[str, Any]
+```
+
+Returns memory statistics from the active backend.
+
+### `flush_memory`
+
+```python
+def flush_memory(self) -> None
+```
+
+Flushes memory caches without discarding stored knowledge.
+
+### `close`
+
+```python
+def close(self) -> None
+```
+
+Closes the underlying memory backend and releases agent resources.
+
+## Module ownership map
+
+The eight primary files are the stable ownership boundaries for the refactor.
+
+| File | Owns |
+| --- | --- |
+| `learning_agent.py` | constructor, shared state, lifecycle, retry helpers, public delegation |
+| `learning_ingestion.py` | ingestion pipeline, fact batch preparation, source labels, summary storage |
+| `answer_synthesizer.py` | answer synthesis, completeness evaluation, prompt assembly |
+| `retrieval_strategies.py` | retrieval selection, simple/entity/concept/aggregation strategies |
+| `intent_detector.py` | intent classification and routing metadata |
+| `temporal_reasoning.py` | transition chains, temporal lookups, temporal parsing |
+| `code_synthesis.py` | generated Python for hard temporal reasoning cases |
+| `knowledge_utils.py` | arithmetic validation, knowledge explanation, fact verification helpers |
+
+## Expected method placement
+
+The refactor keeps these methods with their owning modules.
+
+### `learning_ingestion.py`
+
+- `learn_from_content`
+- `_truncate_learning_content`
+- `_extract_source_label`
+- `_build_store_fact_kwargs`
+- `_build_summary_store_kwargs`
+- `prepare_fact_batch`
+- `store_fact_batch`
+- `_store_summary_concept_map`
+- `_detect_temporal_metadata_fast`
+- `_detect_temporal_metadata`
+- `_extract_facts_with_llm`
+
+### `intent_detector.py`
+
+- `_detect_intent`
+- `SIMPLE_INTENTS`
+- `AGGREGATION_INTENTS`
+
+### `temporal_reasoning.py`
+
+- `_transition_chain_from_facts`
+- `retrieve_transition_chain`
+- `_extract_temporal_state_values`
+- `_collapse_change_count_transitions`
+- `_collapse_temporal_lookup_transitions`
+- `_format_temporal_lookup_answer`
+- `_parse_temporal_index`
+- `_heuristic_temporal_entity_field`
+- `_should_short_circuit_temporal_answer`
+
+### `code_synthesis.py`
+
+- `temporal_code_synthesis`
+- `_code_generation_tool`
+
+### `knowledge_utils.py`
+
+- `_validate_arithmetic`
+- `_compute_math_result`
+- `_explain_knowledge`
+- `_find_knowledge_gaps`
+- `_verify_fact`
+- `get_memory_stats`
+
+### `retrieval_strategies.py`
+
+- `_simple_retrieval`
+- `_keyword_expanded_retrieval`
+- `_entity_retrieval`
+- `_concept_retrieval`
+- `_aggregation_retrieval`
+- `_get_summary_nodes`
+- and the rest of the retrieval-adjacent helpers that support those strategies
+
+### `answer_synthesizer.py`
+
+- `answer_question`
+- `answer_question_agentic`
+- `_evaluate_answer_completeness`
+- `_synthesize_with_llm`
+
+## Registered actions
+
+The facade still registers the same high-level actions on `ActionExecutor`.
+
+| Action | Backing behavior |
+| --- | --- |
+| `read_content` | content ingestion input helper |
+| `search_memory` | memory lookup through the active backend |
+| `synthesize_answer` | LLM synthesis via `answer_synthesizer.py` |
+| `calculate` | deterministic arithmetic helper |
+| `code_generation` | temporal code generation via `code_synthesis.py` |
+| `explain_knowledge` | topic explanation helper |
+| `find_knowledge_gaps` | knowledge gap analysis |
+| `verify_fact` | fact validation against stored knowledge |
+
+## Configuration surface
+
+The refactor does not add new runtime configuration. It preserves the existing knobs.
+
+### Constructor-driven configuration
+
+| Knob | Scope | Effect |
+| --- | --- | --- |
+| `model` | extraction and synthesis | Chooses the LLM used for prompts and completions |
+| `storage_path` | memory backend | Changes where memory data is stored |
+| `use_hierarchical` | memory backend | Selects `CognitiveAdapter` or `FlatRetrieverAdapter` when available |
+| `prompt_variant` | synthesis | Loads a variant prompt for eval or experimentation |
+
+### Environment variables
+
+| Variable | Used when | Effect |
+| --- | --- | --- |
+| `EVAL_MODEL` | `model` is omitted | Provides the default LLM model name |
+
+No new environment variables are introduced by the module split.
+
+## Internal helper modules
+
+Private support files may exist to keep the primary modules small. Two common patterns are expected:
+
+- retrieval support helpers such as `_retrieval_core.py`, `_retrieval_entity.py`, and `_retrieval_meta.py`
+- synthesis support helpers such as `_answer_prompting.py`
+
+These files stay private implementation details. Callers should continue to target `LearningAgent`, not individual support modules.
+
+## Test layout
+
+| Test file | Scope |
+| --- | --- |
+| `test_learning_agent_core.py` | constructor, retry, lifecycle |
+| `test_learning_agent_ingestion.py` | ingestion and storage |
+| `test_learning_agent_retrieval.py` | retrieval strategies and fallbacks |
+| `test_learning_agent_temporal.py` | temporal reasoning and code synthesis |
+| `test_math_intent.py` | math and intent behavior |
+| `test_agentic_answer_mode.py` | answer refinement behavior |
+| `test_goal_seeking_agent.py` | higher-level agent compatibility |
+
+## Validation commands
+
+The refactored LearningAgent is validated with focused checks:
+
+```bash
+uv run ruff check src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run pyright src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run python -m pytest tests/agents/goal_seeking/
+```
+
+## Related docs
+
+- [Understanding the LearningAgent module architecture](../concepts/learning-agent-module-architecture.md)
+- [How to maintain and extend the refactored LearningAgent](../howto/maintain-learning-agent-modules.md)
+- [Tutorial: trace the refactored LearningAgent end to end](../tutorials/learning-agent-refactor-tutorial.md)

--- a/docs/tutorials/learning-agent-refactor-tutorial.md
+++ b/docs/tutorials/learning-agent-refactor-tutorial.md
@@ -1,0 +1,209 @@
+---
+title: "Tutorial: Trace the refactored LearningAgent end to end"
+description: Learn the refactored LearningAgent by loading facts, asking direct and temporal questions, and mapping each step to its owning module.
+last_updated: 2026-03-30
+review_schedule: quarterly
+owner: goal-seeking
+doc_type: tutorial
+related:
+  - ../GOAL_SEEKING_AGENTS.md
+  - ../concepts/learning-agent-module-architecture.md
+  - ../howto/maintain-learning-agent-modules.md
+  - ../reference/learning-agent-module-reference.md
+---
+
+# Tutorial: Trace the refactored LearningAgent end to end
+
+In this tutorial, we will create a small `LearningAgent`, teach it a few timeline facts, ask direct and temporal questions, and connect each step back to the module that owns the behavior.
+
+## What you will learn
+
+- how to construct a `LearningAgent` after the refactor
+- how learning flows through ingestion and storage
+- how direct questions and temporal questions follow different paths
+- how to map observed behavior back to the owning module
+
+## Prerequisites
+
+- Python environment with amplihack available
+- familiarity with async Python
+- basic understanding of goal-seeking agents
+
+## Time required
+
+Approximately 20 minutes.
+
+---
+
+## Step 1: Create a small tutorial script
+
+Create `tutorial_learning_agent.py`:
+
+```python
+import asyncio
+from pathlib import Path
+
+from amplihack.agents.goal_seeking.learning_agent import LearningAgent
+
+
+CONTENT = """
+Title: Release timeline
+Project Atlas shipped version 1.0 in January 2026.
+Project Atlas shipped version 1.1 in February 2026.
+Project Atlas shipped version 1.2 in March 2026.
+The March release added 14 workflow fixes.
+"""
+
+
+async def main() -> None:
+    agent = LearningAgent(
+        agent_name="tutorial-learning-agent",
+        storage_path=Path("./tutorial-memory"),
+        use_hierarchical=True,
+    )
+
+    try:
+        learning_result = await agent.learn_from_content(CONTENT)
+        print("Learned:", learning_result)
+
+        recall_answer = await agent.answer_question(
+            "What version shipped in February 2026?"
+        )
+        print("Recall:", recall_answer)
+
+        temporal_answer = await agent.answer_question_agentic(
+            "How did the Project Atlas version change from January 2026 to March 2026?"
+        )
+        print("Temporal:", temporal_answer)
+
+        print("Stats:", agent.get_memory_stats())
+    finally:
+        agent.close()
+
+
+asyncio.run(main())
+```
+
+**Expected result**: you have a complete, minimal script that exercises learning, direct answering, temporal answering, and memory statistics.
+
+## Step 2: Run the tutorial script
+
+```bash
+uv run python tutorial_learning_agent.py
+```
+
+You should see four outputs:
+
+- a learning result dictionary
+- a direct-answer response
+- an agentic temporal response
+- memory statistics
+
+---
+
+## Step 3: Map the learning path to modules
+
+The call to `learn_from_content()` now crosses a small number of ownership boundaries:
+
+1. `learning_agent.py` receives the public method call.
+2. `learning_ingestion.py` prepares the fact batch.
+3. `learning_ingestion.py` detects source labels and temporal metadata.
+4. `learning_ingestion.py` stores facts and the optional summary concept map.
+5. the configured memory backend persists the result.
+
+The important point is that callers still use the old method name. The refactor changes the implementation layout, not the public learning surface.
+
+## Step 4: Map the direct answer path
+
+The call to:
+
+```python
+await agent.answer_question("What version shipped in February 2026?")
+```
+
+follows this path:
+
+1. `learning_agent.py` delegates the request.
+2. `intent_detector.py` classifies the question.
+3. `retrieval_strategies.py` selects the retrieval path.
+4. `answer_synthesizer.py` turns the retrieved facts into the final answer.
+
+For a direct recall question, temporal code generation is usually not involved.
+
+## Step 5: Map the temporal answer path
+
+The call to:
+
+```python
+await agent.answer_question_agentic(
+    "How did the Project Atlas version change from January 2026 to March 2026?"
+)
+```
+
+adds the temporal and refinement layers:
+
+1. `answer_synthesizer.py` runs the standard single-shot answer first.
+2. `intent_detector.py` marks the question as temporal.
+3. `retrieval_strategies.py` retrieves candidate facts.
+4. `temporal_reasoning.py` assembles transition chains or direct temporal lookups.
+5. `code_synthesis.py` generates deterministic Python when the temporal lookup is too complex for a simple shortcut.
+6. `answer_synthesizer.py` evaluates completeness and re-synthesizes only if more facts are needed.
+
+**Checkpoint**: you should now be able to explain why temporal logic lives outside the facade.
+
+## Step 6: Inspect the module layout
+
+After the refactor, the goal-seeking package contains these primary files:
+
+```text
+src/amplihack/agents/goal_seeking/
+├── learning_agent.py
+├── learning_ingestion.py
+├── answer_synthesizer.py
+├── retrieval_strategies.py
+├── intent_detector.py
+├── temporal_reasoning.py
+├── code_synthesis.py
+└── knowledge_utils.py
+```
+
+Keep this rule in mind:
+
+- the facade owns state and delegation
+- the leaf modules own behavior
+
+---
+
+## Step 7: Run the goal-seeking validation suite
+
+From the repository root:
+
+```bash
+uv run ruff check src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run pyright src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run python -m pytest tests/agents/goal_seeking/
+```
+
+If you only changed a temporal path, start with:
+
+```bash
+uv run python -m pytest tests/agents/goal_seeking/test_learning_agent_temporal.py
+```
+
+**Expected result**: the module-aligned tests confirm that the refactor preserved behavior while keeping responsibilities separated.
+
+## Summary
+
+You used the refactored `LearningAgent` exactly as before, but the internal path is now clearer:
+
+- learning work flows through `learning_ingestion.py`
+- question classification lives in `intent_detector.py`
+- retrieval stays in `retrieval_strategies.py`
+- temporal logic lives in `temporal_reasoning.py` and `code_synthesis.py`
+- final answer generation stays in `answer_synthesizer.py`
+
+## Next steps
+
+- Read the [LearningAgent module architecture](../concepts/learning-agent-module-architecture.md) for the rationale behind the split.
+- Use the [LearningAgent module reference](../reference/learning-agent-module-reference.md) when you need exact signatures or ownership rules.
+- Follow [How to maintain and extend the refactored LearningAgent](../howto/maintain-learning-agent-modules.md) before making changes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,13 @@ nav:
           - Eval Operator Guide: hive_mind/EVAL_OPERATOR_GUIDE.md
           - Eval Components: hive_mind/EVAL_COMPONENTS.md
           - Investigation Guide: INVESTIGATION_hive_mind_guide.md
+      - Goal-Seeking Agents:
+          - Overview: GOAL_SEEKING_AGENTS.md
+          - Generator Tutorial: tutorials/GOAL_SEEKING_AGENT_TUTORIAL.md
+          - LearningAgent Architecture: concepts/learning-agent-module-architecture.md
+          - Maintaining LearningAgent Modules: howto/maintain-learning-agent-modules.md
+          - LearningAgent Module Reference: reference/learning-agent-module-reference.md
+          - LearningAgent Refactor Tutorial: tutorials/learning-agent-refactor-tutorial.md
       - Agent Memory Integration: AGENT_MEMORY_INTEGRATION.md
       - Memory Quickstart: AGENT_MEMORY_QUICKSTART.md
       - External Knowledge: external_knowledge_integration.md


### PR DESCRIPTION
## Summary
- add retcon docs for the refactored LearningAgent module architecture
- document the preserved public API, configuration surface, and module ownership map
- add contributor how-to and tutorial pages, then link them from the goal-seeking docs and MkDocs nav

## Notes
- documentation-only change
- written as the post-refactor specification for the planned LearningAgent split

Refs #3847