### PR TITLE
fix(launcher): strip --dangerously-skip-permissions from Copilot binary paths

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: ws-4150
+## Project: ws-4174
 
 ## Overview
 

--- a/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
+++ b/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
@@ -1,8 +1,17 @@
 """Knowledge acquirer using web search."""
 
+import os
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
+
+
+def _is_copilot_binary(agent_cmd: str) -> bool:
+    """Return True if agent_cmd resolves to the Copilot binary."""
+    return (
+        os.path.basename(agent_cmd) == "copilot"
+        or os.getenv("AMPLIHACK_AGENT_BINARY", "") == "copilot"
+    )
 
 
 class KnowledgeAcquirer:
@@ -41,8 +50,11 @@ Requirements:
   - [url2]
   - [url3]"""
 
+        cmd = [self.agent_cmd, "-p", prompt]
+        if not _is_copilot_binary(self.agent_cmd):
+            cmd.insert(1, "--dangerously-skip-permissions")
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            cmd,
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/knowledge_builder/modules/question_generator.py
+++ b/src/amplihack/knowledge_builder/modules/question_generator.py
@@ -1,8 +1,17 @@
 """Question generator using Socratic method."""
 
+import os
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
+
+
+def _is_copilot_binary(agent_cmd: str) -> bool:
+    """Return True if agent_cmd resolves to the Copilot binary."""
+    return (
+        os.path.basename(agent_cmd) == "copilot"
+        or os.getenv("AMPLIHACK_AGENT_BINARY", "") == "copilot"
+    )
 
 
 class QuestionGenerator:
@@ -34,8 +43,11 @@ Requirements:
 - Format: One question per line, numbered 1-10
 - No additional commentary"""
 
+        cmd = [self.agent_cmd, "-p", prompt]
+        if not _is_copilot_binary(self.agent_cmd):
+            cmd.insert(1, "--dangerously-skip-permissions")
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            cmd,
             capture_output=True,
             text=True,
             check=False,
@@ -91,8 +103,11 @@ Requirements:
 - Format: One question per line, numbered 1-3
 - No additional commentary"""
 
+        cmd = [self.agent_cmd, "-p", prompt]
+        if not _is_copilot_binary(self.agent_cmd):
+            cmd.insert(1, "--dangerously-skip-permissions")
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            cmd,
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -510,7 +510,8 @@ class ClaudeLauncher:
                 raise RuntimeError("No Claude binary found. Please install Claude CLI.")
 
             # Build standard claude command
-            cmd = [claude_path, "--dangerously-skip-permissions"]
+            is_copilot = os.getenv("AMPLIHACK_AGENT_BINARY", "") == "copilot"
+            cmd = [claude_path] if is_copilot else [claude_path, "--dangerously-skip-permissions"]
 
             # Add --verbose if requested
             if self.verbose:
@@ -552,8 +553,10 @@ class ClaudeLauncher:
             trace_file=trace_file,
         )
 
-        # Add standard Claude CLI arguments
-        cmd.append("--dangerously-skip-permissions")
+        # Add standard Claude CLI arguments (not supported by copilot binary)
+        is_copilot = binary.name == "copilot" or os.getenv("AMPLIHACK_AGENT_BINARY", "") == "copilot"
+        if not is_copilot:
+            cmd.append("--dangerously-skip-permissions")
 
         # Add --verbose if requested
         if self.verbose:


### PR DESCRIPTION
## Summary

Guards `--dangerously-skip-permissions` behind a Copilot binary detection check in three code paths that were previously unconditional:

- `src/amplihack/launcher/core.py` lines 513 and 556: both the `claude_path` (env-var) and native binary paths now check `binary.name == 'copilot'` or `AMPLIHACK_AGENT_BINARY` env var
- `src/amplihack/knowledge_builder/modules/knowledge_acquirer.py`: guards flag via `_is_copilot_binary()` helper
- `src/amplihack/knowledge_builder/modules/question_generator.py`: same guard

The `fix(delegate)` commit #4168 covered the delegate path. This PR covers the remaining paths not addressed by #4168.

Closes #4174
Related: #4166, #4167, #4144, #4136, #4137, #4138, #4139