### PR TITLE
docs: clarify API keys required vs optional in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ pre-commit install
 # 4. Copy the environment template
 cp .env.example .env
 # Edit .env with your API keys as needed
+# 
+# Required API Keys (needed to run tests):
+#   - AZURE_TENANT_ID (required)
+#   - AZURE_CLIENT_ID (required)  
+#   - AZURE_CLIENT_SECRET (required)
+#
+# Optional API Keys (only needed for specific features):
+#   - AZURE_SUBSCRIPTION_ID
+#   - AZURE_RESOURCE_GROUP
+#   - Other Azure-related keys for fleet management features
+#
+# Tip: You can run basic tests with just the required keys above.
 ```
 
 ### Running Tests


### PR DESCRIPTION
## Fix for issue: CONTRIBUTING.md .env setup clarification

Added explanation:
- Required API keys: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
- Optional keys: Azure fleet management features

Hope this helps new contributors!