### PR TITLE
fix(knowledge_builder): guard --dangerously-skip-permissions against copilot binary (#4188)

### DIFF
--- a/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
+++ b/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
@@ -29,8 +29,15 @@ graph LR
     F27["output_validator<br/>refs: 17"]
     F28["models<br/>refs: 16"]
     F29["models<br/>refs: 16"]
+    F30["knowledge_acquirer<br/>refs: 3"]
+    F31["question_generator<br/>refs: 3"]
+    F32["core<br/>refs: 12"]
+    F33["rust_runner<br/>refs: 8"]
     F22 --> F6
     F23 --> F7
     F24 --> F8
+    F30 --> F29
+    F31 --> F29
+    F32 --> F33
 
     click F0 "../ast-lsp-bindings/" "View AST bindings"

--- a/docs/atlas/ast-lsp-bindings/index.md
+++ b/docs/atlas/ast-lsp-bindings/index.md
@@ -9,7 +9,7 @@ title: "Layer 2: AST + LSP Bindings"
 # Layer 2: AST + LSP Bindings
 
 <div class="atlas-metadata">
-Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00:00
+Category: <strong>Structural</strong> | Generated: 2026-04-03T03:04:17.482736+00:00
 </div>
 
 ## Map
@@ -36,7 +36,7 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
         F15["common<br/>refs: 22"]
         F16["utils<br/>refs: 22"]
         F17["xpia_defense_interface<br/>refs: 22"]
-        F18["event_bus<br/>refs: 19"]
+        F18["event_bus<br/>refs: 20"]
         F19["uvx_launcher<br/>refs: 19"]
         F20["uvx_models<br/>refs: 18"]
         F21["considerations<br/>refs: 17"]
@@ -65,9 +65,9 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
 
     | Metric | Value |
     |--------|-------|
-    | Total definitions | 15383 |
+    | Total definitions | 15343 |
     | Total exports | 2268 |
-    | Total imports | 16757 |
+    | Total imports | 16848 |
     | Potentially dead | 434 |
     | Files with `__all__` | 428 |
 
@@ -75,19 +75,19 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
 
 <div class="atlas-legend" markdown>
 
-| Symbol    | Meaning               |
-| --------- | --------------------- |
-| Rectangle | Source file           |
-| Arrow     | Import dependency     |
+| Symbol | Meaning |
+|--------|---------|
+| Rectangle | Source file |
+| Arrow | Import dependency |
 | `refs: N` | Total reference count |
 
 </div>
 
 ## Key Findings
 
-- 15383 total definitions across all files
+- 15343 total definitions across all files
 - 434 potentially dead definitions (2.8% of total)
-- 1983 files without `__all__` exports
+- 1979 files without `__all__` exports
 
 ## Detail
 
@@ -95,15 +95,15 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
 
     **Summary metrics:**
 
-    - **Total Definitions**: 15383
+    - **Total Definitions**: 15343
     - **Total Exports**: 2268
-    - **Total Imports**: 16757
+    - **Total Imports**: 16848
     - **Potentially Dead Count**: 434
     - **Files With All**: 428
-    - **Files Without All**: 1983
+    - **Files Without All**: 1979
     - **Importlib Dynamic Imports**: 43
     - **Language Counts**:
-        - `python`: 15383
+        - `python`: 15343
 
 ## Cross-References
 

--- a/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
+++ b/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
@@ -1,8 +1,17 @@
 """Knowledge acquirer using web search."""
 
+import os
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
+
+
+def _build_agent_cmd(agent_cmd: str, prompt: str) -> list[str]:
+    """Build subprocess command list, routing copilot vs claude flags appropriately."""
+    effective_agent = os.environ.get("AMPLIHACK_AGENT_BINARY", agent_cmd)
+    if effective_agent == "copilot":
+        return ["amplihack", "copilot", "--allow-all-tools", "--add-dir", "/", "-p", prompt]
+    return [effective_agent, "--dangerously-skip-permissions", "-p", prompt]
 
 
 class KnowledgeAcquirer:
@@ -41,8 +50,9 @@ Requirements:
   - [url2]
   - [url3]"""
 
+        cmd = _build_agent_cmd(self.agent_cmd, prompt)
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            cmd,
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/knowledge_builder/modules/question_generator.py
+++ b/src/amplihack/knowledge_builder/modules/question_generator.py
@@ -1,8 +1,17 @@
 """Question generator using Socratic method."""
 
+import os
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
+
+
+def _build_agent_cmd(agent_cmd: str, prompt: str) -> list[str]:
+    """Build subprocess command list, routing copilot vs claude flags appropriately."""
+    effective_agent = os.environ.get("AMPLIHACK_AGENT_BINARY", agent_cmd)
+    if effective_agent == "copilot":
+        return ["amplihack", "copilot", "--allow-all-tools", "--add-dir", "/", "-p", prompt]
+    return [effective_agent, "--dangerously-skip-permissions", "-p", prompt]
 
 
 class QuestionGenerator:
@@ -35,7 +44,7 @@ Requirements:
 - No additional commentary"""
 
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            _build_agent_cmd(self.agent_cmd, prompt),
             capture_output=True,
             text=True,
             check=False,
@@ -92,7 +101,7 @@ Requirements:
 - No additional commentary"""
 
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            _build_agent_cmd(self.agent_cmd, prompt),
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -510,7 +510,9 @@ class ClaudeLauncher:
                 raise RuntimeError("No Claude binary found. Please install Claude CLI.")
 
             # Build standard claude command
-            cmd = [claude_path, "--dangerously-skip-permissions"]
+            cmd = [claude_path]
+            if os.getenv("AMPLIHACK_AGENT_BINARY", "claude") != "copilot":
+                cmd.append("--dangerously-skip-permissions")
 
             # Add --verbose if requested
             if self.verbose:
@@ -553,7 +555,8 @@ class ClaudeLauncher:
         )
 
         # Add standard Claude CLI arguments
-        cmd.append("--dangerously-skip-permissions")
+        if os.getenv("AMPLIHACK_AGENT_BINARY", "claude") != "copilot":
+            cmd.append("--dangerously-skip-permissions")
 
         # Add --verbose if requested
         if self.verbose:


### PR DESCRIPTION
## Summary

Guards `--dangerously-skip-permissions` (a Claude-specific flag) from being passed when `AMPLIHACK_AGENT_BINARY=copilot`.

## Changes

- `knowledge_builder/modules/knowledge_acquirer.py`: Added `_build_agent_cmd()` helper; routes copilot to `--allow-all-tools`
- `knowledge_builder/modules/question_generator.py`: Same fix for both subprocess.run calls
- `launcher/core.py`: Guards both `--dangerously-skip-permissions` append sites behind `AMPLIHACK_AGENT_BINARY != copilot` check
- `docs/atlas/ast-lsp-bindings/`: Refreshed atlas layer 8 to clear CI staleness check

## Pattern

Follows the same branching pattern as `auto_mode._run_sdk_subprocess()` (merged in #4168).

Closes #4188
Related: #4159, #4169