### PR TITLE
fix(recipe-runner): auto-update rust runner binary on version mismatch (#4189)

### DIFF
--- a/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
+++ b/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
@@ -29,8 +29,15 @@ graph LR
     F27["output_validator<br/>refs: 17"]
     F28["models<br/>refs: 16"]
     F29["models<br/>refs: 16"]
+    F30["knowledge_acquirer<br/>refs: 3"]
+    F31["question_generator<br/>refs: 3"]
+    F32["core<br/>refs: 12"]
+    F33["rust_runner<br/>refs: 8"]
     F22 --> F6
     F23 --> F7
     F24 --> F8
+    F30 --> F29
+    F31 --> F29
+    F32 --> F33
 
     click F0 "../ast-lsp-bindings/" "View AST bindings"

--- a/docs/atlas/ast-lsp-bindings/index.md
+++ b/docs/atlas/ast-lsp-bindings/index.md
@@ -9,7 +9,7 @@ title: "Layer 2: AST + LSP Bindings"
 # Layer 2: AST + LSP Bindings
 
 <div class="atlas-metadata">
-Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00:00
+Category: <strong>Structural</strong> | Generated: 2026-04-03T03:04:17.482736+00:00
 </div>
 
 ## Map
@@ -36,7 +36,7 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
         F15["common<br/>refs: 22"]
         F16["utils<br/>refs: 22"]
         F17["xpia_defense_interface<br/>refs: 22"]
-        F18["event_bus<br/>refs: 19"]
+        F18["event_bus<br/>refs: 20"]
         F19["uvx_launcher<br/>refs: 19"]
         F20["uvx_models<br/>refs: 18"]
         F21["considerations<br/>refs: 17"]
@@ -65,9 +65,9 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
 
     | Metric | Value |
     |--------|-------|
-    | Total definitions | 15383 |
+    | Total definitions | 15343 |
     | Total exports | 2268 |
-    | Total imports | 16757 |
+    | Total imports | 16848 |
     | Potentially dead | 434 |
     | Files with `__all__` | 428 |
 
@@ -75,19 +75,19 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
 
 <div class="atlas-legend" markdown>
 
-| Symbol    | Meaning               |
-| --------- | --------------------- |
-| Rectangle | Source file           |
-| Arrow     | Import dependency     |
+| Symbol | Meaning |
+|--------|---------|
+| Rectangle | Source file |
+| Arrow | Import dependency |
 | `refs: N` | Total reference count |
 
 </div>
 
 ## Key Findings
 
-- 15383 total definitions across all files
+- 15343 total definitions across all files
 - 434 potentially dead definitions (2.8% of total)
-- 1983 files without `__all__` exports
+- 1979 files without `__all__` exports
 
 ## Detail
 
@@ -95,15 +95,15 @@ Category: <strong>Structural</strong> | Generated: 2026-04-06T17:03:00.000000+00
 
     **Summary metrics:**
 
-    - **Total Definitions**: 15383
+    - **Total Definitions**: 15343
     - **Total Exports**: 2268
-    - **Total Imports**: 16757
+    - **Total Imports**: 16848
     - **Potentially Dead Count**: 434
     - **Files With All**: 428
-    - **Files Without All**: 1983
+    - **Files Without All**: 1979
     - **Importlib Dynamic Imports**: 43
     - **Language Counts**:
-        - `python`: 15383
+        - `python`: 15343
 
 ## Cross-References
 

--- a/src/amplihack/recipes/rust_runner.py
+++ b/src/amplihack/recipes/rust_runner.py
@@ -329,19 +329,26 @@ def _build_rust_env() -> dict[str, str]:
 
 
 def ensure_rust_recipe_runner(*, quiet: bool = False) -> bool:
-    """Ensure the recipe-runner-rs binary is installed.
+    """Ensure the recipe-runner-rs binary is installed and up-to-date.
 
-    If the binary is already available, returns True immediately.
-    Otherwise, attempts to install via ``cargo install --git``.
+    If the binary is already available and meets the minimum version, returns True immediately.
+    If the binary is present but outdated, re-installs it via ``cargo install --git``.
+    If the binary is absent, installs it.
 
     Args:
         quiet: Suppress progress messages.
 
     Returns:
-        True if binary is available after this call, False if installation failed.
+        True if binary is available and up-to-date after this call, False otherwise.
     """
-    if is_rust_runner_available():
+    if is_rust_runner_available() and check_runner_version():
         return True
+
+    if is_rust_runner_available() and not check_runner_version():
+        if not quiet:
+            logger.info(
+                "recipe-runner-rs is outdated — updating from %s …", _REPO_URL
+            )
 
     cargo = shutil.which("cargo")
     if cargo is None:


### PR DESCRIPTION
## Summary

Fixes `ensure_rust_recipe_runner()` to upgrade the binary when it's present but outdated, not just when it's absent.

## Root Cause

`ensure_rust_recipe_runner()` previously returned `True` immediately if any binary was found via `is_rust_runner_available()`, even if `check_runner_version()` would have returned `False`.

## Changes

- `src/amplihack/recipes/rust_runner.py`: Split the early-return check into two cases:
  1. Present + compatible → return `True` immediately (unchanged behaviour)  
  2. Present + outdated → log a message and fall through to `cargo install` to upgrade
- Updated docstring to reflect new behaviour
- `docs/atlas/ast-lsp-bindings/`: Refreshed atlas layer 8 to clear CI staleness check

Closes #4159
Related: #4188, #4169