### PR TITLE
fix: prevent hollow success when step-08 replaces stubs (#4094)

### DIFF
--- a/amplifier-bundle/agents/core/builder.md
+++ b/amplifier-bundle/agents/core/builder.md
@@ -117,6 +117,14 @@ def primary_function(input: InputModel) -> OutputModel:
 - **Working defaults**: Use files instead of external services initially
 - **Every function works**: Or doesn't exist
 
+#### Stub/Placeholder Replacement
+
+When a task asks to "replace", "rewrite", or "implement" something, existing
+stubs, placeholders, `pass`-only functions, `NotImplementedError` raises, and
+TODO-marked code are **targets for replacement**. Do NOT treat them as
+intentional architecture to preserve. Producing zero file changes when the task
+explicitly requests code modifications is a hollow success and must be avoided.
+
 #### Module Quality
 
 - **Self-contained**: All module code in its directory

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -704,11 +704,21 @@ steps:
       6. Clear error messages
       7. Appropriate logging
 
+      **Stub/Placeholder Replacement Rule (CRITICAL):**
+      When the task description contains words like "replace", "rewrite",
+      "implement", "real implementation", "remove stub", or "remove placeholder",
+      existing stubs, placeholders, TODO-marked code, NotImplementedError raises,
+      pass-only functions, and type-alias-only modules are **targets for
+      replacement, NOT patterns to preserve**. You MUST modify these files.
+      Treating existing stub code as correct architecture and producing zero
+      changes is a **hollow success** — the worst possible outcome.
+
       **Output:**
-      - Complete implementation code (all files)
+      - Complete implementation code (all files modified or created)
       - File headers: `# File: path/to/file.py`
       - Brief explanation of key decisions
       - Any deviations from design (with justification)
+      - List of files changed (MUST be non-empty when task requests changes)
     output: "implementation"
 
   - id: "step-08b-integration"
@@ -727,6 +737,50 @@ steps:
 
       Skip if no external integrations are required.
     output: "integration_code"
+
+  # --------------------------------------------------------------------------
+  # HOLLOW SUCCESS DETECTION: Catch 0-change implementations early
+  # --------------------------------------------------------------------------
+  - id: "step-08c-hollow-success-guard"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      cd "{{worktree_setup.worktree_path}}" 2>/dev/null || cd "{{repo_path}}"
+      echo "=== Step 8c: Hollow Success Guard ==="
+
+      # Count files changed (staged + unstaged + untracked)
+      CHANGED=$(git diff --name-only 2>/dev/null | wc -l)
+      STAGED=$(git diff --cached --name-only 2>/dev/null | wc -l)
+      UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null | wc -l)
+      TOTAL=$((CHANGED + STAGED + UNTRACKED))
+
+      echo "Files changed: $CHANGED staged: $STAGED untracked: $UNTRACKED total: $TOTAL"
+
+      if [ "$TOTAL" -eq 0 ]; then
+        # Check if the task description contains action verbs that imply changes
+        TASK_DESC=$(cat <<EOFTASKDESC
+      {{task_description}}
+      EOFTASKDESC
+        )
+        # Detect replace/rewrite/implement/fix/add/create/remove keywords
+        if echo "$TASK_DESC" | grep -qiE '(replace|rewrite|implement|fix|add|create|remove|update|refactor|stub|placeholder|real implementation)'; then
+          echo "ERROR: Hollow success detected." >&2
+          echo "Task description contains action keywords but step-08 produced 0 file changes." >&2
+          echo "Task: $(echo "$TASK_DESC" | head -3)" >&2
+          echo "" >&2
+          echo "This means the implementation agent treated existing code as correct" >&2
+          echo "when it should have been replaced. Failing the step so the workflow" >&2
+          echo "does not silently succeed with no work done." >&2
+          exit 1
+        else
+          echo "INFO: No file changes, but task does not appear to require code modifications."
+        fi
+      else
+        echo "OK: $TOTAL file(s) affected — implementation produced changes."
+      fi
+
+      echo "=== Hollow Success Guard Complete ==="
+    output: "hollow_success_check"
 
   # --------------------------------------------------------------------------
   # CHECKPOINT: Stage implementation work to prevent loss if later steps fail

--- a/tests/recipes/test_hollow_success_guard.py
+++ b/tests/recipes/test_hollow_success_guard.py
@@ -1,0 +1,153 @@
+"""Tests for hollow-success detection in default-workflow.yaml.
+
+Verifies that:
+1. step-08-implement prompt contains stub-replacement instructions
+2. step-08c-hollow-success-guard exists and detects 0-change implementations
+3. The guard checks for action keywords in the task description
+4. Builder agent documentation includes stub-replacement guidance
+
+Addresses: GitHub issue #4094
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+RECIPE_FILE = Path("amplifier-bundle/recipes/default-workflow.yaml")
+BUILDER_AGENT_FILE = Path("amplifier-bundle/agents/core/builder.md")
+
+
+def _load_recipe() -> dict:
+    content = RECIPE_FILE.read_text(encoding="utf-8")
+    return yaml.safe_load(content)
+
+
+def _find_step(recipe: dict, step_id: str) -> dict:
+    for step in recipe.get("steps", []):
+        if step.get("id") == step_id:
+            return step
+    raise KeyError(f"Step '{step_id}' not found in recipe")
+
+
+@pytest.fixture(scope="module")
+def recipe() -> dict:
+    return _load_recipe()
+
+
+@pytest.fixture(scope="module")
+def step_08(recipe: dict) -> dict:
+    return _find_step(recipe, "step-08-implement")
+
+
+@pytest.fixture(scope="module")
+def hollow_guard(recipe: dict) -> dict:
+    return _find_step(recipe, "step-08c-hollow-success-guard")
+
+
+# ===========================================================================
+# YAML must parse cleanly
+# ===========================================================================
+
+
+class TestRecipeParses:
+    def test_yaml_loads(self, recipe: dict):
+        assert recipe is not None
+        assert "steps" in recipe
+
+
+# ===========================================================================
+# Step 08: Implementation prompt contains stub-replacement instructions
+# ===========================================================================
+
+
+class TestStep08StubReplacement:
+    def test_prompt_mentions_stub_replacement(self, step_08: dict):
+        prompt = step_08.get("prompt", "")
+        assert "Stub/Placeholder Replacement" in prompt, (
+            "step-08 prompt must contain stub/placeholder replacement instructions"
+        )
+
+    def test_prompt_warns_about_hollow_success(self, step_08: dict):
+        prompt = step_08.get("prompt", "")
+        assert "hollow success" in prompt.lower(), "step-08 prompt must warn about hollow success"
+
+    def test_prompt_lists_replacement_targets(self, step_08: dict):
+        """Prompt must mention common stub patterns as replacement targets."""
+        prompt = step_08.get("prompt", "")
+        for target in ["stubs", "placeholders", "NotImplementedError", "TODO"]:
+            assert target in prompt, f"step-08 prompt must mention '{target}' as replacement target"
+
+    def test_output_requires_files_changed(self, step_08: dict):
+        prompt = step_08.get("prompt", "")
+        assert "List of files changed" in prompt, (
+            "step-08 output section must require listing files changed"
+        )
+
+
+# ===========================================================================
+# Step 08c: Hollow success guard exists and is properly configured
+# ===========================================================================
+
+
+class TestHollowSuccessGuard:
+    def test_guard_step_exists(self, hollow_guard: dict):
+        assert hollow_guard["id"] == "step-08c-hollow-success-guard"
+
+    def test_guard_is_bash_type(self, hollow_guard: dict):
+        assert hollow_guard.get("type") == "bash", (
+            "Hollow success guard must be a bash step for reliable file-change detection"
+        )
+
+    def test_guard_checks_git_diff(self, hollow_guard: dict):
+        command = hollow_guard.get("command", "")
+        assert "git diff" in command, "Guard must use git diff to detect changes"
+
+    def test_guard_checks_untracked_files(self, hollow_guard: dict):
+        command = hollow_guard.get("command", "")
+        assert "ls-files" in command, "Guard must check for untracked files via git ls-files"
+
+    def test_guard_detects_action_keywords(self, hollow_guard: dict):
+        """Guard must grep for action keywords that imply code changes."""
+        command = hollow_guard.get("command", "")
+        for keyword in ["replace", "implement", "fix", "create"]:
+            assert keyword in command, f"Guard must detect action keyword '{keyword}'"
+
+    def test_guard_fails_on_zero_changes_with_action_keywords(self, hollow_guard: dict):
+        command = hollow_guard.get("command", "")
+        assert "exit 1" in command, "Guard must exit 1 when hollow success is detected"
+
+    def test_guard_has_output(self, hollow_guard: dict):
+        assert hollow_guard.get("output") == "hollow_success_check"
+
+    def test_guard_comes_before_checkpoint(self, recipe: dict):
+        """Guard must appear between step-08b and checkpoint-after-implementation."""
+        step_ids = [s.get("id") for s in recipe.get("steps", [])]
+        guard_idx = step_ids.index("step-08c-hollow-success-guard")
+        checkpoint_idx = step_ids.index("checkpoint-after-implementation")
+        step_08b_idx = step_ids.index("step-08b-integration")
+        assert step_08b_idx < guard_idx < checkpoint_idx, (
+            "Guard must be ordered: step-08b < step-08c (guard) < checkpoint"
+        )
+
+
+# ===========================================================================
+# Builder agent: stub-replacement guidance
+# ===========================================================================
+
+
+class TestBuilderAgentStubGuidance:
+    def test_builder_agent_file_exists(self):
+        assert BUILDER_AGENT_FILE.exists()
+
+    def test_builder_mentions_stub_replacement(self):
+        content = BUILDER_AGENT_FILE.read_text(encoding="utf-8")
+        assert "Stub/Placeholder Replacement" in content, (
+            "Builder agent must include stub/placeholder replacement section"
+        )
+
+    def test_builder_warns_about_hollow_success(self):
+        content = BUILDER_AGENT_FILE.read_text(encoding="utf-8")
+        assert "hollow success" in content.lower(), "Builder agent must warn about hollow success"

--- a/tests/recipes/test_shell_injection_fix_3045_3076.py
+++ b/tests/recipes/test_shell_injection_fix_3045_3076.py
@@ -53,6 +53,7 @@ AFFECTED_STEP_IDS = [
     "step-00-workflow-preparation",
     "step-03-create-issue",
     "step-04-setup-worktree",
+    "step-08c-hollow-success-guard",
     "step-15-commit-push",
     "step-16-create-draft-pr",
     "step-22b-final-status",


### PR DESCRIPTION
## Summary

- Add **Stub/Placeholder Replacement Rule** to step-08-implement prompt so the builder agent knows existing stubs are targets for replacement, not architecture to preserve
- Add **step-08c-hollow-success-guard** bash step between implementation and checkpoint that detects 0-change implementations when the task contains action keywords (replace, implement, fix, etc.) and fails early
- Add stub-replacement guidance to the **builder agent** definition (`amplifier-bundle/agents/core/builder.md`)
- Update `AFFECTED_STEP_IDS` in shell injection tests to include the new heredoc-using step

## Test plan

- [x] 16 new tests in `tests/recipes/test_hollow_success_guard.py` (all passing)
- [x] 144 total tests pass in `test_shell_injection_fix_3045_3076.py` + `test_hollow_success_guard.py`
- [x] Pre-commit hooks pass (ruff, pyright, prettier, yaml validation)
- [ ] Manual: run default-workflow with a "replace stub" task and verify step-08c catches 0-change implementations

Closes #4094

## Merge-Ready Evidence

| Criteria | Status | Evidence |
|----------|--------|----------|
| CI green | PASS | All GitHub Actions checks pass (no failures) |
| QA scenario | PASS | gadugi-test scenario validates and passes (5/5 assertions: guard exists, ordering correct, keywords detected, stub rule present, builder guidance present) |
| Docs check | PASS | Internal-only change (recipe + agent definition + tests). No user-facing docs affected. |
| Quality audit | PASS | 3 SEEK-VALIDATE-FIX cycles: (1) shell injection safety via heredoc pattern, (2) guard logic correctness, (3) test coverage proportionality. No issues found. |
| Scope check | PASS | 4 files changed, all directly related to hollow success detection |
| Tests | PASS | 144/144 tests pass (`uv run pytest tests/recipes/test_hollow_success_guard.py tests/recipes/test_shell_injection_fix_3045_3076.py`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)