### PR TITLE
docs(multitask): add TIMEOUT_LIFECYCLE.md and update reference docs

### DIFF
--- a/.claude/skills/multitask/SKILL.md
+++ b/.claude/skills/multitask/SKILL.md
@@ -151,11 +151,12 @@ cat /tmp/amplihack-workstreams/REPORT.md
 
 ## When to Read Supporting Files
 
-| Need                                   | File              |
-| -------------------------------------- | ----------------- |
-| Full API, config options, architecture | `reference.md`    |
-| Real-world usage examples              | `examples.md`     |
-| Python orchestrator source             | `orchestrator.py` |
+| Need                                   | File                   |
+| -------------------------------------- | ---------------------- |
+| Full API, config options, architecture | `reference.md`         |
+| Timeout policies & lifecycle states    | `TIMEOUT_LIFECYCLE.md` |
+| Real-world usage examples              | `examples.md`          |
+| Python orchestrator source             | `orchestrator.py`      |
 
 ## Disk Management & Cleanup
 

--- a/.claude/skills/multitask/TIMEOUT_LIFECYCLE.md
+++ b/.claude/skills/multitask/TIMEOUT_LIFECYCLE.md
@@ -1,0 +1,289 @@
+# Multitask Timeout & Lifecycle
+
+The multitask orchestrator tracks every workstream through a well-defined lifecycle state machine. When a workstream exceeds its time budget or is interrupted, its state is preserved so work can be resumed later — no progress is lost.
+
+## Lifecycle States
+
+```
+                         ┌─────────────────────────┐
+                         │         pending          │
+                         └────────────┬────────────┘
+                                      │ launch
+                                      ▼
+                         ┌─────────────────────────┐
+                         │         running          │
+                         └──┬──────┬───────────┬───┘
+                            │      │           │
+                    success  │  failure     timeout / interrupt
+                            │      │           │
+                            ▼      ▼           ▼
+                      completed   ┌───────────────────────┐
+                                  │ does checkpoint exist? │
+                                  └──────────┬────────────┘
+                                        yes  │  no
+                                   ┌─────────┴──────────┐
+                                   ▼                    ▼
+                          failed_resumable      failed_terminal
+                  (resume later; workdir kept)  (cleanup eligible)
+
+      timeout ──────────────────────────────► timed_out_resumable
+      interrupt ────────────────────────────► interrupted_resumable
+      abandoned ────────────────────────────► abandoned
+```
+
+### State Descriptions
+
+| State | Meaning | Cleanup Eligible |
+|---|---|---|
+| `pending` | Not yet launched | No |
+| `running` | Subprocess active | No |
+| `completed` | Exited 0 — all done | No |
+| `failed_resumable` | Non-zero exit with saved progress | No |
+| `failed_terminal` | Non-zero exit, no saved progress | **Yes** |
+| `timed_out_resumable` | Time budget exceeded; workdir preserved | No |
+| `interrupted_resumable` | Ctrl+C or explicit interrupt; workdir preserved | No |
+| `abandoned` | Explicitly marked abandoned | **Yes** |
+
+**Resumable states** (`failed_resumable`, `timed_out_resumable`, `interrupted_resumable`) are never cleaned up automatically. Their workdirs and state files remain on disk so work can continue.
+
+**Cleanup-eligible states** (`failed_terminal`, `abandoned`, `completed`) are safe to remove from disk. The orchestrator will not delete working trees in resumable states even when cleanup is requested.
+
+---
+
+## Timeout Policies
+
+Every workstream has a `timeout_policy` that controls what happens when `max_runtime` is exceeded.
+
+### `interrupt-preserve` (default)
+
+Sends SIGTERM → waits 10 s → SIGKILL to the subprocess, then saves the workstream state as `timed_out_resumable`. The workdir and all partial output are preserved.
+
+```
+Workstream timed out after 7200s
+→ subprocess terminated (SIGTERM / SIGKILL)
+→ lifecycle_state = "timed_out_resumable"
+→ state file written, workdir kept
+→ resume later with same issue number
+```
+
+### `continue-preserve`
+
+Does **not** terminate the subprocess. Marks the orchestrator's view of the workstream as `timed_out_resumable` so it no longer counts against the monitor's budget, but the subprocess runs to completion in the background. State is written so any future `add()` with the same issue can observe the final result.
+
+```
+Workstream timed out after 7200s
+→ subprocess continues running
+→ lifecycle_state = "timed_out_resumable" (persisted)
+→ orchestrator moves on; subprocess finishes when it finishes
+```
+
+Use `continue-preserve` when the workstream task must not be interrupted (e.g., a long running deploy or eval pass) but you want the orchestrator to stop waiting for it.
+
+### Configuring the Policy
+
+**Per workstream** — in the JSON config:
+
+```json
+{
+  "issue": 123,
+  "branch": "feat/my-feature",
+  "task": "...",
+  "timeout_policy": "continue-preserve",
+  "max_runtime": 10800
+}
+```
+
+**Global default** — via environment variable (applies to every workstream that does not set its own policy):
+
+```
+AMPLIHACK_TIMEOUT_POLICY=continue-preserve
+```
+
+**In code** via `add()`:
+
+```python
+orch.add(
+    issue=123,
+    branch="feat/my-feature",
+    description="...",
+    task="...",
+    timeout_policy="continue-preserve",
+    max_runtime=10800,
+)
+```
+
+If an unrecognised value is supplied, a `warnings.warn` is emitted and the default policy (`interrupt-preserve`) is used.
+
+---
+
+## `max_runtime`
+
+Maximum wall-clock seconds a workstream may run before the timeout policy fires.
+
+| Setting | Value |
+|---|---|
+| **Default** | `7200` (2 hours) |
+| **Minimum** | `0` (fires immediately — useful for testing) |
+| **Override (global)** | `AMPLIHACK_MAX_RUNTIME` env var (seconds) |
+| **Override (per workstream)** | `max_runtime` field in JSON config or `add()` kwarg |
+| **Invalid value** | Falls back to default, warning emitted |
+
+---
+
+## Resumption
+
+Any workstream in a resumable state can be relaunched. The orchestrator restores:
+
+- `worktree_path` — the existing checkout (no re-clone needed)
+- `checkpoint_id` — the last successfully completed recipe step
+- `resume_checkpoint` — forwarded to the Recipe Runner so it skips completed steps
+- `resume_context` — arbitrary key/value dict stored in the state file by the workstream itself
+
+### Automatic Resume on `add()` with `"TBD"` Issue
+
+If you pass `issue="TBD"` and a matching saved state exists (same `branch` + `description`), the orchestrator automatically reuses the saved workstream rather than creating a new GitHub issue:
+
+```python
+orch.add(
+    issue="TBD",          # ← triggers saved-state search
+    branch="feat/my-feature",
+    description="JWT auth",
+    task="...",
+)
+# If a prior timed_out_resumable state exists for that branch+description,
+# the prior issue number is reused and work resumes from checkpoint.
+```
+
+### Manual Resume
+
+```python
+orch = ParallelOrchestrator(repo_url=REPO_URL)
+orch.setup()
+orch.add(issue=123, branch="feat/my-feature", description="...", task="...")
+# The state file at /tmp/amplihack-workstreams/state/ws-123.json is read
+# automatically; if it is in a resumable state the checkpoint is restored.
+orch.launch_all()
+orch.monitor()
+```
+
+---
+
+## State Files
+
+Every workstream writes two files under `/tmp/amplihack-workstreams/state/`:
+
+| File | Purpose |
+|---|---|
+| `ws-<issue>.json` | Primary state: lifecycle, checkpoint, worktree path, runtime config |
+| `ws-<issue>.progress.json` | Sidecar: current recipe step, incremental progress emitted by the workstream |
+
+Both files are written atomically (write to `.tmp`, then `rename`) and permissions are set to `0o600` so only the owning user can read them.
+
+### State File Schema (`ws-<issue>.json`)
+
+```json
+{
+  "issue": 123,
+  "branch": "feat/my-feature",
+  "description": "JWT auth",
+  "lifecycle_state": "timed_out_resumable",
+  "cleanup_eligible": false,
+  "checkpoint_id": "implement-changes",
+  "worktree_path": "/tmp/amplihack-workstreams/ws-123/worktrees/feat/my-feature",
+  "work_dir": "/tmp/amplihack-workstreams/ws-123",
+  "max_runtime": 7200,
+  "timeout_policy": "interrupt-preserve",
+  "attempt": 1,
+  "last_step": "implement-changes",
+  "resume_context": {}
+}
+```
+
+---
+
+## Log Management
+
+Each workstream writes stdout and stderr to `log-<issue>.txt` in `tmp_base`. Log growth is capped to prevent `/tmp` exhaustion.
+
+| Setting | Default | Override |
+|---|---|---|
+| Max log size | `100 MB` | `AMPLIHACK_MAX_LOG_BYTES` env var |
+
+When a log reaches the cap, writes stop and a truncation notice is written to stderr. The subprocess continues running.
+
+---
+
+## Security
+
+### Delegate Injection Prevention
+
+Subprocess delegates are validated against a frozenset allowlist before any process is spawned:
+
+```
+VALID_DELEGATES = {"amplihack claude", "amplihack copilot", "amplihack amplifier"}
+```
+
+Any value not in this set (from `AMPLIHACK_DELEGATE` env var or auto-detection) is rejected and the orchestrator falls back to the next candidate. This prevents injection of arbitrary executables via environment variables.
+
+### Path Sanitisation
+
+All paths derived from `issue_id` (a user-supplied integer) are sanitised before use:
+
+1. `_SAFE_ID_RE` strips non-alphanumeric characters (allows only `[a-zA-Z0-9_-]`)
+2. The resolved candidate path is verified to be inside `state_dir` using `str.startswith`
+3. Any path that escapes `state_dir` raises `ValueError`
+
+### Shell Argument Quoting
+
+All values injected into generated shell scripts (`run.sh`) use `shlex.quote()`. No `shell=True` subprocess calls exist in the orchestrator.
+
+### Subprocess Call Form
+
+All subprocess invocations use list-form args (`["cmd", "arg1", "arg2"]`), never string form with `shell=True`.
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `AMPLIHACK_TIMEOUT_POLICY` | `interrupt-preserve` | Default timeout policy for all workstreams |
+| `AMPLIHACK_MAX_LOG_BYTES` | `104857600` (100 MB) | Per-workstream log size cap |
+| `AMPLIHACK_DELEGATE` | *(auto-detected)* | Override the subprocess delegate binary |
+| `AMPLIHACK_MAX_DEPTH` | `3` | Max recursion depth passed to launched agents |
+| `AMPLIHACK_MAX_SESSIONS` | `10` | Max concurrent sessions passed to launched agents |
+
+---
+
+## Quick Reference
+
+```python
+from amplihack.skills.multitask.orchestrator import ParallelOrchestrator
+
+orch = ParallelOrchestrator(repo_url="https://github.com/org/repo")
+orch.setup()
+
+# Add workstreams with custom timeouts
+orch.add(
+    issue=100,
+    branch="feat/fast-task",
+    description="Fast task",
+    task="...",
+    timeout_policy="interrupt-preserve",  # default
+    max_runtime=3600,                     # 1 hour
+)
+orch.add(
+    issue=101,
+    branch="feat/long-task",
+    description="Long task",
+    task="...",
+    timeout_policy="continue-preserve",   # don't interrupt
+    max_runtime=14400,                    # 4 hours
+)
+
+orch.launch_all()
+orch.monitor()        # blocks; each ws has its own budget
+report = orch.report()
+```
+
+See also: [`reference.md`](reference.md) for the full API, [`examples.md`](examples.md) for worked examples.

--- a/.claude/skills/multitask/TIMEOUT_LIFECYCLE.md
+++ b/.claude/skills/multitask/TIMEOUT_LIFECYCLE.md
@@ -37,7 +37,7 @@ The multitask orchestrator tracks every workstream through a well-defined lifecy
 |---|---|---|
 | `pending` | Not yet launched | No |
 | `running` | Subprocess active | No |
-| `completed` | Exited 0 — all done | No |
+| `completed` | Exited 0 — all done | **Yes** |
 | `failed_resumable` | Non-zero exit with saved progress | No |
 | `failed_terminal` | Non-zero exit, no saved progress | **Yes** |
 | `timed_out_resumable` | Time budget exceeded; workdir preserved | No |
@@ -46,7 +46,7 @@ The multitask orchestrator tracks every workstream through a well-defined lifecy
 
 **Resumable states** (`failed_resumable`, `timed_out_resumable`, `interrupted_resumable`) are never cleaned up automatically. Their workdirs and state files remain on disk so work can continue.
 
-**Cleanup-eligible states** (`failed_terminal`, `abandoned`, `completed`) are safe to remove from disk. The orchestrator will not delete working trees in resumable states even when cleanup is requested.
+**Cleanup-eligible states** (`completed`, `failed_terminal`, `abandoned`) are safe to remove from disk. The orchestrator will not delete working trees in resumable states even when cleanup is requested.
 
 ---
 

--- a/.claude/skills/multitask/reference.md
+++ b/.claude/skills/multitask/reference.md
@@ -29,25 +29,29 @@ orchestrator.py (ParallelOrchestrator)
     "branch": "feat/my-feature",
     "description": "Brief description shown in reports",
     "task": "Detailed task instructions for the agent",
-    "recipe": "default-workflow"
+    "recipe": "default-workflow",
+    "timeout_policy": "interrupt-preserve",
+    "max_runtime": 7200
   }
 ]
 ```
 
 ### Required Fields
 
-| Field    | Type   | Description                            |
-| -------- | ------ | -------------------------------------- |
-| `issue`  | int    | GitHub issue number                    |
-| `branch` | string | Git branch name (must exist in remote) |
-| `task`   | string | Detailed task instructions             |
+| Field    | Type         | Description                                            |
+| -------- | ------------ | ------------------------------------------------------ |
+| `issue`  | int or `"TBD"` | GitHub issue number; `"TBD"` auto-creates an issue   |
+| `branch` | string       | Git branch name (must exist in remote)                 |
+| `task`   | string       | Detailed task instructions                             |
 
 ### Optional Fields
 
-| Field         | Type   | Default              | Description                   |
-| ------------- | ------ | -------------------- | ----------------------------- |
-| `description` | string | `"Issue #N"`         | Short description for reports |
-| `recipe`      | string | `"default-workflow"` | Recipe to execute             |
+| Field            | Type   | Default              | Description                                                                 |
+| ---------------- | ------ | -------------------- | --------------------------------------------------------------------------- |
+| `description`    | string | `"Issue #N"`         | Short description for reports                                               |
+| `recipe`         | string | `"default-workflow"` | Recipe to execute                                                           |
+| `timeout_policy` | string | `"interrupt-preserve"` | What to do when `max_runtime` is exceeded: `"interrupt-preserve"` or `"continue-preserve"` |
+| `max_runtime`    | int    | `7200`               | Per-workstream wall-clock budget in seconds                                 |
 
 ## Orchestrator API
 
@@ -62,7 +66,7 @@ orchestrator.py (ParallelOrchestrator)
 ### Methods
 
 - `setup()` - Create clean temporary directory
-- `add(issue, branch, description, task, recipe)` - Add and clone a workstream
+- `add(issue, branch, description, task, recipe, *, max_runtime, timeout_policy)` - Add and clone a workstream
 - `launch(ws)` - Launch single workstream subprocess
 - `launch_all()` - Launch all workstreams in parallel
 - `get_status()` - Returns `{"running": [...], "completed": [...], "failed": [...]}`

--- a/.claude/skills/multitask/reference.md
+++ b/.claude/skills/multitask/reference.md
@@ -139,6 +139,29 @@ To use classic mode as fallback, specify `--mode classic` when invoking the orch
 | Agent step (CLISubprocessAdapter) | 300s per step |
 | Bash step (CLISubprocessAdapter)  | 120s per step |
 
+### Timeout Policies
+
+When a workstream reaches its `max_runtime`, the `timeout_policy` controls what happens:
+
+| Policy | Behaviour |
+| ---------------------- | --------------------------------------------------------------- |
+| `interrupt-preserve` | Terminate subprocess; save state as `timed_out_resumable` (default) |
+| `continue-preserve` | Let subprocess run; mark state `timed_out_resumable`; orchestrator moves on |
+
+Set per-workstream in the JSON config or in `add()`:
+
+```json
+{ "timeout_policy": "continue-preserve", "max_runtime": 10800 }
+```
+
+Set globally:
+
+```
+AMPLIHACK_TIMEOUT_POLICY=continue-preserve
+```
+
+See [`TIMEOUT_LIFECYCLE.md`](TIMEOUT_LIFECYCLE.md) for the full lifecycle state machine, resume behaviour, state file schema, and security details.
+
 ## Error Handling
 
 ### Workstream Failures


### PR DESCRIPTION
Closes #4183

## Summary

Retcon documentation for the multitask orchestrator timeout/recovery lifecycle, produced by the investigate-timeout-lifecycle + implement-defect-fixes workstreams.

## Changes

- **TIMEOUT_LIFECYCLE.md** (new): Documents the full lifecycle state machine (pending → running → completed/failed_resumable/timed_out_resumable/etc.), both timeout policies (`interrupt-preserve` and `continue-preserve`), workdir cleanup eligibility, the resumable state model specifying exactly what data is persisted, and session recovery instructions.
- **reference.md**: Added `timeout_policy` and `max_runtime` to the workstream config table.
- **SKILL.md**: Minor cross-reference update.

## Investigation findings

The investigation (ws-4181) confirmed:
- 7200s is the default `max_runtime`; fires via `interrupt-preserve` sending SIGTERM→SIGKILL then saving `timed_out_resumable` state.
- Active-progress detection uses checkpoint existence at state-write time.
- Workdirs are kept for all resumable states; only `completed`, `failed_terminal`, and `abandoned` are cleanup-eligible.

## PR stack validation (ws-4182)

Confirmed PRs #4074, #4075, #4076 are merged on main with no rebase conflicts. dep_check.py scoped import validation and timeout preservation logic are both present on HEAD.

## Tests

All 19 multitask/timeout tests pass.