### PR TITLE
fix: integrate recovery fixes #4022, #4032, #4064 (#4077)

### DIFF
--- a/tests/recipes/test_git_push_idempotency.py
+++ b/tests/recipes/test_git_push_idempotency.py
@@ -241,6 +241,29 @@ class TestGitIdempotency:
         assert "Nothing to commit" in result.stdout
         assert "Nothing to push" not in result.stdout
 
+    @staticmethod
+    def _create_publish_validation_stubs(repo_path: Path) -> None:
+        """Create stub scripts so the publish-import-validation phase succeeds."""
+        scripts_dir = repo_path / "scripts" / "pre-commit"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        (scripts_dir / "build_publish_validation_scope.py").write_text(
+            "import json, sys, argparse\n"
+            "p = argparse.ArgumentParser()\n"
+            'p.add_argument("--manifest")\n'
+            'p.add_argument("--output")\n'
+            'p.add_argument("--repo-root")\n'
+            'p.add_argument("--exclude-claude-scenarios", action="store_true")\n'
+            "args = p.parse_args()\n"
+            'open(args.output, "w").write("")\n'
+            'print(json.dumps({"seed_count": 0, "expanded_local_dep_count": 0, "validated_count": 0}))\n'
+        )
+        (scripts_dir / "check_imports.py").write_text(
+            "import argparse\n"
+            "p = argparse.ArgumentParser()\n"
+            'p.add_argument("--files-from")\n'
+            "p.parse_args()\n"
+        )
+
     def test_step_15_sets_upstream_when_branch_has_no_tracking(self, workflow_steps, git_repo):
         """A fresh feature branch should publish successfully without step-04 pre-pushing it."""
         branch_name = "feat/issue-1234"
@@ -251,6 +274,7 @@ class TestGitIdempotency:
             text=True,
         )
         (git_repo / "fresh_feature.txt").write_text("content\n")
+        self._create_publish_validation_stubs(git_repo)
 
         script = self._render_step_15(
             workflow_steps["step-15-commit-push"]["command"],

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack"
-version = "0.6.103"
+version = "0.6.104"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Manually integrates three recovery fixes that do not cherry-pick cleanly onto main due to overlapping changes in `amplifier-bundle/recipes/default-workflow.yaml` and `tests/test_multitask_orchestrator_local_src_bootstrap.py`
- Resolves all merge conflicts by understanding the semantic intent of each fix and combining their changes

## Integrated Fixes
1. **#4022** (PR #4076, `3d12de885`): Isolate stream-local worktrees -- adds `working_dir` to agent steps and strict worktree validation at step boundaries
2. **#4032** (PR #4075, `43fad5462`): Preserve resumable timeout workstreams -- adds `condition` gates and checkpoint state persistence for durable resume
3. **#4064** (PR #4074, `3ba9cdd3f`): Scope step-15 publish import validation to staged surface, excluding `.claude/scenarios`

## Conflict Resolution Strategy
- **Agent steps**: kept both `working_dir` (#4022) and `condition` (#4032) attributes
- **Worktree validation (step-04b)**: used #4032 resume-aware validation that handles both fresh and resume paths
- **Checkpoint steps**: combined #4022 strict validation with #4032 state file persistence
- **Step-15 push**: used #4022 `--set-upstream` bootstrap logic for first-push scenarios
- **Step-15 commit**: integrated #4064 scoped import validation before the commit
- **Tests**: updated `test_git_push_idempotency` to stub publish validation scripts in test fixtures

## Test plan
- [x] All 82 affected tests pass (49 recipe/integration + 33 orchestrator unit tests)
- [x] YAML syntax validated
- [x] Python syntax validated
- [x] All pre-commit hooks pass (ruff, pyright, prettier, secrets, imports)

## Merge-Ready Evidence

### Surfaces Checked (Internal Docs)
- `amplifier-bundle/recipes/default-workflow.yaml` -- recipe step conditions, working_dir, checkpoint persistence, scoped import validation
- `.claude/skills/multitask/orchestrator.py` -- resumable timeout lifecycle, worktree isolation, state persistence
- `docs/features/` -- new docs for resumable-workstream-timeouts and workflow-publish-import-validation
- `docs/howto/`, `docs/tutorials/`, `docs/reference/` -- configuration, tutorial, and reference docs for both features
- `mkdocs.yml` -- navigation entries for new doc pages
- `pyproject.toml` / `uv.lock` -- version bump 0.6.103 -> 0.6.104

### Quality Audit (3 SEEK-VALIDATE-FIX cycles)
1. **SEEK: Error handling in orchestrator** -- VALIDATE: `_write_json_file` uses atomic rename (`.tmp` -> target), `_read_json_file` handles OSError/JSONDecodeError with cache invalidation, `_terminate_process` escalates SIGTERM->SIGKILL with 10s timeout. FIX: No issues found.
2. **SEEK: Recipe condition correctness** -- VALIDATE: `resume_checkpoint` conditions use correct Python `not in` list syntax matching recipe condition evaluation (`eval()`). Step-03 uses `not issue_number` for idempotency. Step-04b handles both fresh and resume worktree paths with fallback. FIX: No issues found.
3. **SEEK: Step-15 scoped import validation** -- VALIDATE: `build_publish_validation_scope.py` with `--exclude-claude-scenarios` runs before `check_imports.py --files-from`, scope artifact cleanup via trap, empty-scope handled as explicit success, `SKIP=check-imports` prevents double-validation. FIX: No issues found.

### CI Status
- Root Directory Hygiene: PASS
- Check Version Bump: PASS
- Check skill/agent drift: PASS
- Code Examples: PASS
- Documentation Policy: PASS
- GitGuardian Security: PASS
- MkDocs Navigation: PASS
- test-plugin / test-plugin-shell: PASS
- Atlas PR Impact Check: FAIL (non-blocking, no required status checks)
- Validate Code / Link Validation / agent: pending (CI still running)

### Scope Verification
Diff is focused on the 3 recovery fix integrations:
- Orchestrator (`orchestrator.py`, `test_orchestrator.py`, `test_disk_management.py`, `test_resumable_timeouts.py`) -- #4032 resumable timeouts
- Recipe (`default-workflow.yaml`) -- #4022 worktree isolation + #4032 resume conditions + #4064 scoped imports
- Tests (`test_default_workflow_resumable_timeouts.py`, `test_default_workflow_step15_scoped_imports.py`, `test_git_push_idempotency.py`, `test_heartbeat.py`, `test_multitask_orchestrator_local_src_bootstrap.py`) -- integration coverage
- Docs (features, howto, tutorials, reference for both features) + mkdocs.yml nav
- Version bump (`pyproject.toml`, `uv.lock`) -- 0.6.103 -> 0.6.104
No unrelated changes detected.

Closes #4077

🤖 Generated with [Claude Code](https://claude.com/claude-code)