### PR TITLE
fix(workflow): isolate stream-local worktrees (#4022)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -472,11 +472,9 @@ steps:
         CREATED=true
       fi
 
-      # Push branch to remote with tracking (idempotent).
-      # NOTE: Push failures are suppressed here and surface at step-16 PR creation.
-      # This allows idempotent re-runs where the remote branch already exists.
-      git -C "${WORKTREE_PATH}" push origin "${BRANCH_NAME}" > /dev/null 2>&1 || true
-      git -C "${WORKTREE_PATH}" branch --set-upstream-to="origin/${BRANCH_NAME}" "${BRANCH_NAME}" > /dev/null 2>&1 || true
+      # Keep setup local-only. Remote branch creation/tracking is deferred until
+      # step-15, when there is actual work to publish. This avoids redundant
+      # network round-trips on reruns and on branches that never produce a commit.
 
       echo "" >&2
       echo "=== Worktree Setup Complete ===" >&2
@@ -493,18 +491,66 @@ steps:
     output: "worktree_setup"
     parse_json: true
 
+  - id: "step-04b-validate-worktree"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      WORKTREE_DIR="{{worktree_setup.worktree_path}}"
+      EXPECTED_BRANCH="{{worktree_setup.branch_name}}"
+
+      echo "=== Step 4b: Validating Worktree ===" >&2
+
+      if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "ERROR: worktree directory '$WORKTREE_DIR' does not exist" >&2
+        exit 1
+      fi
+      WORKTREE_DIR="$(cd "$WORKTREE_DIR" && pwd -P)"
+      cd "$WORKTREE_DIR"
+
+      if [ "$(git rev-parse --is-inside-work-tree)" != "true" ]; then
+        echo "ERROR: '$WORKTREE_DIR' is not inside a git worktree" >&2
+        exit 1
+      fi
+
+      ACTUAL_TOPLEVEL="$(git rev-parse --show-toplevel)"
+      if [ "$ACTUAL_TOPLEVEL" != "$WORKTREE_DIR" ]; then
+        echo "ERROR: expected git top-level '$WORKTREE_DIR' but found '$ACTUAL_TOPLEVEL'" >&2
+        exit 1
+      fi
+
+      ACTUAL_BRANCH="$(git branch --show-current)"
+      if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+        echo "ERROR: expected branch '$EXPECTED_BRANCH' but found '$ACTUAL_BRANCH'" >&2
+        exit 1
+      fi
+
+      cat <<EOF
+      {
+        "worktree_path": "$WORKTREE_DIR",
+        "branch_name": "$ACTUAL_BRANCH",
+        "validated": true
+      }
+      EOF
+    output: "worktree_validation"
+    parse_json: true
+
   # ==========================================================================
   # STEP 5: RESEARCH AND DESIGN
   # ==========================================================================
   - id: "step-05-architecture"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5: Research and Design - Architecture
 
       **Task:** {{task_description}}
       **Requirements:** {{final_requirements}}
       **Codebase Analysis:** {{codebase_analysis}}
-      **Worktree:** {{worktree_setup}}
+      **Active Repository Root:** {{worktree_setup.worktree_path}}
+      **Worktree Metadata:** {{worktree_setup}}
+
+      Treat `{{worktree_setup.worktree_path}}` as the active repository root for all code reads, edits,
+      and commands in this stream.
 
       Design the solution architecture:
 
@@ -521,6 +567,7 @@ steps:
 
   - id: "step-05b-api-design"
     agent: "amplihack:api-designer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5b: API Design (if applicable)
 
@@ -538,6 +585,7 @@ steps:
 
   - id: "step-05c-database-design"
     agent: "amplihack:database"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5c: Database Design (if applicable)
 
@@ -555,6 +603,7 @@ steps:
 
   - id: "step-05d-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5d: Security Requirements Review
 
@@ -574,6 +623,7 @@ steps:
 
   - id: "step-05e-design-consolidation"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5e: Design Consolidation
 
@@ -603,6 +653,7 @@ steps:
   # ==========================================================================
   - id: "step-06-documentation"
     agent: "amplihack:documentation-writer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6: Retcon Documentation Writing
 
@@ -624,6 +675,7 @@ steps:
 
   - id: "step-06b-documentation-review"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6b: Documentation Review
 
@@ -640,6 +692,7 @@ steps:
 
   - id: "step-06c-documentation-refinement"
     agent: "amplihack:documentation-writer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6c: Documentation Refinement
 
@@ -655,6 +708,7 @@ steps:
   # ==========================================================================
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -684,6 +738,7 @@ steps:
   # ==========================================================================
   - id: "step-08-implement"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -713,6 +768,7 @@ steps:
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -734,19 +790,46 @@ steps:
   - id: "checkpoint-after-implementation"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}} && \
-      echo "=== Checkpoint: Staging Implementation ===" && \
-      git add -A && \
-      STAGED=$(git diff --cached --name-only) && \
-      if [ -n "$STAGED" ]; then \
+      set -euo pipefail
+      WORKTREE_DIR="{{worktree_setup.worktree_path}}"
+      EXPECTED_BRANCH="{{worktree_setup.branch_name}}"
+
+      if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "ERROR: worktree directory '$WORKTREE_DIR' does not exist" >&2
+        exit 1
+      fi
+      WORKTREE_DIR="$(cd "$WORKTREE_DIR" && pwd -P)"
+      cd "$WORKTREE_DIR"
+
+      if [ "$(git rev-parse --is-inside-work-tree)" != "true" ]; then
+        echo "ERROR: '$WORKTREE_DIR' is not inside a git worktree" >&2
+        exit 1
+      fi
+
+      ACTUAL_TOPLEVEL="$(git rev-parse --show-toplevel)"
+      if [ "$ACTUAL_TOPLEVEL" != "$WORKTREE_DIR" ]; then
+        echo "ERROR: expected git top-level '$WORKTREE_DIR' but found '$ACTUAL_TOPLEVEL'" >&2
+        exit 1
+      fi
+
+      ACTUAL_BRANCH="$(git branch --show-current)"
+      if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+        echo "ERROR: expected branch '$EXPECTED_BRANCH' but found '$ACTUAL_BRANCH'" >&2
+        exit 1
+      fi
+
+      echo "=== Checkpoint: Staging Implementation ==="
+      git add -A
+      STAGED="$(git diff --cached --name-only)"
+      if [ -n "$STAGED" ]; then
         git commit -m "wip: checkpoint after implementation (steps 7-8)
 
       Automatic checkpoint to preserve work in progress.
-      Tests and implementation saved before refactoring phase." && \
-        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)" ; \
-      else \
-        echo "No changes to checkpoint" ; \
-      fi && \
+      Tests and implementation saved before refactoring phase."
+        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)"
+      else
+        echo "No changes to checkpoint"
+      fi
       echo "=== Checkpoint Complete ==="
     output: "impl_checkpoint"
 
@@ -755,6 +838,7 @@ steps:
   # ==========================================================================
   - id: "step-09-refactor"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 9: Refactor and Simplify
 
@@ -783,6 +867,7 @@ steps:
 
   - id: "step-09b-optimize"
     agent: "amplihack:optimizer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 9b: Performance Optimization
 
@@ -803,6 +888,7 @@ steps:
   # ==========================================================================
   - id: "step-10-pre-commit-review"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 10: Review Pass Before Commit
 
@@ -834,6 +920,7 @@ steps:
 
   - id: "step-10b-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 10b: Security Review
 
@@ -853,6 +940,7 @@ steps:
 
   - id: "step-10c-philosophy-check"
     agent: "amplihack:philosophy-guardian"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 10c: Philosophy Compliance Check
 
@@ -874,6 +962,7 @@ steps:
   # ==========================================================================
   - id: "step-11-incorporate-feedback"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 11: Assess Review Feedback
 
@@ -891,6 +980,7 @@ steps:
 
   - id: "step-11b-implement-feedback"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 11b: Implement Review Feedback
 
@@ -913,19 +1003,46 @@ steps:
   - id: "checkpoint-after-review-feedback"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}} && \
-      echo "=== Checkpoint: Staging Review Feedback ===" && \
-      git add -A && \
-      STAGED=$(git diff --cached --name-only) && \
-      if [ -n "$STAGED" ]; then \
+      set -euo pipefail
+      WORKTREE_DIR="{{worktree_setup.worktree_path}}"
+      EXPECTED_BRANCH="{{worktree_setup.branch_name}}"
+
+      if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "ERROR: worktree directory '$WORKTREE_DIR' does not exist" >&2
+        exit 1
+      fi
+      WORKTREE_DIR="$(cd "$WORKTREE_DIR" && pwd -P)"
+      cd "$WORKTREE_DIR"
+
+      if [ "$(git rev-parse --is-inside-work-tree)" != "true" ]; then
+        echo "ERROR: '$WORKTREE_DIR' is not inside a git worktree" >&2
+        exit 1
+      fi
+
+      ACTUAL_TOPLEVEL="$(git rev-parse --show-toplevel)"
+      if [ "$ACTUAL_TOPLEVEL" != "$WORKTREE_DIR" ]; then
+        echo "ERROR: expected git top-level '$WORKTREE_DIR' but found '$ACTUAL_TOPLEVEL'" >&2
+        exit 1
+      fi
+
+      ACTUAL_BRANCH="$(git branch --show-current)"
+      if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+        echo "ERROR: expected branch '$EXPECTED_BRANCH' but found '$ACTUAL_BRANCH'" >&2
+        exit 1
+      fi
+
+      echo "=== Checkpoint: Staging Review Feedback ==="
+      git add -A
+      STAGED="$(git diff --cached --name-only)"
+      if [ -n "$STAGED" ]; then
         git commit -m "wip: checkpoint after review feedback (steps 10-11)
 
       Automatic checkpoint to preserve review-addressed changes.
-      Saved before running pre-commit hooks and tests." && \
-        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)" ; \
-      else \
-        echo "No changes to checkpoint" ; \
-      fi && \
+      Saved before running pre-commit hooks and tests."
+        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)"
+      else
+        echo "No changes to checkpoint"
+      fi
       echo "=== Checkpoint Complete ==="
     output: "review_checkpoint"
 
@@ -934,6 +1051,7 @@ steps:
   # ==========================================================================
   - id: "step-12-run-precommit"
     agent: "amplihack:pre-commit-diagnostic"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 12: Run Tests and Pre-commit Hooks
 
@@ -971,11 +1089,12 @@ steps:
   # ==========================================================================
   - id: "step-13-local-testing"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 13: Mandatory Outside-In Testing (CANNOT BE SKIPPED)
 
       **Task:** {{task_description}}
-      **Repository:** {{repo_path}}
+      **Repository Worktree:** {{worktree_setup.worktree_path}}
       **Branch:** Run `git branch --show-current` to get the current branch name.
 
       You MUST perform outside-in testing using the `qa-team` skill (`outside-in-testing` remains an alias)
@@ -1053,6 +1172,7 @@ steps:
   # ==========================================================================
   - id: "step-14-bump-version"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 14: Bump Version in pyproject.toml (MANDATORY - DO NOT SKIP)
 
@@ -1063,7 +1183,7 @@ steps:
       Before committing changes to git history, bump the version number in `pyproject.toml` to reflect the nature of your changes.
 
       **Task:** {{task_description}}
-      **Repository:** {{repo_path}}
+      **Repository Worktree:** {{worktree_setup.worktree_path}}
 
       **Actions Required:**
 
@@ -1090,7 +1210,7 @@ steps:
 
       **Commands to execute:**
       ```bash
-      cd {{repo_path}}
+      cd {{worktree_setup.worktree_path}}
 
       # Show changes
       git diff main...HEAD --stat
@@ -1139,25 +1259,67 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
-      cd "{{worktree_setup.worktree_path}}"
+      WORKTREE_DIR="{{worktree_setup.worktree_path}}"
+      EXPECTED_BRANCH="{{worktree_setup.branch_name}}"
+      HAS_REMOTE=false
+
+      if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "ERROR: worktree directory '$WORKTREE_DIR' does not exist" >&2
+        exit 1
+      fi
+      WORKTREE_DIR="$(cd "$WORKTREE_DIR" && pwd -P)"
+      cd "$WORKTREE_DIR"
+
+      if [ "$(git rev-parse --is-inside-work-tree)" != "true" ]; then
+        echo "ERROR: '$WORKTREE_DIR' is not inside a git worktree" >&2
+        exit 1
+      fi
+
+      ACTUAL_TOPLEVEL="$(git rev-parse --show-toplevel)"
+      if [ "$ACTUAL_TOPLEVEL" != "$WORKTREE_DIR" ]; then
+        echo "ERROR: expected git top-level '$WORKTREE_DIR' but found '$ACTUAL_TOPLEVEL'" >&2
+        exit 1
+      fi
+
+      ACTUAL_BRANCH="$(git branch --show-current)"
+      if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+        echo "ERROR: expected branch '$EXPECTED_BRANCH' but found '$ACTUAL_BRANCH'" >&2
+        exit 1
+      fi
+
+      if git remote get-url origin >/dev/null 2>&1; then
+        HAS_REMOTE=true
+      fi
+
       echo "=== Step 15: Commit and Push ==="
       echo ""
       echo "--- Staging Changes ---"
       git add -A
       echo ""
       echo "--- Creating Commit ---"
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
       TASK_DESC=$(cat <<EOFTASKDESC
       {{task_description}}
       EOFTASKDESC
       )
       COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
-      COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" {{issue_number}} {{issue_number}})
+      COMMIT_MSG=$(cat <<EOF
+      $COMMIT_TITLE
+
+      Implements issue #{{issue_number}}
+
+      Changes:
+      - Implementation as per design specification
+      - Tests added for new functionality
+      - Documentation updated
+
+      Closes #{{issue_number}}
+      EOF
+      )
       if [ -n "$(git diff --cached --name-only)" ]; then
         git commit -m "$COMMIT_MSG"
       else
         echo "ERROR: Nothing staged to commit. The implementation step may have written files" >&2
-        echo "outside the worktree ({{worktree_setup.worktree_path}}), or no code changes were produced." >&2
+        echo "outside the worktree ($WORKTREE_DIR), or no code changes were produced." >&2
         echo "This is a hollow-success condition — the workflow completed structurally but" >&2
         echo "produced no git artifacts. Check that agents created files in the worktree," >&2
         echo "not in AMPLIHACK_HOME or other locations." >&2
@@ -1166,19 +1328,28 @@ steps:
       fi
       echo ""
       echo "--- Pushing to Remote ---"
-      # REL-002: Detect missing upstream tracking branch before rev-list
-      if ! git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
-        echo "WARNING: No upstream tracking branch configured — skipping push" >&2
+      if [ "$HAS_REMOTE" != "true" ]; then
+        echo "WARNING: No origin remote configured — skipping push" >&2
         exit 0
       fi
-      COMMITS_AHEAD=$(git rev-list --count @{u}..HEAD)
-      if [ "$COMMITS_AHEAD" -ne 0 ]; then
-        # REL-001: No stderr suppression on rebase — surface conflict diagnostics
-        # Split into separate statements so set -e catches rebase failures
-        git pull --rebase
-        git push
+      UPSTREAM_REF=""
+      if git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+        UPSTREAM_REF='@{u}'
+      elif git show-ref --verify --quiet "refs/remotes/origin/$EXPECTED_BRANCH"; then
+        git branch --set-upstream-to="origin/$EXPECTED_BRANCH" "$EXPECTED_BRANCH" >/dev/null
+        UPSTREAM_REF='@{u}'
+      fi
+      if [ -z "$UPSTREAM_REF" ]; then
+        echo "INFO: No upstream tracking branch configured — publishing branch and setting upstream" >&2
+        git push --set-upstream origin "$EXPECTED_BRANCH"
       else
-        echo "WARNING: Nothing to push - branch is up to date with remote"
+        COMMITS_AHEAD=$(git rev-list --count "${UPSTREAM_REF}..HEAD")
+        if [ "$COMMITS_AHEAD" -ne 0 ]; then
+          git pull --rebase
+          git push
+        else
+          echo "WARNING: Nothing to push - branch is up to date with remote"
+        fi
       fi
       echo ""
       echo "=== Commit and Push Complete ==="
@@ -1283,6 +1454,7 @@ steps:
   # ==========================================================================
   - id: "step-16b-outside-in-fix-loop"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 16b: Outside-In Testing and Fix Loop (MANDATORY)
 
@@ -1390,6 +1562,7 @@ steps:
 
   - id: "step-17b-reviewer-agent"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17b: Comprehensive Code Review (MANDATORY)
 
@@ -1417,6 +1590,7 @@ steps:
 
   - id: "step-17c-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17c: Security Review (MANDATORY)
 
@@ -1440,6 +1614,7 @@ steps:
 
   - id: "step-17d-philosophy-guardian"
     agent: "amplihack:philosophy-guardian"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17d: Philosophy Guardian Review (MANDATORY)
 
@@ -1463,6 +1638,7 @@ steps:
 
   - id: "step-17e-address-blocking-issues"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 17e: Address Blocking Issues (MANDATORY)
 
@@ -1505,6 +1681,7 @@ steps:
   # ==========================================================================
   - id: "step-18a-analyze-feedback"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 18a: Analyze Review Feedback (MANDATORY)
 
@@ -1522,6 +1699,7 @@ steps:
 
   - id: "step-18b-implement-feedback"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 18b: Implement Review Feedback (MANDATORY)
 
@@ -1603,6 +1781,7 @@ steps:
   # ==========================================================================
   - id: "step-19a-philosophy-check"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 19a: Philosophy Compliance Review (MANDATORY)
 
@@ -1622,6 +1801,7 @@ steps:
 
   - id: "step-19b-patterns-check"
     agent: "amplihack:patterns"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 19b: Pattern Compliance Review (MANDATORY)
 
@@ -1703,6 +1883,7 @@ steps:
   # ==========================================================================
   - id: "step-20-final-cleanup"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 20: Final Cleanup and Verification
 
@@ -1752,12 +1933,13 @@ steps:
   # ==========================================================================
   - id: "step-20c-quality-audit"
     agent: "amplihack:core:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 20c: Quality Audit Loop
 
       **Requirements:** {{final_requirements}}
       **PR URL:** {{pr_url}}
-      **Repository:** {{repo_path}}
+      **Repository Worktree:** {{worktree_setup.worktree_path}}
 
       Run a comprehensive, iterative quality audit on all files changed in
       this PR. This step follows the quality-audit-cycle recipe (v3.0).
@@ -1851,11 +2033,12 @@ steps:
   # ==========================================================================
   - id: "step-22-ensure-mergeable"
     agent: "amplihack:ci-diagnostic-workflow"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 21: Ensure PR is Mergeable (TASK COMPLETION POINT)
 
       **PR URL:** {{pr_url}}
-      **Repository:** {{repo_path}}
+      **Repository Worktree:** {{worktree_setup.worktree_path}}
 
       Final verification that PR is ready to merge:
 
@@ -1880,21 +2063,47 @@ steps:
   - id: "step-22b-final-status"
     type: "bash"
     command: |
-      cd {{repo_path}} && \
-      echo "=== WORKFLOW COMPLETE ===" && \
-      echo "" && \
-      echo "PR Status:" && \
-      gh pr view --json state,mergeable,reviews,statusCheckRollup && \
-      echo "" && \
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
+      set -euo pipefail
+      WORKTREE_DIR="{{worktree_setup.worktree_path}}"
+      EXPECTED_BRANCH="{{worktree_setup.branch_name}}"
+
+      if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "ERROR: worktree directory '$WORKTREE_DIR' does not exist" >&2
+        exit 1
+      fi
+      WORKTREE_DIR="$(cd "$WORKTREE_DIR" && pwd -P)"
+      cd "$WORKTREE_DIR"
+
+      if [ "$(git rev-parse --is-inside-work-tree)" != "true" ]; then
+        echo "ERROR: '$WORKTREE_DIR' is not inside a git worktree" >&2
+        exit 1
+      fi
+
+      ACTUAL_TOPLEVEL="$(git rev-parse --show-toplevel)"
+      if [ "$ACTUAL_TOPLEVEL" != "$WORKTREE_DIR" ]; then
+        echo "ERROR: expected git top-level '$WORKTREE_DIR' but found '$ACTUAL_TOPLEVEL'" >&2
+        exit 1
+      fi
+
+      ACTUAL_BRANCH="$(git branch --show-current)"
+      if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+        echo "ERROR: expected branch '$EXPECTED_BRANCH' but found '$ACTUAL_BRANCH'" >&2
+        exit 1
+      fi
+
+      echo "=== WORKFLOW COMPLETE ==="
+      echo ""
+      echo "PR Status:"
+      gh pr view --json state,mergeable,reviews,statusCheckRollup
+      echo ""
       TASK_DESC=$(cat <<EOFTASKDESC
       {{task_description}}
       EOFTASKDESC
-      ) && \
-      printf '=== Task: %s ===\n' "$TASK_DESC" && \
-      printf '=== Issue: #%s ===\n' {{issue_number}} && \
-      printf '=== PR: %s ===\n' {{pr_url}} && \
-      echo "" && \
+      )
+      printf '=== Task: %s ===\n' "$TASK_DESC"
+      printf '=== Issue: #%s ===\n' {{issue_number}}
+      printf '=== PR: %s ===\n' {{pr_url}}
+      echo ""
       echo "All 23 workflow steps completed successfully."
     output: "final_status"
 

--- a/tests/recipes/test_git_push_idempotency.py
+++ b/tests/recipes/test_git_push_idempotency.py
@@ -71,6 +71,17 @@ def git_repo(tmp_path):
 class TestYamlStructure:
     """Verify the YAML step definitions contain idempotency guards."""
 
+    def test_step_04_stays_local_only(self, workflow_steps):
+        step = workflow_steps.get("step-04-setup-worktree")
+        assert step is not None, "step-04-setup-worktree should exist"
+        cmd = step.get("command", "")
+        assert 'git -C "${WORKTREE_PATH}" push origin "${BRANCH_NAME}"' not in cmd, (
+            "step-04 should not push a remote branch before there is work to publish"
+        )
+        assert 'branch --set-upstream-to="origin/${BRANCH_NAME}"' not in cmd, (
+            "step-04 should not spend time configuring remote tracking during local setup"
+        )
+
     def test_step_15_has_commit_idempotency_check(self, workflow_steps):
         step = workflow_steps.get("step-15-commit-push")
         assert step is not None, "step-15-commit-push should exist"
@@ -84,6 +95,14 @@ class TestYamlStructure:
         assert step is not None
         cmd = step.get("command", "")
         assert "git rev-list" in cmd, "step-15 should check for unpushed commits before pushing"
+
+    def test_step_15_bootstraps_upstream_on_first_push(self, workflow_steps):
+        step = workflow_steps.get("step-15-commit-push")
+        assert step is not None
+        cmd = step.get("command", "")
+        assert 'git push --set-upstream origin "$EXPECTED_BRANCH"' in cmd, (
+            "step-15 should create upstream tracking lazily instead of paying for it in step-04"
+        )
 
     def test_step_18c_has_commit_idempotency_check(self, workflow_steps):
         step = workflow_steps.get("step-18c-push-feedback-changes")
@@ -126,6 +145,17 @@ class TestGitIdempotency:
             text=True,
             cwd=str(cwd),
             timeout=30,
+        )
+
+    @staticmethod
+    def _render_step_15(
+        command: str, *, branch_name: str, task_description: str, issue_number: str
+    ) -> str:
+        return (
+            command.replace("{{worktree_setup.worktree_path}}", ".")
+            .replace("{{worktree_setup.branch_name}}", branch_name)
+            .replace("{{task_description}}", task_description)
+            .replace("{{issue_number}}", issue_number)
         )
 
     def test_nothing_to_commit_succeeds(self, git_repo):
@@ -210,6 +240,35 @@ class TestGitIdempotency:
         # Should have commit warning (nothing to commit) but no push warning
         assert "Nothing to commit" in result.stdout
         assert "Nothing to push" not in result.stdout
+
+    def test_step_15_sets_upstream_when_branch_has_no_tracking(self, workflow_steps, git_repo):
+        """A fresh feature branch should publish successfully without step-04 pre-pushing it."""
+        branch_name = "feat/issue-1234"
+        subprocess.run(
+            ["git", "-C", str(git_repo), "checkout", "-b", branch_name],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        (git_repo / "fresh_feature.txt").write_text("content\n")
+
+        script = self._render_step_15(
+            workflow_steps["step-15-commit-push"]["command"],
+            branch_name=branch_name,
+            task_description="test task",
+            issue_number="1234",
+        )
+
+        result = self._run_bash(script, git_repo)
+        assert result.returncode == 0, f"Step 15 should bootstrap upstream: {result.stderr}"
+
+        upstream = subprocess.run(
+            ["git", "-C", str(git_repo), "rev-parse", "--abbrev-ref", "@{u}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert upstream.stdout.strip() == f"origin/{branch_name}"
 
     def test_full_step_15_command_with_no_changes(self, git_repo):
         """Full step-15 command should succeed when nothing to commit/push."""

--- a/tests/test_multitask_orchestrator_local_src_bootstrap.py
+++ b/tests/test_multitask_orchestrator_local_src_bootstrap.py
@@ -25,6 +25,41 @@ def _write_file(path: Path, content: str) -> None:
     path.write_text(content)
 
 
+def _write_local_recipe_stub(work_dir: Path, *, step_id: str) -> None:
+    _write_file(work_dir / "src" / "amplihack" / "__init__.py", "")
+    _write_file(
+        work_dir / "src" / "amplihack" / "recipes" / "__init__.py",
+        f"""class _Status:
+    value = "completed"
+
+
+class _StepResult:
+    step_id = "{step_id}"
+    status = _Status()
+
+
+class _Result:
+    success = True
+    step_results = [_StepResult()]
+
+
+def run_recipe_by_name(name, user_context=None, dry_run=False, progress=False, **_kwargs):
+    return _Result()
+""",
+    )
+
+
+def _run_launcher(work_dir: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "launcher.py"],
+        cwd=work_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
 def test_recipe_launcher_prefers_local_src_over_stale_installed_package(tmp_path):
     """Generated launchers should import from the checked-out repo's src tree first."""
     orchestrator = _load_orchestrator_module()
@@ -47,27 +82,7 @@ def test_recipe_launcher_prefers_local_src_over_stale_installed_package(tmp_path
     orch = ParallelOrchestrator(repo_url="https://example.invalid/repo.git", tmp_base=str(tmp_path))
     orch._write_recipe_launcher(ws)
 
-    _write_file(work_dir / "src" / "amplihack" / "__init__.py", "")
-    _write_file(
-        work_dir / "src" / "amplihack" / "recipes" / "__init__.py",
-        """class _Status:
-    value = "completed"
-
-
-class _StepResult:
-    step_id = "local-src-step"
-    status = _Status()
-
-
-class _Result:
-    success = True
-    step_results = [_StepResult()]
-
-
-def run_recipe_by_name(name, user_context=None, dry_run=False, progress=False, **_kwargs):
-    return _Result()
-""",
-    )
+    _write_local_recipe_stub(work_dir, step_id="local-src-step")
 
     _write_file(tmp_path / "installed" / "amplihack" / "__init__.py", "")
     _write_file(
@@ -78,15 +93,49 @@ def run_recipe_by_name(name, user_context=None, dry_run=False, progress=False, *
     env = os.environ.copy()
     env["PYTHONPATH"] = str(tmp_path / "installed")
 
-    result = subprocess.run(
-        [sys.executable, "launcher.py"],
-        cwd=work_dir,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
+    result = _run_launcher(work_dir, env)
 
     assert result.returncode == 0, result.stderr
     assert "RECIPE EXECUTION RESULTS" in result.stdout
     assert "local-src-step" in result.stdout
+
+
+def test_recipe_launcher_isolates_from_broken_shared_checkout_pythonpath(tmp_path):
+    """Shared-checkout contamination on PYTHONPATH must not break a stream-local launcher."""
+    orchestrator = _load_orchestrator_module()
+    ParallelOrchestrator = orchestrator.ParallelOrchestrator
+    Workstream = orchestrator.Workstream
+
+    work_dir = tmp_path / "ws-4022"
+    work_dir.mkdir()
+
+    ws = Workstream(
+        issue=4022,
+        branch="test-branch",
+        description="Shared checkout contamination regression",
+        task="Regression task",
+        recipe="default-workflow",
+    )
+    ws.work_dir = work_dir
+    ws.log_file = tmp_path / "log-4022.txt"
+
+    orch = ParallelOrchestrator(repo_url="https://example.invalid/repo.git", tmp_base=str(tmp_path))
+    orch._write_recipe_launcher(ws)
+
+    _write_local_recipe_stub(work_dir, step_id="stream-local-step")
+
+    shared_checkout_src = tmp_path / "shared-checkout" / "src"
+    _write_file(shared_checkout_src / "amplihack" / "__init__.py", "")
+    _write_file(
+        shared_checkout_src / "amplihack" / "recipes" / "__init__.py",
+        'raise FileNotFoundError("shared checkout missing src/amplihack/recipes/rust_runner_copilot.py")\n',
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(shared_checkout_src)
+
+    result = _run_launcher(work_dir, env)
+
+    assert result.returncode == 0, result.stderr
+    assert "RECIPE EXECUTION RESULTS" in result.stdout
+    assert "stream-local-step" in result.stdout

--- a/tests/unit/recipes/test_worktree_isolation_3684_3673.py
+++ b/tests/unit/recipes/test_worktree_isolation_3684_3673.py
@@ -1,4 +1,4 @@
-"""Tests for worktree isolation fixes: GitHub issues #3684 and #3673.
+"""Tests for worktree isolation fixes: GitHub issues #4022, #3684 and #3673.
 
 Verifies:
 1. No silent fallback from worktree_path to repo_path in post-step-04 steps.
@@ -7,8 +7,12 @@ Verifies:
 4. step-14 version bump uses worktree_path, not repo_path.
 5. step-22b final-status uses worktree_path.
 6. Clean-worktree invariant is enforced in step-15.
+7. Post-step-04 agent steps run inside worktree_path via working_dir.
+8. step-05 architecture handoff names worktree_path as the active repo root.
+9. Post-step-04 agent prompts never route back to repo_path.
 
-References: #3684 (worktree handoff), #3673 (clean-worktree invariant),
+References: #4022 (shared checkout contamination), #3684 (worktree handoff),
+            #3673 (clean-worktree invariant),
             #3646 (duplicate), #3647 (duplicate)
 """
 
@@ -45,6 +49,18 @@ def step_ids(steps):
 
 
 @pytest.fixture(scope="module")
+def post_step04_steps(steps, step_ids):
+    step04_idx = step_ids.index("step-04-setup-worktree")
+    pre_step04_ids = set(step_ids[: step04_idx + 1])
+    return [step for step in steps if step["id"] not in pre_step04_ids]
+
+
+@pytest.fixture(scope="module")
+def post_step04_agent_steps(post_step04_steps):
+    return [step for step in post_step04_steps if "agent" in step]
+
+
+@pytest.fixture(scope="module")
 def recipe_text():
     return RECIPE_PATH.read_text()
 
@@ -71,9 +87,7 @@ class TestNoSilentFallback:
                 if stripped.startswith("#"):
                     continue
                 if stripped.startswith("cd {{repo_path}}"):
-                    pytest.fail(
-                        f"Step '{step['id']}' uses 'cd {{{{repo_path}}}}' after step-04."
-                    )
+                    pytest.fail(f"Step '{step['id']}' uses 'cd {{{{repo_path}}}}' after step-04.")
 
 
 class TestWorktreeValidationStep:
@@ -104,9 +118,7 @@ class TestWorktreeValidationStep:
         assert "EXPECTED_BRANCH" in cmd and "ACTUAL_BRANCH" in cmd
 
     def test_step_04b_has_output(self, step_map):
-        assert (
-            step_map["step-04b-validate-worktree"].get("output") == "worktree_validation"
-        )
+        assert step_map["step-04b-validate-worktree"].get("output") == "worktree_validation"
 
 
 class TestStep15CleanWorktreeInvariant:
@@ -172,3 +184,55 @@ class TestCheckpointSteps:
     def test_checkpoint_no_silent_fallback(self, step_map, step_id):
         cmd = step_map[step_id]["command"]
         assert "2>/dev/null || cd" not in cmd
+
+
+class TestPostStep04AgentIsolation:
+    """Verify post-worktree agent steps stay rooted in the stream-local tree."""
+
+    def test_post_step04_agent_steps_use_worktree_working_dir(self, post_step04_agent_steps):
+        expected = "{{worktree_setup.worktree_path}}"
+        missing: list[str] = []
+        wrong: list[str] = []
+
+        for step in post_step04_agent_steps:
+            working_dir = step.get("working_dir")
+            if working_dir is None:
+                missing.append(step["id"])
+            elif working_dir != expected:
+                wrong.append(f"{step['id']}={working_dir!r}")
+
+        details: list[str] = []
+        if missing:
+            details.append(f"missing working_dir on: {', '.join(missing)}")
+        if wrong:
+            details.append(f"wrong working_dir on: {', '.join(wrong)}")
+
+        assert not details, (
+            "Once step-04 creates the stream-local worktree, every later agent step must run with "
+            f"working_dir {expected!r} so concurrent streams cannot drift back to the shared checkout; "
+            + "; ".join(details)
+        )
+
+    def test_step05_handoff_names_worktree_path_as_active_repository(self, step_map):
+        prompt = step_map["step-05-architecture"].get("prompt", "")
+        assert "worktree_setup.worktree_path" in prompt, (
+            "Step 'step-05-architecture' is the first post-step-04 agent handoff and must name "
+            "{{worktree_setup.worktree_path}} explicitly so downstream agents treat the worktree, "
+            "not {{repo_path}}, as the active repository root."
+        )
+
+
+class TestPostStep04PromptIsolation:
+    """Verify agent prompts do not reintroduce shared-checkout guidance."""
+
+    def test_post_step04_agent_prompts_do_not_reference_repo_path(self, post_step04_agent_steps):
+        leaking_steps = [
+            step["id"]
+            for step in post_step04_agent_steps
+            if "{{repo_path}}" in step.get("prompt", "")
+        ]
+
+        assert not leaking_steps, (
+            "Post-step-04 agent prompts must not point back to {{repo_path}} after the worktree is "
+            f"created; found repo_path references in: {', '.join(leaking_steps)}"
+        )


### PR DESCRIPTION
## Summary
- keep workflow writes isolated to the stream-local worktree instead of leaking back to the outer recovery root
- harden default-workflow handoff and local-src bootstrap behavior around stream-local execution
- expand worktree isolation and git-push idempotency regression coverage

## Validation
- dedicated #4022 fix workflow produced the pushed fix commit and validated the isolation surface before its publish step was blocked by the separate step-15 import-validation bug now tracked/fixed via #4064

Closes #4022