### PR TITLE
fix(workflow): replace not-in-list conditions with Rust-runner-compatible form

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: ws-4150
+## Project: issue-4177-treat-issues-4070-4105-4103-4102-4067-as-one-coord
 
 ## Overview
 

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -842,7 +842,7 @@ steps:
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -877,7 +877,7 @@ steps:
   - id: "step-08-implement"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -918,7 +918,7 @@ steps:
   - id: "step-08b-integration"
     agent: "amplihack:integration"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -983,7 +983,7 @@ steps:
   # --------------------------------------------------------------------------
   - id: "checkpoint-after-implementation"
     type: "bash"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     command: |
       set -euo pipefail
       WORKTREE_DIR="{{worktree_setup.worktree_path}}"

--- a/tests/recipes/test_default_workflow_resumable_timeouts.py
+++ b/tests/recipes/test_default_workflow_resumable_timeouts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -112,3 +113,67 @@ def test_checkpoint_commands_are_shell_syntax_valid(
     )
 
     assert result.returncode == 0, result.stderr
+
+
+# --- Rust runner compatibility ---
+
+
+_LIST_LITERAL_IN_CONDITION = re.compile(r"\bnot\s+in\s*\[|\bin\s*\[")
+
+
+@pytest.mark.parametrize(
+    "step_id,condition",
+    [
+        (s["id"], s["condition"])
+        for s in _load_recipe()["steps"]
+        if s.get("condition")
+    ],
+)
+def test_step_conditions_do_not_use_list_literals(step_id: str, condition: str):
+    """Conditions using 'not in [...]' or 'in [...]' break the Rust recipe runner.
+
+    The Rust runner does not support list literal syntax in condition expressions.
+    Use '!= X and != Y' form instead of 'not in [X, Y]'.
+    """
+    assert not _LIST_LITERAL_IN_CONDITION.search(condition), (
+        f"Step '{step_id}' condition uses list-literal 'in [...]' syntax "
+        f"which is incompatible with the Rust recipe runner: {condition!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "step_id,checkpoint_value,expected",
+    [
+        ("step-07-write-tests", "", True),
+        ("step-07-write-tests", "checkpoint-after-implementation", False),
+        ("step-07-write-tests", "checkpoint-after-review-feedback", False),
+        ("step-08-implement", "", True),
+        ("step-08-implement", "checkpoint-after-implementation", False),
+        ("step-08-implement", "checkpoint-after-review-feedback", False),
+        ("checkpoint-after-implementation", "", True),
+        ("checkpoint-after-implementation", "checkpoint-after-implementation", False),
+        ("checkpoint-after-implementation", "checkpoint-after-review-feedback", False),
+    ],
+)
+def test_pre_checkpoint_conditions_evaluate_correctly(
+    steps: dict[str, dict],
+    step_id: str,
+    checkpoint_value: str,
+    expected: bool,
+):
+    """Verify the checkpoint resume conditions evaluate to the expected boolean."""
+    from amplihack.recipes.models import Step, StepType
+
+    raw = steps[step_id]
+    step = Step(
+        id=raw["id"],
+        step_type=StepType.AGENT if raw.get("agent") else StepType.BASH,
+        condition=raw.get("condition"),
+        prompt=raw.get("prompt", ""),
+        output=raw.get("output"),
+    )
+    result = step.evaluate_condition({"resume_checkpoint": checkpoint_value})
+    assert result is expected, (
+        f"Step '{step_id}' with resume_checkpoint={checkpoint_value!r}: "
+        f"expected {expected}, got {result}"
+    )


### PR DESCRIPTION
## Summary

During coordinated investigation of the timeout/recovery stack cluster (#4070, #4105, #4103, #4102, #4067), the parallel default-workflow workstream failed at step-07-write-tests with:

```
[ERROR recipe_runner_rs::runner] Condition evaluation FAILED for step 'step-07-write-tests': Parse error: unexpected token: LBracket
```

**Root cause**: Four steps in default-workflow.yaml used `not in [...]` list-literal syntax in conditions, which the Rust recipe runner cannot parse.

## Changes

- **default-workflow.yaml**: Replace 4 conditions using `resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']` with the equivalent `!= ... and != ...` form compatible with both the Python (simpleeval) and Rust runners
- **test_default_workflow_resumable_timeouts.py**: Add two new test groups:
  - `test_step_conditions_do_not_use_list_literals`: parametrized across all step conditions to catch future regressions
  - `test_pre_checkpoint_conditions_evaluate_correctly`: verifies each checkpoint guard evaluates to the expected boolean

## Validation

`uv run pytest tests/recipes/test_default_workflow_resumable_timeouts.py -v` — 51 passed

Closes #4177