### PR TITLE
fix(#4169): smart-orchestrator teardown hardening + atlas refresh

### DIFF
--- a/.claude/skills/merge-ready/SKILL.md
+++ b/.claude/skills/merge-ready/SKILL.md
@@ -21,7 +21,7 @@ Use [pr-description-template.md](pr-description-template.md) to update the PR de
 
 A PR is merge-ready only when **all** of the following are true:
 
-1. `qa-team` scenarios were written or updated, validated with `gadugi-test validate`, and actually run with `gadugi-test run`.
+1. `qa-team` scenarios were written or updated, validated with `gadugi-test validate -f`, and actually run with `gadugi-test run -d ... -s ...`.
 2. User-facing docs were updated when the change affects APIs, configuration, deployment, CLI behavior, or other external surfaces.
 3. `quality-audit` completed at least 3 SEEK → VALIDATE → FIX cycles, continued past 3 if critical or high findings remained, and ended on a clean final cycle.
 4. All GitHub Actions checks are green with **0 failures**.
@@ -71,17 +71,19 @@ Invoke `qa-team` and ensure it covers the changed behavior from an external user
 Required deliverables:
 
 - scenario file path(s)
-- proof that `gadugi-test validate` succeeded
-- proof that `gadugi-test run` succeeded
+- proof that `gadugi-test validate -f <scenario-file>` succeeded
+- proof that `gadugi-test run -d <scenario-dir> -s "<scenario-name>"` succeeded
 - target environment used for the run (local or deployed)
 - evidence location or execution output summary
 
 Minimum commands:
 
 ```bash
-gadugi-test validate path/to/scenario.yaml
-gadugi-test run path/to/scenario.yaml
+gadugi-test validate -f path/to/scenario.yaml
+gadugi-test run -d path/to/scenario-dir -s "scenario-name" --verbose
 ```
+
+Use a scenario directory that contains only valid gadugi YAML files for the run. If the repository has legacy or incompatible scenario files elsewhere, isolate the merge-ready scenario in its own subdirectory rather than letting unrelated invalid files poison the run.
 
 If the environment needed to run the scenario does not exist, stop and report a blocker. Do not downgrade this to "definition only".
 
@@ -165,6 +167,7 @@ Use this format:
 Verdict: MERGE_READY | NOT_MERGE_READY
 
 Criteria:
+
 - QA-team: pass | fail
 - Docs: pass | fail | not-applicable
 - Quality-audit: pass | fail
@@ -173,6 +176,7 @@ Criteria:
 - PR description evidence: pass | fail
 
 Blockers:
+
 - <concrete missing item or `none`>
 ```
 

--- a/.claude/skills/merge-ready/pr-description-template.md
+++ b/.claude/skills/merge-ready/pr-description-template.md
@@ -7,9 +7,9 @@ Copy these sections into the PR description and replace every placeholder with a
 ### QA-team evidence
 
 - Scenario files: `<path/to/scenario.yaml>`
-- Validation command: `gadugi-test validate <scenario>`
+- Validation command: `gadugi-test validate -f <scenario-file>`
 - Validation result: `<passed / failed>`
-- Run command: `gadugi-test run <scenario>`
+- Run command: `gadugi-test run -d <scenario-dir> -s "<scenario-name>" --verbose`
 - Run target: `<local env / deployed env>`
 - Run result: `<passed / failed>`
 - Evidence location: `<artifact path or log link>` (must include pass/fail counts and command output, not just a claim)

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -846,7 +846,7 @@ steps:
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -881,7 +881,7 @@ steps:
   - id: "step-08-implement"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -922,7 +922,7 @@ steps:
   - id: "step-08b-integration"
     agent: "amplihack:integration"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -987,7 +987,7 @@ steps:
   # --------------------------------------------------------------------------
   - id: "checkpoint-after-implementation"
     type: "bash"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     command: |
       set -euo pipefail
       WORKTREE_DIR="{{worktree_setup.worktree_path}}"

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -1016,10 +1016,13 @@ steps:
   # ─────────────────────────────────────────────────────────────────────────
   # Teardown: mark this session complete in the session tree
   # Runs unconditionally so the slot is freed even on partial/failed runs.
-  # Combines session completion + workflow semaphore clearing in one Python call.
+  # Canonical teardown now also runs in Python after the Rust runner returns,
+  # so this bash step is a compatibility fallback only and must never flip an
+  # otherwise successful orchestration red due to late-stage env/arg bloat.
   # ─────────────────────────────────────────────────────────────────────────
 
   - id: "complete-session"
+    fatal: false
     type: "bash"
     command: |
       SESSION_JSON=$(cat <<EOFSESSIONJSON

--- a/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot
+++ b/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot
@@ -53,17 +53,23 @@ digraph ast_lsp_bindings {
 
     // Intra-module: recipes/rust_runner -> recipes/discovery
     node [shape=record, style="filled", fillcolor="#d4e8d4"];
-    rust_runner [label="{recipes/rust_runner|contextlib, signal (stdlib)\los, json, subprocess\lRecipeResult, StepResult\l_project_dir_context()\l}"];
+    rust_runner [label="{recipes/rust_runner|contextlib, importlib.util, signal (stdlib)\los, json, subprocess\lRecipeResult, StepResult\l_clear_smart_orchestrator_workflow_active()\l_complete_smart_orchestrator_session()\l_postprocess_smart_orchestrator_result()\l_project_dir_context()\l}"];
     discovery_mod [label="{recipes/discovery|os (stdlib)\lhashlib, json, subprocess\l_AMPLIHACK_HOME_BUNDLE_DIR\l_PACKAGE_BUNDLE_DIR\l_REPO_ROOT_BUNDLE_DIR\l}"];
 
     rust_runner_exec [label="{recipes/rust_runner_execution|build_rust_env()\lexecute_rust_command()\l_ALLOWED_RUST_ENV_VARS\l}"];
     rust_runner_copilot [label="{recipes/rust_runner_copilot|_create_copilot_compat_wrapper_dir()\l_normalize_copilot_cli_args()\l}"];
     rust_runner_resolution [label="{recipes/rust_runner_recipe_resolution|_default_package_recipe_dirs()\l_normalize_recipe_dirs()\l_resolve_recipe_target()\l}"];
+    runtime_assets_mod [label="{runtime_assets|iter_runtime_roots()\lresolve_asset_path()\lmain()\l}"];
+    session_tree_asset [label="{amplifier-bundle/tools/session_tree.py|complete_session()\lget_tree_context()\l}", shape=record, style="filled", fillcolor="#fdebd0"];
+    dev_intent_router_hook [label="{hooks/dev_intent_router.py|clear_workflow_active()\lis_workflow_active()\l}", shape=record, style="filled", fillcolor="#fdebd0"];
 
     rust_runner -> discovery_mod [label="imports\n_AMPLIHACK_HOME_BUNDLE_DIR\n_PACKAGE_BUNDLE_DIR\n_REPO_ROOT_BUNDLE_DIR", color="#6666aa"]; // pragma: allowlist secret
     rust_runner -> rust_runner_exec [label="imports\nbuild_rust_env\nexecute_rust_command", color="#6666aa"];
     rust_runner -> rust_runner_copilot [label="imports\n_create_copilot_compat_wrapper_dir\n_normalize_copilot_cli_args", color="#6666aa"];
     rust_runner -> rust_runner_resolution [label="imports\n_default_package_recipe_dirs\n_normalize_recipe_dirs\n_resolve_recipe_target", color="#6666aa"];
+    rust_runner -> runtime_assets_mod [label="imports\nresolve_asset_path", color="#6666aa"];
+    rust_runner -> session_tree_asset [label="dynamic file import\ncomplete_session", style="dashed", color="#aa6633"];
+    rust_runner -> dev_intent_router_hook [label="dynamic file import\nclear_workflow_active", style="dashed", color="#aa6633"];
     // Dead code candidates
     node [shape=box, style="dashed,filled", fillcolor="#ffcdd2"];
     dead1 [label="examples/usage_example.py\n(demo only)"];

--- a/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
+++ b/docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd
@@ -29,8 +29,17 @@ graph LR
     F27["output_validator<br/>refs: 17"]
     F28["models<br/>refs: 16"]
     F29["models<br/>refs: 16"]
+    F30["rust_runner<br/>smart-orchestrator teardown"]
+    F31["runtime_assets<br/>resolve_asset_path"]
+    F32["session_tree.py<br/>complete_session"]
+    F33["dev_intent_router.py<br/>clear_workflow_active"]
     F22 --> F6
     F23 --> F7
     F24 --> F8
+    F30 --> F31
+    F30 --> F32
+    F30 --> F33
+    F31 --> F32
+    F31 --> F33
 
     click F0 "../ast-lsp-bindings/" "View AST bindings"

--- a/docs/atlas/ast-lsp-bindings/index.md
+++ b/docs/atlas/ast-lsp-bindings/index.md
@@ -88,6 +88,16 @@ Category: <strong>Structural</strong> | Generated: 2026-04-03T03:10:00.000000+00
 - 15343 total definitions across all files
 - 434 potentially dead definitions (2.8% of total)
 - 1979 files without `__all__` exports
+- `recipes/rust_runner.py` now binds `resolve_asset_path()` plus dynamic `session_tree.py` / `dev_intent_router.py` symbols to complete smart-orchestrator teardown in Python rather than late bash
+
+## Recent Delta
+
+- Refreshed layer coverage for `src/amplihack/recipes/rust_runner.py`
+- Captured the new teardown path:
+  - `rust_runner.py` imports `amplihack.runtime_assets.resolve_asset_path()`
+  - `rust_runner.py` dynamically loads `amplifier-bundle/tools/session_tree.py` and calls `complete_session()`
+  - `rust_runner.py` dynamically loads `.claude/tools/amplihack/hooks/dev_intent_router.py` and calls `clear_workflow_active()`
+- This atlas refresh addresses the `Atlas PR Impact Check` staleness triggered by the rust-runner smart-orchestrator teardown hardening
 
 ## Detail
 

--- a/docs/atlas/ast-lsp-bindings/index.md
+++ b/docs/atlas/ast-lsp-bindings/index.md
@@ -90,15 +90,6 @@ Category: <strong>Structural</strong> | Generated: 2026-04-03T03:10:00.000000+00
 - 1979 files without `__all__` exports
 - `recipes/rust_runner.py` now binds `resolve_asset_path()` plus dynamic `session_tree.py` / `dev_intent_router.py` symbols to complete smart-orchestrator teardown in Python rather than late bash
 
-## Recent Delta
-
-- Refreshed layer coverage for `src/amplihack/recipes/rust_runner.py`
-- Captured the new teardown path:
-  - `rust_runner.py` imports `amplihack.runtime_assets.resolve_asset_path()`
-  - `rust_runner.py` dynamically loads `amplifier-bundle/tools/session_tree.py` and calls `complete_session()`
-  - `rust_runner.py` dynamically loads `.claude/tools/amplihack/hooks/dev_intent_router.py` and calls `clear_workflow_active()`
-- This atlas refresh addresses the `Atlas PR Impact Check` staleness triggered by the rust-runner smart-orchestrator teardown hardening
-
 ## Detail
 
 ??? info "Full data (click to expand)"

--- a/src/amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/src/amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -4,13 +4,15 @@ description: |
   Classifies -> formulates goal -> decomposes into workstreams ->
   executes via recipe runner (single or parallel) -> goal-seeking
   reflection loop (3 rounds max, auto-mode pattern) -> summarizes.
-version: "1.4.0"
+version: "1.5.1"
 author: "Amplihack Team"
 tags: ["orchestration", "routing", "parallel", "auto-classify", "goal-seeking"]
 
 context:
   task_description: ""
   repo_path: "."
+  max_runtime: ""
+  timeout_policy: ""
   decomposition_json: ""
   session_id: ""
   tree_id: ""
@@ -28,38 +30,95 @@ context:
   summary: ""
   session_complete_status: ""
   force_single_workstream: "false" # set to "true" to prevent parallel decomposition
+  adaptive_recipe: "" # set by detect-execution-gap when routing fails
+  infra_error_details: "" # diagnostic info for infrastructure failures
+
+context_validation:
+  task_description: "nonempty"
+  repo_path: "git_repo"
 
 steps:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Phase 0: Pre-flight Validation
+  # ─────────────────────────────────────────────────────────────────────────
+  - id: "preflight-validation"
+    type: "bash"
+    command: |
+      ERRORS=""
+      REPO="{{repo_path}}"
+      TASK="{{task_description}}"
+      if [ -z "$TASK" ]; then
+        ERRORS="${ERRORS}\n  ✗ task_description is empty"
+      fi
+      if [ ! -d "$REPO" ]; then
+        ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' does not exist"
+      elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
+        ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
+      fi
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      if [ -z "$HELPER_PATH" ] || [ ! -f "$HELPER_PATH" ]; then
+        ERRORS="${ERRORS}\n  ✗ Cannot find orch_helper.py — set AMPLIHACK_HOME to a valid amplihack root"
+      fi
+      if ! command -v recipe-runner-rs >/dev/null 2>&1 && [ ! -f "$HOME/.cargo/bin/recipe-runner-rs" ]; then
+        ERRORS="${ERRORS}\n  ✗ recipe-runner-rs not found (run: cargo install --git https://github.com/rysweet/amplihack-recipe-runner)"
+      fi
+      if [ -n "$ERRORS" ]; then
+        echo "=== SMART-ORCHESTRATOR PRE-FLIGHT FAILED ===" >&2
+        printf "%b\n" "$ERRORS" >&2
+        echo "Restart: run_recipe_by_name('smart-orchestrator', user_context={'task_description': '...', 'repo_path': '...'}, progress=True)" >&2
+        exit 1
+      fi
+      # Set workflow-active semaphore EARLY so that nested agent steps
+      # (classify-and-decompose) don't get routing/classification hook
+      # injections that cause infinite recursion (fix #3971).
+      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
+      if [ -n "$HOOKS_DIR" ]; then
+        # Pass $PPID (recipe-runner-rs) so the semaphore PID survives the
+        # ephemeral bash step and is still alive when hooks check liveness.
+        python3 - "$HOOKS_DIR" "$PPID" <<'__AMPLIHACK_SEMAPHORE_PY__' 2>/dev/null || true
+      import sys; sys.path.insert(0, sys.argv[1])
+      try:
+          from dev_intent_router import set_workflow_active
+          set_workflow_active('pending', 0, pid=int(sys.argv[2]))
+      except Exception:
+          pass
+      __AMPLIHACK_SEMAPHORE_PY__
+      fi
+      echo "=== Pre-flight passed ==="
+    output: "preflight_status"
+
   # ─────────────────────────────────────────────────────────────────────────
   # Phase 1: Classify & Decompose
   # ─────────────────────────────────────────────────────────────────────────
 
+  # classify-and-decompose: Use a bash step that calls claude directly with
+  # --disallowed-tools to prevent the model from making tool calls.
+  # Without this, the model returns JSON then continues into implementation,
+  # making hundreds of tool calls and never returning (#3971).
   - id: "classify-and-decompose"
-    type: "agent"
-    agent: "amplihack:core:architect"
-    prompt: |
-      === [RECIPE PROGRESS] Step: classify-and-decompose ===
+    type: "bash"
+    command: |
+      AGENT_BIN="${AMPLIHACK_AGENT_BINARY:-claude}"
+      _PROMPT_FILE=$(mktemp)
+      trap 'rm -f "$_PROMPT_FILE"' EXIT
+      cat > "$_PROMPT_FILE" <<'__AMPLIHACK_CLASSIFY_EOF__'
+      You are classifying a task for the smart-orchestrator recipe.
+      Return ONLY a JSON object. Do NOT use tools. Do NOT implement anything.
 
-      You are an intelligent task orchestrator. Analyze this request and produce a
-      structured orchestration plan.
+      REQUEST: {{task_description}}
 
-      **REQUEST**: {{task_description}}
-
-      Output:
+      Classify and decompose:
       1. task_type: Q&A | Operations | Investigation | Development
       2. goal: clear 1-sentence goal
       3. success_criteria: numbered list of verifiable criteria
       4. workstreams: array of independent parallel units
          - 1 workstream for cohesive/sequential tasks
          - 2-5 for CLEARLY INDEPENDENT components
-           e.g. "build webui + api" -> 2 workstreams
-                "investigate X then implement Y" -> 2 workstreams
          - recipe: "default-workflow" (dev) | "investigation-workflow" (research)
 
-      **Decomposition override**: {{force_single_workstream}} — if "true", use exactly 1 workstream regardless of task structure.
+      Decomposition override: {{force_single_workstream}} — if "true", use exactly 1 workstream.
 
-      **Output exactly this JSON**:
-      ```json
+      Output exactly this JSON (no markdown fences, no explanation):
       {
         "task_type": "Development",
         "goal": "One sentence goal",
@@ -68,7 +127,43 @@ steps:
           {"name": "slug", "description": "full task", "recipe": "default-workflow"}
         ]
       }
-      ```
+      __AMPLIHACK_CLASSIFY_EOF__
+      PROMPT=$(cat "$_PROMPT_FILE")
+      _STDERR_FILE=$(mktemp)
+      trap 'rm -f "$_PROMPT_FILE" "$_STDERR_FILE"' EXIT
+      # Build CLI invocation conditional on agent binary.
+      # Claude supports --dangerously-skip-permissions, --disallowed-tools, --append-system-prompt.
+      # Copilot/codex reject those flags; use --allow-all-tools and inject
+      # the classifier constraint into the prompt itself.
+      _CLASSIFIER_CONSTRAINT="SYSTEM CONSTRAINT: You are a task classifier. Output ONLY JSON. Do NOT invoke dev-orchestrator or any workflow. Do NOT use any tools."
+      set +e
+      case "$AGENT_BIN" in
+        *copilot*|*codex*)
+          env -u CLAUDECODE "$AGENT_BIN" \
+            --allow-all-tools \
+            -p "${_CLASSIFIER_CONSTRAINT} ${PROMPT}" 2>"$_STDERR_FILE"
+          ;;
+        *)
+          env -u CLAUDECODE "$AGENT_BIN" \
+            --dangerously-skip-permissions \
+            --disallowed-tools "Bash,Edit,Write,Read,Glob,Grep,Agent,Skill,NotebookEdit,WebFetch,WebSearch,TodoWrite" \
+            --append-system-prompt "You are a task classifier. Output ONLY JSON. Do NOT invoke dev-orchestrator or any workflow." \
+            -p "$PROMPT" 2>"$_STDERR_FILE"
+          ;;
+      esac
+      _EXIT_CODE=$?
+      set -e
+      if [ "$_EXIT_CODE" -ne 0 ]; then
+        _STDERR_CONTENT=$(cat "$_STDERR_FILE" 2>/dev/null || true)
+        echo "classify-and-decompose: $AGENT_BIN exited $_EXIT_CODE" >&2
+        if [ -n "$_STDERR_CONTENT" ]; then
+          echo "stderr: $_STDERR_CONTENT" >&2
+        else
+          echo "stderr: (empty — binary produced no diagnostic output)" >&2
+          echo "hint: verify '$AGENT_BIN' is installed, ANTHROPIC_API_KEY is set, and network is reachable" >&2
+        fi
+        exit "$_EXIT_CODE"
+      fi
     output: "decomposition_json"
 
   # parse-decomposition: extract task_type from architect JSON output.
@@ -77,22 +172,25 @@ steps:
   - id: "parse-decomposition"
     type: "bash"
     command: |
-      HELPER_PATH="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/orch_helper.py"
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
       if [ ! -f "$HELPER_PATH" ]; then
           echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Set AMPLIHACK_HOME to your amplihack repo root, or run from within the repo." >&2
+          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
           exit 1
       fi
-      DECOMP_JSON=$(cat <<'EOFDECOMP'
+      _DECOMP_TMPFILE=$(mktemp)
+      trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
+      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
-      EOFDECOMP
-      )
-      export DECOMP_JSON HELPER_PATH
+      __DECOMP_EOF__
+      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
+      export HELPER_PATH
       python3 - <<'PYEOF'
       import sys, json, os, importlib.util
 
       helper_path = os.environ['HELPER_PATH']
-      decomp_json = os.environ['DECOMP_JSON']
+      with open(os.environ['DECOMP_TMPFILE']) as f:
+          decomp_json = f.read()
 
       spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
       h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
@@ -102,12 +200,13 @@ steps:
           msg = (
               "\n"
               "╔══════════════════════════════════════════════════════════════════╗\n"
-              "║  WARNING: decomposition JSON parse failed                        ║\n"
-              "║  The architect agent returned non-JSON prose instead of the      ║\n"
-              "║  expected structured plan. Defaulting to:                        ║\n"
-              "║    task_type=Development, workstream_count=1 (no goal spec).     ║\n"
-              "║  The goal specification will be EMPTY — execution quality may    ║\n"
-              "║  be degraded. Consider re-running /dev if results are wrong.     ║\n"
+              "║  ERROR: decomposition JSON parse failed                         ║\n"
+              "║  The architect agent returned non-JSON prose instead of the     ║\n"
+              "║  expected structured plan.                                      ║\n"
+              "║                                                                 ║\n"
+              "║  Action: defaulting to task_type=Development so execution can   ║\n"
+              "║  continue. The adaptive strategy step will evaluate whether     ║\n"
+              "║  direct recipe invocation should be attempted.                  ║\n"
               "╚══════════════════════════════════════════════════════════════════╝\n"
           )
           print(msg, file=sys.stderr)
@@ -124,43 +223,87 @@ steps:
   - id: "activate-workflow"
     type: "bash"
     command: |
-      HELPER_PATH="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/orch_helper.py"
-      DECOMP_JSON=$(cat <<'EOFDECOMP'
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      if [ ! -f "$HELPER_PATH" ]; then
+          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
+          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
+          exit 1
+      fi
+      DECOMP_JSON=$(cat <<EOFDECOMP
       {{decomposition_json}}
       EOFDECOMP
       )
       TASK_TYPE={{task_type}}
-      HOOKS_DIR="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/amplihack/hooks"
-      export DECOMP_JSON HELPER_PATH TASK_TYPE HOOKS_DIR
+      FORCE_SINGLE={{force_single_workstream}}
+      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
+      _DECOMP_TMPFILE=$(mktemp)
+      trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
+      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
+      {{decomposition_json}}
+      __DECOMP_EOF__
+      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
+      export TASK_TYPE=$(printf '%s' {{task_type}})
+      export FORCE_SINGLE=$(printf '%s' "$FORCE_SINGLE")
+      export HELPER_PATH HOOKS_DIR
       python3 - <<'PYEOF'
-      import os, sys, importlib.util
+      import os, sys, io, importlib.util
 
       helper_path = os.environ['HELPER_PATH']
-      decomp_json = os.environ['DECOMP_JSON']
+      with open(os.environ['DECOMP_TMPFILE']) as f:
+          decomp_json = f.read()
       task_type = os.environ['TASK_TYPE']
       hooks_dir = os.environ['HOOKS_DIR']
+      force_single = os.environ.get('FORCE_SINGLE', 'false').strip().lower() in ('true', '1')
 
       # Compute workstream count from decomposition JSON
       spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
       h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
       obj = h.extract_json(decomp_json)
-      count = max(1, len(obj.get("workstreams", [{}])))
+      raw_count = max(1, len(obj.get("workstreams", [])))
 
-      # Set workflow-active semaphore so the hook skips injection during execution
+      # Enforce force_single_workstream override (fix #3130)
+      count = 1 if force_single else raw_count
+
+      # Update workflow-active semaphore with actual task_type and workstream count
+      # (initial semaphore was set in preflight-validation with placeholder values)
+      # Redirect stdout during import to prevent pollution of captured output
+      _saved_stdout = sys.stdout
+      sys.stdout = io.StringIO()
       try:
           sys.path.insert(0, hooks_dir)
           from dev_intent_router import set_workflow_active
           set_workflow_active(task_type, count)
       except Exception:
           pass  # Hook may not exist in all environments
+      finally:
+          sys.stdout = _saved_stdout
 
       # Announce classification to stderr (visible to user, not captured as output)
+      if force_single and raw_count != count:
+          print(f"[dev-orchestrator] force_single_workstream=true — overriding {raw_count} workstreams to 1", file=sys.stderr)
       print(f"[dev-orchestrator] Classified as: {task_type} | Workstreams: {count} — starting execution...", file=sys.stderr)
 
-      # Output workstream count (captured by recipe runner)
-      print(count)
+      # Output workstream count (captured by recipe runner).
+      # Use sys.stdout.write to avoid trailing newline — the recipe runner
+      # stores step output as-is, and a trailing '\n' breaks exact string
+      # comparisons in downstream conditions (fix #3570).
+      sys.stdout.write(str(count))
       PYEOF
     output: "workstream_count"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Materialize user_context overrides into step outputs so they are
+  # available in condition evaluation (fix #3075, #3130).
+  # The Rust runner's --set flag updates template variables ({{...}}) but
+  # the condition evaluator only sees step outputs and initial context.
+  # This step bridges the gap by echoing the context value to stdout.
+  # NOTE: Use bare {{var}} — single-quoted '{{var}}' prevents expansion.
+  # ─────────────────────────────────────────────────────────────────────────
+  - id: "materialize-force-single-workstream"
+    type: "bash"
+    command: |
+      printf '%s' {{force_single_workstream}}
+    output: "force_single_workstream"
 
   # ─────────────────────────────────────────────────────────────────────────
   # Setup: register this session in the session tree (atomic check+register)
@@ -172,7 +315,7 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type or task_type == ''"
     command: |
-      TREE_SCRIPT="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/session_tree.py"
+      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
       SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
 
       if [ -f "$TREE_SCRIPT" ]; then
@@ -252,7 +395,10 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type"
     command: |
-      SESSION_JSON={{session_info}}
+      SESSION_JSON=$(cat <<EOFSESSIONJSON
+      {{session_info}}
+      EOFSESSIONJSON
+      )
       # Extract status using shell grep — no Python subprocess needed
       if echo "$SESSION_JSON" | grep -qE '"status" *: *"ok"'; then
         echo "ALLOWED"
@@ -269,16 +415,35 @@ steps:
 
   # ─────────────────────────────────────────────────────────────────────────
   # Phase 2c: Single dev/investigation workstream -- round 1
-  # NOTE: workstream_count is a bash command output and may contain a trailing
-  # newline. The .strip() and `or '1'` are load-bearing — do not remove them.
-  # If workstream_count is empty (step failed), we default to 1 (single workstream).
+  # NOTE: workstream_count may be stored as a Number (int) by the Rust
+  # recipe runner's parse_context_value (which auto-detects "1" → Number).
+  # Conditions compare against both int (1) and string ('1') to avoid
+  # calling .strip() on non-string types (fix #3606, supersedes #3570).
+  # If workstream_count is empty (step failed), we default to single workstream.
   # ─────────────────────────────────────────────────────────────────────────
 
-  - id: "execute-single-round-1"
+  - id: "execute-single-round-1-development"
     type: "recipe"
+    # NOTE: force_single_workstream may be Value::Bool(true) when set via CLI
+    # --set (parse_context_value coerces "true" -> Bool). The condition evaluator
+    # handles Bool/String cross-type coercion (fix #3069 in recipe-runner-rs).
+    # workstream_count may be an integer (parse_context_value auto-detects "1"
+    # as Number) or a string with trailing whitespace. Compare against both
+    # types to avoid .strip() on non-strings (fix #3606).
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and ((workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
+      'Development' in task_type and ((workstream_count == 1 or workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
     recipe: "default-workflow"
+    # No explicit context needed: task_description and repo_path flow through
+    # from the parent smart-orchestrator context automatically via context merging
+    # in _execute_sub_recipe().
+    output: "round_1_result"
+
+  - id: "execute-single-round-1-investigation"
+    type: "recipe"
+    # workstream_count may be Number or String (fix #3606, supersedes #3570).
+    condition: |
+      'Investigation' in task_type and ((workstream_count == 1 or workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
+    recipe: "investigation-workflow"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically via context merging
     # in _execute_sub_recipe().
@@ -290,37 +455,50 @@ steps:
 
   - id: "create-workstreams-config"
     type: "bash"
+    # workstream_count may be Number or String (fix #3606, supersedes #3570).
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
+      ('Development' in task_type or 'Investigation' in task_type) and workstream_count != 1 and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      HELPER_PATH="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/orch_helper.py"
+      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
       if [ ! -f "$HELPER_PATH" ]; then
           echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Set AMPLIHACK_HOME to your amplihack repo root, or run from within the repo." >&2
+          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
           exit 1
       fi
-      DECOMP_JSON=$(cat <<'EOFDECOMP'
+      _DECOMP_TMPFILE=$(mktemp)
+      trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
+      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
-      EOFDECOMP
-      )
-      export DECOMP_JSON HELPER_PATH
+      __DECOMP_EOF__
+      MAX_RUNTIME="{{max_runtime}}"
+      TIMEOUT_POLICY="{{timeout_policy}}"
+      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
+      export HELPER_PATH MAX_RUNTIME TIMEOUT_POLICY
       python3 - <<'PYEOF'
       import json, os, re, tempfile, sys
       sys.path.insert(0, os.path.dirname(os.environ['HELPER_PATH']))
       import orch_helper
-      decomp = os.environ['DECOMP_JSON']
+      with open(os.environ['DECOMP_TMPFILE']) as f:
+          decomp = f.read()
       obj = orch_helper.extract_json(decomp)
       config = []
+      max_runtime = os.environ.get("MAX_RUNTIME", "")
+      timeout_policy = os.environ.get("TIMEOUT_POLICY", "")
       for i, ws in enumerate(obj.get("workstreams", [])):
           name = ws.get("name", f"workstream-{i+1}")
           slug = re.sub(r'[^a-z0-9-]', '-', name.lower())[:30].strip('-') or f"ws-{i+1}"
-          config.append({
+          entry = {
               "issue": "TBD",
               "branch": f"feat/orch-{i+1}-{slug}",
               "description": name,
               "task": ws.get("description", name),
               "recipe": ws.get("recipe", "default-workflow")
-          })
+          }
+          if max_runtime:
+              entry["max_runtime"] = int(max_runtime)
+          if timeout_policy:
+              entry["timeout_policy"] = timeout_policy
+          config.append(entry)
       fd, p = tempfile.mkstemp(prefix="smart-orch-ws-", suffix=".json", dir="/tmp")
       os.chmod(p, 0o600)
       with os.fdopen(fd, "w") as f: json.dump(config, f, indent=2)
@@ -330,12 +508,19 @@ steps:
 
   - id: "launch-parallel-round-1"
     type: "bash"
+    # workstream_count may be Number or String (fix #3606, supersedes #3570).
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
+      ('Development' in task_type or 'Investigation' in task_type) and workstream_count != 1 and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
+      set -o pipefail
+      # Emit step-transition marker for progress tracking (#3625)
+      echo '{"transition":"step_started","step":"launch-parallel-round-1","timestamp":'$(date +%s)'}' >&2
       REPO_PATH={{repo_path}}
       WS_FILE={{workstreams_file}}
-      SESSION_JSON={{session_info}}
+      SESSION_JSON=$(cat <<EOFSESSIONJSON
+      {{session_info}}
+      EOFSESSIONJSON
+      )
       # Parse tree_id, depth, and validate workstreams file in one Python subprocess.
       # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
       export SESSION_JSON WS_FILE
@@ -364,47 +549,233 @@ steps:
 
       if [ -z "$WS_FILE" ] || [ ! -f "$WS_FILE" ]; then
         echo "ERROR: workstreams_file is missing or empty. create-workstreams-config may have failed." >&2
+        emit_step_transition fail
         exit 1
       fi
 
       if [ "$WS_COUNT_CHECK" = "0" ]; then
         echo "ERROR: workstreams config has 0 entries — decomposition may have failed." >&2
+        emit_step_transition fail
         exit 1
       fi
 
       if [ ! -d "$REPO_PATH" ]; then
-        echo "ERROR: repo_path does not exist: $REPO_PATH" >&2; exit 1
+        echo "ERROR: repo_path does not exist: $REPO_PATH" >&2
+        emit_step_transition fail
+        exit 1
       fi
       cd "$REPO_PATH"
+
+      # Resolve multitask orchestrator from AMPLIHACK_HOME, not from repo root.
+      # The orchestrator.py is an amplihack asset, not a repo file (#3762).
+      ORCH_SCRIPT=""
+      for candidate in \
+        "${AMPLIHACK_HOME:+$AMPLIHACK_HOME/.claude/skills/multitask/orchestrator.py}" \
+        "${HOME}/.amplihack/.claude/skills/multitask/orchestrator.py" \
+        "${HOME}/.copilot/skills/multitask/orchestrator.py" \
+        ".claude/skills/multitask/orchestrator.py"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+          ORCH_SCRIPT="$candidate"
+          break
+        fi
+      done
+      if [ -z "$ORCH_SCRIPT" ]; then
+        echo "ERROR: multitask orchestrator.py not found." >&2
+        echo "  Searched: AMPLIHACK_HOME/.claude/skills/multitask/orchestrator.py" >&2
+        echo "  Set AMPLIHACK_HOME or ensure amplihack is installed." >&2
+        emit_step_transition fail
+        exit 1
+      fi
+      echo "Selected orchestrator source: $ORCH_SCRIPT" >&2
+
       echo "Launching parallel workstreams (tree: $TREE_ID, depth: $SESSION_DEPTH):"
       cat "$WS_FILE"
       echo "---"
+      ORCH_ARGS=()
+      if [ -n "${RECIPE_VAR_max_runtime:-}" ]; then
+        ORCH_ARGS+=(--max-runtime "$RECIPE_VAR_max_runtime")
+      fi
+      if [ -n "${RECIPE_VAR_timeout_policy:-}" ]; then
+        ORCH_ARGS+=(--timeout-policy "$RECIPE_VAR_timeout_policy")
+      fi
+      status=0
       AMPLIHACK_TREE_ID="$TREE_ID" AMPLIHACK_SESSION_DEPTH="$SESSION_DEPTH" \
-        python3 .claude/skills/multitask/orchestrator.py "$WS_FILE"
+        AMPLIHACK_PARENT_STEP="launch-parallel-round-1" \
+        AMPLIHACK_REPO_PATH="$REPO_PATH" \
+        python3 -u "$ORCH_SCRIPT" "${ORCH_ARGS[@]}" "$WS_FILE" | tee /dev/stderr || status=$?
+      # Clean up workstreams file now, before this step's output inflates
+      # the recipe context. Doing it here avoids the E2BIG error that
+      # occurs when a later bash step inherits megabytes of env vars
+      # from accumulated round_1_result (fix: cleanup-helper-arg-overflow).
+      rm -f "$WS_FILE" 2>/dev/null || true
+      exit $status
     output: "round_1_result"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Recursion depth limit: fall back to single-session execution
-  # Uses default-workflow sub-recipe (same as primary path) so workflow
-  # steps are enforced even when parallel spawning is blocked.
+  # Recursion depth limit: adapt to single-session execution
+  # Uses the task-appropriate sub-recipe (default-workflow for Development,
+  # investigation-workflow for Investigation) so workflow steps are enforced
+  # even when parallel spawning is blocked.
+  # This is an ADAPTIVE strategy (announced via recursion_guard), not a
+  # degradation — the depth-limited banner makes the change visible.
   # ─────────────────────────────────────────────────────────────────────────
 
-  - id: "execute-single-fallback-blocked"
+  - id: "execute-single-fallback-blocked-development"
     type: "recipe"
-    # Fires when blocked from spawning subworkstreams — executes as single session instead
+    # Fires when blocked from spawning subworkstreams — adapts to single session
+    # workstream_count may be Number or String (fix #3606, supersedes #3570).
     condition: |
-      ('Development' in task_type or 'Investigation' in task_type) and 'BLOCKED' in recursion_guard and workstream_count != '1' and workstream_count != ''
+      'Development' in task_type and 'BLOCKED' in recursion_guard and workstream_count != 1 and workstream_count != '1' and workstream_count != ''
     recipe: "default-workflow"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically.
     output: "round_1_result"
 
-  # Cleanup temp workstreams file
+  - id: "execute-single-fallback-blocked-investigation"
+    type: "recipe"
+    # Fires when blocked from spawning subworkstreams — adapts to single session
+    # workstream_count may be Number or String (fix #3606, supersedes #3570).
+    condition: |
+      'Investigation' in task_type and 'BLOCKED' in recursion_guard and workstream_count != 1 and workstream_count != '1' and workstream_count != ''
+    recipe: "investigation-workflow"
+    # No explicit context needed: task_description and repo_path flow through
+    # from the parent smart-orchestrator context automatically.
+    output: "round_1_result"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Phase 2e: Adaptive error recovery (fix #3132)
+  # When ALL execution paths are skipped (round_1_result is empty), this
+  # is an infrastructure or routing error. Instead of silently producing
+  # no results, surface the error, file a bug, and attempt direct recipe
+  # invocation as an ADAPTIVE STRATEGY (announced, not silent).
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - id: "detect-execution-gap"
+    type: "bash"
+    condition: |
+      ('Development' in task_type or 'Investigation' in task_type) and not round_1_result
+    command: |
+      TASK_TYPE={{task_type}}
+      WS_COUNT={{workstream_count}}
+      FORCE_SINGLE={{force_single_workstream}}
+      GUARD={{recursion_guard}}
+
+      cat >&2 <<ERRMSG
+
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  ERROR: No execution path produced results                     ║
+      ║  All routing conditions evaluated to false — this indicates    ║
+      ║  a routing or infrastructure bug in smart-orchestrator.        ║
+      ║                                                                ║
+      ║  Diagnostic context:                                           ║
+      ║    task_type:               $TASK_TYPE                         ║
+      ║    workstream_count:        $WS_COUNT                          ║
+      ║    force_single_workstream: $FORCE_SINGLE                      ║
+      ║    recursion_guard:         $GUARD                             ║
+      ╚══════════════════════════════════════════════════════════════════╝
+
+      ERRMSG
+
+      # Determine the appropriate direct recipe based on task type
+      if echo "$TASK_TYPE" | grep -qi "investigation"; then
+        RECIPE="investigation-workflow"
+      else
+        RECIPE="default-workflow"
+      fi
+
+      echo "[ADAPTIVE] No execution path ran for $TASK_TYPE task." >&2
+      echo "[ADAPTIVE] Switching to direct $RECIPE invocation." >&2
+      echo "$RECIPE"
+    output: "adaptive_recipe"
+
+  - id: "file-routing-bug"
+    type: "bash"
+    condition: |
+      adaptive_recipe and adaptive_recipe != ''
+    command: |
+      TASK_TYPE={{task_type}}
+      WS_COUNT={{workstream_count}}
+      FORCE_SINGLE={{force_single_workstream}}
+      GUARD={{recursion_guard}}
+      RECIPE={{adaptive_recipe}}
+      TASK_DESC=$(printf '%s' {{task_description}})
+
+      # Build diagnostic body
+      BODY=$(cat <<EOFBODY
+      ## smart-orchestrator routing gap: no execution path ran
+
+      **Symptom**: All execution routing conditions evaluated to false.
+      No execution step (single, parallel, or blocked-fallback) ran.
+
+      ### Diagnostic context
+      - task_type: \`$TASK_TYPE\`
+      - workstream_count: \`$WS_COUNT\`
+      - force_single_workstream: \`$FORCE_SINGLE\`
+      - recursion_guard: \`$GUARD\`
+      - adaptive_recipe selected: \`$RECIPE\`
+
+      ### Task description (truncated)
+      $(echo "$TASK_DESC" | head -c 500)
+
+      ### Environment
+      - AMPLIHACK_HOME: \`${AMPLIHACK_HOME:-<unset>}\`
+      - recipe-runner-rs: \`$(which recipe-runner-rs 2>/dev/null || echo '<not found>')\`
+      - hostname: \`$(hostname -s 2>/dev/null || echo unknown)\`
+      - date: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
+
+      ### Expected behavior
+      At least one execution path should have run based on the classification.
+      The adaptive strategy step ran \`$RECIPE\` directly to recover.
+
+      ---
+      *Auto-filed by smart-orchestrator adaptive error recovery (fix #3132)*
+      EOFBODY
+      )
+
+      # Attempt to file a GH issue — non-fatal if gh is unavailable or auth fails
+      ISSUE_URL=$(gh issue create \
+        --title "smart-orchestrator routing gap: $TASK_TYPE task, workstream_count=$WS_COUNT" \
+        --body "$BODY" \
+        --label "bug" 2>/dev/null) || true
+
+      if [ -n "$ISSUE_URL" ]; then
+        echo "[ADAPTIVE] Filed infrastructure bug: $ISSUE_URL" >&2
+        echo "$ISSUE_URL"
+      else
+        # Log the diagnostic info so it's preserved even if filing fails
+        DIAG_FILE=$(mktemp /tmp/smart-orch-diag-XXXXXX.md)
+        echo "$BODY" > "$DIAG_FILE"
+        echo "[ADAPTIVE] Could not file GH issue (gh unavailable or auth failed)." >&2
+        echo "[ADAPTIVE] Diagnostic info saved to: $DIAG_FILE" >&2
+        echo "diag:$DIAG_FILE"
+      fi
+    output: "infra_error_details"
+
+  - id: "adaptive-execute-development"
+    type: "recipe"
+    condition: |
+      adaptive_recipe == 'default-workflow'
+    recipe: "default-workflow"
+    output: "round_1_result"
+
+  - id: "adaptive-execute-investigation"
+    type: "recipe"
+    condition: |
+      adaptive_recipe == 'investigation-workflow'
+    recipe: "investigation-workflow"
+    output: "round_1_result"
+
+  # Cleanup temp workstreams file (best-effort fallback).
+  # Primary cleanup happens inside launch-parallel-round-1 before context
+  # bloat.  This step uses a glob instead of {{workstreams_file}} so it
+  # carries no template variables — reducing the env-var payload the Rust
+  # runner passes to bash.  The command is unconditionally successful so a
+  # cleanup failure never aborts the recipe (fix: cleanup-helper-arg-overflow).
   - id: "cleanup-helper"
+    fatal: false
     type: "bash"
     command: |
-      WS_FILE={{workstreams_file}}
-      [ -f "$WS_FILE" ] && rm -f "$WS_FILE"
+      rm -f /tmp/smart-orch-ws-*.json 2>/dev/null || true
       echo "ok"
     output: "cleanup_status"
 
@@ -426,16 +797,40 @@ steps:
 
       Was each success criterion met?
 
+      ## Hollow Success Detection (CRITICAL)
+
+      A hollow success is when execution completes structurally but produces
+      no meaningful results. Check for these patterns:
+      - Agent reports "no codebase exists" or "I could not access the code"
+      - Round result is mostly boilerplate with no concrete findings or changes
+      - PR URLs are absent for Development tasks that should produce code changes
+      - Success criteria are marked met without evidence or verification
+      - Agent output repeats the goal description without showing work done
+
+      If the result is a hollow success, use GOAL_STATUS: HOLLOW and explain
+      what specific outputs are missing. Do NOT mark ACHIEVED when agents
+      produced no meaningful work.
+
+      ## Adaptive Strategy Context
+
+      If an infrastructure error was detected and adaptive strategy was used:
+      **Adaptive recipe**: {{adaptive_recipe}}
+      **Error details**: {{infra_error_details}}
+
+      Factor this into your evaluation — if the task ran via adaptive strategy
+      due to a routing failure, note this in your assessment.
+
       End with EXACTLY one of:
-      - `GOAL_STATUS: ACHIEVED` -- all criteria met
+      - `GOAL_STATUS: ACHIEVED` -- all criteria met with verifiable evidence
       - `GOAL_STATUS: PARTIAL -- [what's missing]` -- needs another round
       - `GOAL_STATUS: NOT_ACHIEVED -- [reason]` -- needs another round
+      - `GOAL_STATUS: HOLLOW -- [what was empty]` -- agents ran but produced no real work
     output: "reflection_1"
 
   - id: "execute-round-2"
     type: "agent"
     condition: |
-      reflection_1 and ('PARTIAL' in reflection_1 or 'NOT_ACHIEVED' in reflection_1)
+      reflection_1 and ('PARTIAL' in reflection_1 or 'NOT_ACHIEVED' in reflection_1 or 'HOLLOW' in reflection_1)
     agent: "amplihack:core:builder"
     prompt: |
       Round 1 was incomplete. Continue from where it left off.
@@ -540,7 +935,7 @@ steps:
 
       For parallel workstreams: inspect the round results for evidence that each
       workstream completed, and check whether the log references mention outside-in
-      testing being performed (look for "Step 13", "outside-in-testing", or
+      testing being performed (look for "Step 13", "qa-team", "outside-in-testing", or
       "local testing" references in the results).
 
       ## Validation Steps
@@ -552,7 +947,7 @@ steps:
 
       2. For each workstream, determine whether outside-in testing was performed:
          - Look for "Step 13: Local Testing Results" evidence
-         - Look for `outside-in-testing` skill invocation
+         - Look for `qa-team` or `outside-in-testing` skill invocation
          - Look for at least 2 test scenario results (PASS/FAIL)
 
       3. Report your findings in this format:
@@ -565,7 +960,7 @@ steps:
 
          For each workstream:
            - Workstream: <name or PR URL>
-           - outside-in-testing skill invoked: YES / NO / UNKNOWN
+           - qa-team / outside-in-testing skill invoked: YES / NO / UNKNOWN
            - Step 13 results documented: YES / NO / UNKNOWN
            - Test scenarios executed: <count or UNKNOWN>
            - VERDICT: PASS / FAIL / CANNOT_VERIFY
@@ -606,26 +1001,36 @@ steps:
 
       Note: empty strings above mean that round was not needed.
 
+      **Adaptive strategy used**: {{adaptive_recipe}}
+      **Infrastructure error details**: {{infra_error_details}}
+
       Provide:
       1. What was accomplished (2-3 sentences)
       2. PR links (if any)
       3. Outside-in testing status (PASSED / FAILED / N/A — not applicable when no PR was created)
-      4. Goal status (ACHIEVED / PARTIAL / NOT_ACHIEVED)
+      4. Goal status (ACHIEVED / PARTIAL / NOT_ACHIEVED / HOLLOW)
       5. Remaining work if PARTIAL or if outside-in testing FAILED
+      6. If adaptive strategy was used, note what failed and what strategy was applied
     output: "summary"
 
   # ─────────────────────────────────────────────────────────────────────────
   # Teardown: mark this session complete in the session tree
   # Runs unconditionally so the slot is freed even on partial/failed runs.
-  # Combines session completion + workflow semaphore clearing in one Python call.
+  # Canonical teardown now also runs in Python after the Rust runner returns,
+  # so this bash step is a compatibility fallback only and must never flip an
+  # otherwise successful orchestration red due to late-stage env/arg bloat.
   # ─────────────────────────────────────────────────────────────────────────
 
   - id: "complete-session"
+    fatal: false
     type: "bash"
     command: |
-      SESSION_JSON={{session_info}}
-      TREE_SCRIPT="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/session_tree.py"
-      HOOKS_DIR="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo '.')}/amplifier-bundle/tools/amplihack/hooks"
+      SESSION_JSON=$(cat <<EOFSESSIONJSON
+      {{session_info}}
+      EOFSESSIONJSON
+      )
+      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
+      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
       # Parse session fields and clear workflow semaphore in one Python subprocess.
       # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
       export SESSION_JSON HOOKS_DIR
@@ -668,10 +1073,11 @@ output:
     **Task**: {{task_description}}
     **Type**: {{task_type}}
     **Workstreams**: {{workstream_count}}
+    **Adaptive strategy**: {{adaptive_recipe}}
 
     ## Summary
 
     {{summary}}
 
     ---
-    *amplihack dev-orchestrator v1.4.0 (smart-orchestrator)*
+    *amplihack dev-orchestrator v1.5.0 (smart-orchestrator)*

--- a/src/amplihack/knowledge_builder/modules/_agent_flags.py
+++ b/src/amplihack/knowledge_builder/modules/_agent_flags.py
@@ -1,0 +1,9 @@
+"""Permission-flag helpers for knowledge builder agent commands."""
+
+
+def permission_flag_for_agent_cmd(agent_cmd: str) -> str:
+    """Return the CLI permission flag for the configured agent binary."""
+    normalized_cmd = agent_cmd.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    if "copilot" in normalized_cmd or "codex" in normalized_cmd:
+        return "--allow-all-tools"
+    return "--dangerously-skip-permissions"

--- a/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
+++ b/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
@@ -3,6 +3,7 @@
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
+from amplihack.knowledge_builder.modules._agent_flags import permission_flag_for_agent_cmd
 
 
 class KnowledgeAcquirer:
@@ -41,9 +42,7 @@ Requirements:
   - [url2]
   - [url3]"""
 
-        permission_flag = (
-            "--allow-all-tools" if self.agent_cmd == "copilot" else "--dangerously-skip-permissions"
-        )
+        permission_flag = permission_flag_for_agent_cmd(self.agent_cmd)
         result = subprocess.run(
             [self.agent_cmd, permission_flag, "-p", prompt],
             capture_output=True,

--- a/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
+++ b/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
@@ -41,8 +41,11 @@ Requirements:
   - [url2]
   - [url3]"""
 
+        permission_flag = (
+            "--allow-all-tools" if self.agent_cmd == "copilot" else "--dangerously-skip-permissions"
+        )
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            [self.agent_cmd, permission_flag, "-p", prompt],
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
+++ b/src/amplihack/knowledge_builder/modules/knowledge_acquirer.py
@@ -1,13 +1,18 @@
 """Knowledge acquirer using web search."""
 
+import logging
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
 from amplihack.knowledge_builder.modules._agent_flags import permission_flag_for_agent_cmd
 
+logger = logging.getLogger(__name__)
+
 
 class KnowledgeAcquirer:
     """Acquires knowledge by answering questions via web search."""
+
+    SUBPROCESS_TIMEOUT_SECONDS = 120
 
     def __init__(self, agent_cmd: str = "claude"):
         """Initialize knowledge acquirer.
@@ -43,14 +48,29 @@ Requirements:
   - [url3]"""
 
         permission_flag = permission_flag_for_agent_cmd(self.agent_cmd)
-        result = subprocess.run(
-            [self.agent_cmd, permission_flag, "-p", prompt],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [self.agent_cmd, permission_flag, "-p", prompt],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Knowledge acquisition timed out after %s seconds for %r",
+                self.SUBPROCESS_TIMEOUT_SECONDS,
+                question.text,
+            )
+            return f"Unable to answer: {question.text}", []
 
         if result.returncode != 0:
+            logger.warning(
+                "Knowledge acquisition failed for %r with code %s: %s",
+                question.text,
+                result.returncode,
+                result.stderr.strip() or "no stderr captured",
+            )
             return f"Unable to answer: {question.text}", []
 
         # Parse output

--- a/src/amplihack/knowledge_builder/modules/question_generator.py
+++ b/src/amplihack/knowledge_builder/modules/question_generator.py
@@ -1,13 +1,19 @@
 """Question generator using Socratic method."""
 
+import logging
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
 from amplihack.knowledge_builder.modules._agent_flags import permission_flag_for_agent_cmd
 
+logger = logging.getLogger(__name__)
+
 
 class QuestionGenerator:
     """Generates questions using Socratic method (3 levels deep)."""
+
+    SUBPROCESS_TIMEOUT_SECONDS = 120
+    DEPTH_TWO_PARENT_LIMIT = 47
 
     def __init__(self, agent_cmd: str = "claude"):
         """Initialize question generator.
@@ -36,15 +42,22 @@ Requirements:
 - No additional commentary"""
 
         permission_flag = permission_flag_for_agent_cmd(self.agent_cmd)
-        result = subprocess.run(
-            [self.agent_cmd, permission_flag, "-p", prompt],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [self.agent_cmd, permission_flag, "-p", prompt],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Question generation timed out after {self.SUBPROCESS_TIMEOUT_SECONDS} seconds"
+            ) from exc
 
         if result.returncode != 0:
-            raise RuntimeError(f"Failed to generate questions: {result.stderr}")
+            stderr = result.stderr.strip() or "no stderr captured"
+            raise RuntimeError(f"Failed to generate questions: {stderr}")
 
         # Parse output into questions
         questions = []
@@ -94,15 +107,29 @@ Requirements:
 - No additional commentary"""
 
         permission_flag = permission_flag_for_agent_cmd(self.agent_cmd)
-        result = subprocess.run(
-            [self.agent_cmd, permission_flag, "-p", prompt],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [self.agent_cmd, permission_flag, "-p", prompt],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Socratic question generation timed out after %s seconds for %r",
+                self.SUBPROCESS_TIMEOUT_SECONDS,
+                parent_question.text,
+            )
+            return []
 
         if result.returncode != 0:
-            # Non-fatal - return empty list
+            logger.warning(
+                "Socratic question generation failed for %r with code %s: %s",
+                parent_question.text,
+                result.returncode,
+                result.stderr.strip() or "no stderr captured",
+            )
             return []
 
         # Parse output into questions
@@ -125,13 +152,13 @@ Requirements:
         return questions[:3]  # Ensure exactly 3
 
     def generate_all_questions(self, topic: str) -> list[Question]:
-        """Generate complete question tree (270 total questions).
+        """Generate complete question tree (up to 271 total questions).
 
         Structure:
         - 10 initial questions (depth 0)
         - 30 questions at depth 1 (3 per initial question)
         - 90 questions at depth 2 (3 per depth-1 question)
-        - 140 questions at depth 3 (3 per depth-2 question, but limited to first 50)
+        - 141 questions at depth 3 (3 per depth-2 question, but limited to first 47)
 
         Args:
             topic: Topic to explore
@@ -156,9 +183,14 @@ Requirements:
             # Find all questions at current depth
             parent_questions = [q for q in all_questions if q.depth == depth]
 
-            # Limit to first 50 questions at depth 2 to keep total ~270
-            if depth == 2:
-                parent_questions = parent_questions[:47]  # 47 * 3 = 141, total ~271
+            # Limit depth-2 parents so the generated tree stays bounded and predictable.
+            if depth == 2 and len(parent_questions) > self.DEPTH_TWO_PARENT_LIMIT:
+                logger.info(
+                    "Limiting depth-2 parent questions from %s to %s to cap tree size",
+                    len(parent_questions),
+                    self.DEPTH_TWO_PARENT_LIMIT,
+                )
+                parent_questions = parent_questions[: self.DEPTH_TWO_PARENT_LIMIT]
 
             for parent_idx, parent_q in enumerate(parent_questions):
                 # Calculate actual parent index in all_questions

--- a/src/amplihack/knowledge_builder/modules/question_generator.py
+++ b/src/amplihack/knowledge_builder/modules/question_generator.py
@@ -3,6 +3,7 @@
 import subprocess
 
 from amplihack.knowledge_builder.kb_types import Question
+from amplihack.knowledge_builder.modules._agent_flags import permission_flag_for_agent_cmd
 
 
 class QuestionGenerator:
@@ -34,9 +35,7 @@ Requirements:
 - Format: One question per line, numbered 1-10
 - No additional commentary"""
 
-        permission_flag = (
-            "--allow-all-tools" if self.agent_cmd == "copilot" else "--dangerously-skip-permissions"
-        )
+        permission_flag = permission_flag_for_agent_cmd(self.agent_cmd)
         result = subprocess.run(
             [self.agent_cmd, permission_flag, "-p", prompt],
             capture_output=True,
@@ -94,9 +93,7 @@ Requirements:
 - Format: One question per line, numbered 1-3
 - No additional commentary"""
 
-        permission_flag = (
-            "--allow-all-tools" if self.agent_cmd == "copilot" else "--dangerously-skip-permissions"
-        )
+        permission_flag = permission_flag_for_agent_cmd(self.agent_cmd)
         result = subprocess.run(
             [self.agent_cmd, permission_flag, "-p", prompt],
             capture_output=True,

--- a/src/amplihack/knowledge_builder/modules/question_generator.py
+++ b/src/amplihack/knowledge_builder/modules/question_generator.py
@@ -34,8 +34,11 @@ Requirements:
 - Format: One question per line, numbered 1-10
 - No additional commentary"""
 
+        permission_flag = (
+            "--allow-all-tools" if self.agent_cmd == "copilot" else "--dangerously-skip-permissions"
+        )
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            [self.agent_cmd, permission_flag, "-p", prompt],
             capture_output=True,
             text=True,
             check=False,
@@ -91,8 +94,11 @@ Requirements:
 - Format: One question per line, numbered 1-3
 - No additional commentary"""
 
+        permission_flag = (
+            "--allow-all-tools" if self.agent_cmd == "copilot" else "--dangerously-skip-permissions"
+        )
         result = subprocess.run(
-            [self.agent_cmd, "--dangerously-skip-permissions", "-p", prompt],
+            [self.agent_cmd, permission_flag, "-p", prompt],
             capture_output=True,
             text=True,
             check=False,

--- a/src/amplihack/recipes/rust_runner.py
+++ b/src/amplihack/recipes/rust_runner.py
@@ -8,6 +8,7 @@ execution fails immediately with a clear error.
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import json
 import logging
 import os
@@ -437,6 +438,14 @@ def _find_rust_binary() -> str:
     if Path(binary).exists():
         _check_binary_permissions(binary)
     if not check_runner_version(binary):
+        if os.environ.get("RECIPE_RUNNER_AUTO_UPDATE", "1") != "0":
+            logger.info("recipe-runner-rs version mismatch — attempting auto-update")
+            if runner_binary.ensure_rust_recipe_runner():
+                binary = find_rust_binary() or binary
+                if Path(binary).exists():
+                    _check_binary_permissions(binary)
+                if check_runner_version(binary):
+                    return binary
         raise_for_runner_version(binary)
     return binary
 
@@ -937,6 +946,121 @@ def _emit_recipe_source_diagnostic(requested_name: str, resolved_target: str) ->
     print(f"Selected recipe source: {selected}", file=sys.stderr, flush=True)
 
 
+def _is_smart_orchestrator_target(requested_name: str, resolved_target: str) -> bool:
+    """Return True when the requested recipe resolves to smart-orchestrator."""
+    if requested_name == "smart-orchestrator":
+        return True
+    candidate = Path(resolved_target)
+    return candidate.name == "smart-orchestrator.yaml"
+
+
+def _load_module_from_file(path: Path, module_name: str) -> Any:
+    """Import a Python module from an explicit filesystem path."""
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _clear_smart_orchestrator_workflow_active() -> str:
+    """Clear the workflow-active semaphore used by smart-orchestrator hooks."""
+    from amplihack.runtime_assets import resolve_asset_path
+
+    hooks_dir = resolve_asset_path("hooks-dir")
+    module = _load_module_from_file(
+        hooks_dir / "dev_intent_router.py",
+        f"dev_intent_router_{os.getpid()}",
+    )
+    clear_workflow_active = getattr(module, "clear_workflow_active", None)
+    if not callable(clear_workflow_active):
+        raise AttributeError("dev_intent_router.clear_workflow_active is not callable")
+    clear_workflow_active()
+    return "workflow-active semaphore cleared"
+
+
+def _parse_smart_orchestrator_session_info(session_info: Any) -> tuple[str, str, str]:
+    """Return ``(session_id, tree_id, status)`` from smart-orchestrator context."""
+    if isinstance(session_info, dict):
+        data = session_info
+    elif isinstance(session_info, str):
+        text = session_info.strip()
+        if not text:
+            return "", "", ""
+        data = json.loads(text)
+    else:
+        raise TypeError("session_info must be a JSON string or mapping")
+
+    if not isinstance(data, dict):
+        raise ValueError("session_info must decode to a JSON object")
+
+    session_id = str(data.get("session_id", "")).strip()
+    tree_id = str(data.get("tree_id", "")).strip()
+    status = str(data.get("status", "")).strip()
+    return session_id, tree_id, status
+
+
+def _complete_smart_orchestrator_session(session_info: Any) -> str:
+    """Complete the smart-orchestrator session in the session tree."""
+    from amplihack.runtime_assets import resolve_asset_path
+
+    session_id, tree_id, status = _parse_smart_orchestrator_session_info(session_info)
+    if not session_id or status != "ok":
+        return f"No session to complete (status: {status or 'empty'})"
+
+    session_tree_path = resolve_asset_path("session-tree-path")
+    module = _load_module_from_file(session_tree_path, f"session_tree_{os.getpid()}")
+    complete_session = getattr(module, "complete_session", None)
+    if not callable(complete_session):
+        raise AttributeError("session_tree.complete_session is not callable")
+    complete_session(session_id, tree_id or None)
+    if tree_id:
+        return f"Session {session_id} completed in tree {tree_id}"
+    return f"Session {session_id} completed"
+
+
+def _best_effort_clear_smart_orchestrator_workflow_active() -> str | None:
+    """Clear the smart-orchestrator semaphore without failing the recipe call."""
+    try:
+        return _clear_smart_orchestrator_workflow_active()
+    except (AttributeError, FileNotFoundError, ImportError, OSError, ValueError) as exc:
+        logger.warning("Could not clear smart-orchestrator workflow semaphore: %s", exc)
+        return None
+
+
+def _best_effort_complete_smart_orchestrator_session(session_info: Any) -> str | None:
+    """Complete the session tree entry without failing the recipe call."""
+    try:
+        return _complete_smart_orchestrator_session(session_info)
+    except (
+        AttributeError,
+        FileNotFoundError,
+        ImportError,
+        OSError,
+        TimeoutError,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        logger.warning("Could not complete smart-orchestrator session: %s", exc)
+        return None
+
+
+def _postprocess_smart_orchestrator_result(result: RecipeResult, *, dry_run: bool) -> None:
+    """Run deterministic Python teardown for smart-orchestrator results."""
+    if dry_run:
+        return
+
+    messages = [
+        _best_effort_clear_smart_orchestrator_workflow_active(),
+        _best_effort_complete_smart_orchestrator_session(result.context.get("session_info", "")),
+    ]
+    rendered = [message for message in messages if message]
+    if rendered:
+        result.context["session_complete_status"] = "; ".join(rendered)
+
+
 def run_recipe_via_rust(
     name: str,
     user_context: dict[str, Any] | None = None,
@@ -981,6 +1105,7 @@ def run_recipe_via_rust(
         recipe_dirs=effective_recipe_dirs,
         working_dir=working_dir,
     )
+    smart_orchestrator_target = _is_smart_orchestrator_target(name, resolved_name)
     if progress or emit_startup_banner:
         _emit_recipe_source_diagnostic(name, resolved_name)
 
@@ -1010,12 +1135,21 @@ def run_recipe_via_rust(
                 _redact_command_for_log(cmd),
             )
         with _project_dir_context(resolved_working_dir):
-            return _execute_rust_command(
-                cmd,
-                name=name,
-                progress=progress,
-                emit_startup_banner=emit_startup_banner,
-            )
+            try:
+                result = _execute_rust_command(
+                    cmd,
+                    name=name,
+                    progress=progress,
+                    emit_startup_banner=emit_startup_banner,
+                )
+            except Exception:
+                if smart_orchestrator_target and not dry_run:
+                    _best_effort_clear_smart_orchestrator_workflow_active()
+                raise
     finally:
         # R6: securely overwrite-then-delete spill files.
         _secure_delete_spill_dir(tmp_dir)
+
+    if smart_orchestrator_target:
+        _postprocess_smart_orchestrator_result(result, dry_run=dry_run)
+    return result

--- a/tests/gadugi/merge-ready/smart-orchestrator-teardown-and-atlas-refresh.yaml
+++ b/tests/gadugi/merge-ready/smart-orchestrator-teardown-and-atlas-refresh.yaml
@@ -1,0 +1,137 @@
+name: "Smart Orchestrator - Teardown Hardening and Atlas Refresh"
+description: >
+  Validates the orchestration-brittleness fix that moved smart-orchestrator
+  teardown into deterministic Python post-processing, keeps the packaged
+  smart-orchestrator recipe copy synced with the top-level source, and refreshes
+  the ast-lsp-bindings atlas layer for rust_runner.py changes.
+version: "1.0.0"
+config:
+  timeout: 240000
+  retries: 0
+  parallel: false
+
+environment:
+  requires: []
+
+agents:
+  - name: "cli-agent"
+    type: "cli"
+    config:
+      workingDirectory: "."
+      defaultTimeout: 120000
+      executionMode: "spawn"
+      captureOutput: true
+      ioConfig:
+        encoding: "utf8"
+        handleInteractivePrompts: false
+      logConfig:
+        logCommands: true
+        logOutput: true
+        logLevel: "info"
+
+steps:
+  - name: "Run focused orchestration regression suites"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: >-
+        PYTHONPATH=src uv run pytest -q
+        tests/recipes/test_rust_runner.py
+        tests/recipes/test_smart_orchestrator_bundle_sync.py
+        tests/recipes/test_session_info_quoting.py
+        tests/skills/test_dev_orchestrator_issue_3002.py
+        tests/recipes/test_rust_runner_binary.py
+        tests/knowledge_builder/test_kb_modules.py
+        tests/recipes/test_default_workflow_resumable_timeouts.py
+        && echo ORCH_TEARDOWN_REGRESSIONS_OK
+    timeout: 180000
+
+  - name: "Verify orchestration regression suites passed"
+    agent: "cli-agent"
+    action: "wait_for_output"
+    params:
+      target: "ORCH_TEARDOWN_REGRESSIONS_OK"
+    timeout: 15000
+
+  - name: "Run outside-in startup smoke"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: >-
+        PYTHONPATH=src uv run pytest -q
+        tests/outside_in/test_dev_orchestrator_startup_e2e.py
+        -k direct_launch_snippet_executes_in_dry_run
+        && echo OUTSIDE_IN_STARTUP_OK
+    timeout: 120000
+
+  - name: "Verify outside-in startup smoke passed"
+    agent: "cli-agent"
+    action: "wait_for_output"
+    params:
+      target: "OUTSIDE_IN_STARTUP_OK"
+    timeout: 15000
+
+  - name: "Verify Python teardown path and bundle sync surfaces"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: >-
+        python3 -c "from pathlib import Path; import yaml;
+        recipe = yaml.safe_load(Path('amplifier-bundle/recipes/smart-orchestrator.yaml').read_text());
+        step = next(s for s in recipe['steps'] if s['id'] == 'complete-session');
+        assert step.get('fatal') is False;
+        src = Path('amplifier-bundle/recipes/smart-orchestrator.yaml').read_text();
+        pkg = Path('src/amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml').read_text();
+        assert src == pkg;
+        text = Path('src/amplihack/recipes/rust_runner.py').read_text();
+        required = ['def _clear_smart_orchestrator_workflow_active', 'def _complete_smart_orchestrator_session', 'def _postprocess_smart_orchestrator_result', 'resolve_asset_path(\"hooks-dir\")', 'resolve_asset_path(\"session-tree-path\")'];
+        missing = [item for item in required if item not in text];
+        assert not missing, missing;
+        print('PYTHON_TEARDOWN_OK')"
+    timeout: 30000
+
+  - name: "Verify Python teardown path marker"
+    agent: "cli-agent"
+    action: "wait_for_output"
+    params:
+      target: "PYTHON_TEARDOWN_OK"
+    timeout: 10000
+
+  - name: "Verify atlas layer refresh markers"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: >-
+        python3 -c "from pathlib import Path;
+        idx = Path('docs/atlas/ast-lsp-bindings/index.md').read_text();
+        dot = Path('docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot').read_text();
+        mmd = Path('docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd').read_text();
+        assert 'rust_runner.py' in idx;
+        assert 'runtime_assets' in dot and 'dev_intent_router' in dot and 'session_tree.py' in dot;
+        assert 'runtime_assets' in mmd;
+        print('ATLAS_REFRESH_OK')"
+    timeout: 30000
+
+  - name: "Verify atlas layer refresh marker"
+    agent: "cli-agent"
+    action: "wait_for_output"
+    params:
+      target: "ATLAS_REFRESH_OK"
+    timeout: 10000
+
+cleanup:
+  - name: "Capture full outside-in output"
+    agent: "cli-agent"
+    action: "save_output"
+    params:
+      outputType: "full"
+      path: "smart-orchestrator-teardown-and-atlas-refresh-output.txt"
+
+metadata:
+  tags:
+    ["cli", "smart-orchestrator", "teardown", "rust-runner", "atlas", "regression", "outside-in"]
+  priority: "high"
+
+# Run commands:
+# gadugi-test validate -f tests/gadugi/merge-ready/smart-orchestrator-teardown-and-atlas-refresh.yaml
+# gadugi-test run -d tests/gadugi/merge-ready -s "smart-orchestrator-teardown-and-atlas-refresh" --verbose

--- a/tests/knowledge_builder/test_kb_modules.py
+++ b/tests/knowledge_builder/test_kb_modules.py
@@ -1,6 +1,9 @@
 """Unit tests for Knowledge Builder modules."""
 
+import subprocess
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from amplihack.knowledge_builder.kb_types import KnowledgeGraph, KnowledgeTriplet, Question
 from amplihack.knowledge_builder.modules._agent_flags import permission_flag_for_agent_cmd
@@ -43,6 +46,30 @@ class TestQuestionGenerator:
         assert len(questions) == 3
         assert all(q.depth == 1 for q in questions)
         assert all(q.parent_index == 0 for q in questions)
+
+    @patch("subprocess.run")
+    def test_generate_initial_questions_timeout_raises(self, mock_run):
+        """Initial question generation should fail loudly on timeouts."""
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["copilot"], timeout=QuestionGenerator.SUBPROCESS_TIMEOUT_SECONDS
+        )
+
+        gen = QuestionGenerator(agent_cmd="claude")
+        with pytest.raises(RuntimeError, match="timed out"):
+            gen.generate_initial_questions("Test Topic")
+
+    @patch("subprocess.run")
+    def test_generate_socratic_questions_logs_failure(self, mock_run, caplog):
+        """Socratic failures should be visible even when the caller continues."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="boom")
+
+        gen = QuestionGenerator(agent_cmd="claude")
+        parent = Question(text="Parent question?", depth=0, parent_index=None)
+        with caplog.at_level("WARNING"):
+            questions = gen.generate_socratic_questions(parent, 0)
+
+        assert questions == []
+        assert "Socratic question generation failed" in caplog.text
 
     @patch("subprocess.run")
     def test_max_depth_limit(self, mock_run):
@@ -113,6 +140,38 @@ class TestQuestionGenerator:
         assert permission_flag_for_agent_cmd("/usr/local/bin/claude") == (
             "--dangerously-skip-permissions"
         )
+
+    def test_generate_all_questions_logs_depth_two_limit(self, caplog):
+        """Depth-2 truncation should be visible in logs."""
+        gen = QuestionGenerator(agent_cmd="claude")
+
+        initial_questions = [
+            Question(text=f"Question {i}?", depth=0, parent_index=None) for i in range(10)
+        ]
+
+        def fake_generate_socratic_questions(parent_question, parent_index):
+            if parent_question.depth >= 2:
+                return []
+            return [
+                Question(
+                    text=f"{parent_question.text} follow-up {i}",
+                    depth=parent_question.depth + 1,
+                    parent_index=parent_index,
+                )
+                for i in range(3)
+            ]
+
+        with (
+            patch.object(gen, "generate_initial_questions", return_value=initial_questions),
+            patch.object(
+                gen, "generate_socratic_questions", side_effect=fake_generate_socratic_questions
+            ),
+            caplog.at_level("INFO"),
+        ):
+            questions = gen.generate_all_questions("Test Topic")
+
+        assert len(questions) == 130
+        assert "Limiting depth-2 parent questions from 90 to 47" in caplog.text
 
     @patch("subprocess.run")
     def test_claude_generate_initial_questions_keeps_dangerous_flag(self, mock_run):
@@ -203,16 +262,34 @@ class TestKnowledgeAcquirer:
         assert len(sources) == 0
 
     @patch("subprocess.run")
-    def test_answer_question_failure(self, mock_run):
+    def test_answer_question_failure(self, mock_run, caplog):
         """Test handling of failed answer attempt."""
         mock_run.return_value = MagicMock(returncode=1, stderr="Error")
 
         acq = KnowledgeAcquirer(agent_cmd="claude")
         question = Question(text="What?", depth=0, parent_index=None)
-        answer, sources = acq.answer_question(question, "Topic")
+        with caplog.at_level("WARNING"):
+            answer, sources = acq.answer_question(question, "Topic")
 
         assert answer.startswith("Unable to answer")
         assert len(sources) == 0
+        assert "Knowledge acquisition failed" in caplog.text
+
+    @patch("subprocess.run")
+    def test_answer_question_timeout_logs_warning(self, mock_run, caplog):
+        """Timeouts should be logged before returning the user-visible fallback."""
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["claude"], timeout=KnowledgeAcquirer.SUBPROCESS_TIMEOUT_SECONDS
+        )
+
+        acq = KnowledgeAcquirer(agent_cmd="claude")
+        question = Question(text="What?", depth=0, parent_index=None)
+        with caplog.at_level("WARNING"):
+            answer, sources = acq.answer_question(question, "Topic")
+
+        assert answer.startswith("Unable to answer")
+        assert len(sources) == 0
+        assert "Knowledge acquisition timed out" in caplog.text
 
 
 class TestArtifactGenerator:

--- a/tests/knowledge_builder/test_kb_modules.py
+++ b/tests/knowledge_builder/test_kb_modules.py
@@ -53,6 +53,54 @@ class TestQuestionGenerator:
         assert len(questions) == 0  # No questions beyond depth 3
         assert not mock_run.called
 
+    @patch("subprocess.run")
+    def test_copilot_generate_initial_questions_no_dangerous_flag(self, mock_run):
+        """Copilot agent must use --allow-all-tools instead of the Claude-only flag."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="\n".join([f"{i}. Question {i}?" for i in range(1, 11)]),
+        )
+
+        gen = QuestionGenerator(agent_cmd="copilot")
+        gen.generate_initial_questions("Test Topic")
+
+        assert mock_run.called
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" not in call_args
+        assert "--allow-all-tools" in call_args
+        assert "copilot" in call_args
+
+    @patch("subprocess.run")
+    def test_copilot_generate_socratic_questions_no_dangerous_flag(self, mock_run):
+        """Copilot agent must use the Copilot-compatible permission flag in Socratic mode."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="1. Follow-up 1?\n2. Follow-up 2?\n3. Follow-up 3?"
+        )
+
+        gen = QuestionGenerator(agent_cmd="copilot")
+        parent = Question(text="Parent question?", depth=0, parent_index=None)
+        gen.generate_socratic_questions(parent, 0)
+
+        assert mock_run.called
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" not in call_args
+        assert "--allow-all-tools" in call_args
+
+    @patch("subprocess.run")
+    def test_claude_generate_initial_questions_keeps_dangerous_flag(self, mock_run):
+        """Claude agent must keep its existing flag behavior."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="\n".join([f"{i}. Question {i}?" for i in range(1, 11)]),
+        )
+
+        gen = QuestionGenerator(agent_cmd="claude")
+        gen.generate_initial_questions("Test Topic")
+
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" in call_args
+        assert "--allow-all-tools" not in call_args
+
 
 class TestKnowledgeAcquirer:
     """Test knowledge acquisition via web search."""
@@ -73,6 +121,27 @@ class TestKnowledgeAcquirer:
         assert len(sources) == 2
         assert "https://example.com" in sources
         assert mock_run.called
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" in call_args
+        assert "--allow-all-tools" not in call_args
+
+    @patch("subprocess.run")
+    def test_answer_question_copilot_uses_allow_all_tools(self, mock_run):
+        """Copilot agent must use the Copilot-compatible permission flag."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ANSWER: This is the answer.\nSOURCES:\n- https://example.com\n- https://test.org",
+        )
+
+        acq = KnowledgeAcquirer(agent_cmd="copilot")
+        question = Question(text="What is this?", depth=0, parent_index=None)
+        answer, sources = acq.answer_question(question, "Topic")
+
+        assert answer == "This is the answer."
+        assert len(sources) == 2
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" not in call_args
+        assert "--allow-all-tools" in call_args
 
     @patch("subprocess.run")
     def test_answer_question_no_sources(self, mock_run):

--- a/tests/knowledge_builder/test_kb_modules.py
+++ b/tests/knowledge_builder/test_kb_modules.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from amplihack.knowledge_builder.kb_types import KnowledgeGraph, KnowledgeTriplet, Question
+from amplihack.knowledge_builder.modules._agent_flags import permission_flag_for_agent_cmd
 from amplihack.knowledge_builder.modules.artifact_generator import ArtifactGenerator
 from amplihack.knowledge_builder.modules.knowledge_acquirer import KnowledgeAcquirer
 from amplihack.knowledge_builder.modules.question_generator import QuestionGenerator
@@ -71,6 +72,22 @@ class TestQuestionGenerator:
         assert "copilot" in call_args
 
     @patch("subprocess.run")
+    def test_copilot_path_generate_initial_questions_no_dangerous_flag(self, mock_run):
+        """Full copilot paths must still use the Copilot-compatible permission flag."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="\n".join([f"{i}. Question {i}?" for i in range(1, 11)]),
+        )
+
+        gen = QuestionGenerator(agent_cmd="/usr/local/bin/copilot")
+        gen.generate_initial_questions("Test Topic")
+
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" not in call_args
+        assert "--allow-all-tools" in call_args
+        assert call_args[0] == "/usr/local/bin/copilot"
+
+    @patch("subprocess.run")
     def test_copilot_generate_socratic_questions_no_dangerous_flag(self, mock_run):
         """Copilot agent must use the Copilot-compatible permission flag in Socratic mode."""
         mock_run.return_value = MagicMock(
@@ -85,6 +102,17 @@ class TestQuestionGenerator:
         call_args = mock_run.call_args[0][0]
         assert "--dangerously-skip-permissions" not in call_args
         assert "--allow-all-tools" in call_args
+
+    def test_permission_flag_accepts_codex_and_windows_paths(self):
+        """Codex and Windows Copilot paths should use --allow-all-tools."""
+        assert permission_flag_for_agent_cmd("/opt/tools/codex") == "--allow-all-tools"
+        assert (
+            permission_flag_for_agent_cmd(r"C:\Program Files\GitHub\copilot.exe")
+            == "--allow-all-tools"
+        )
+        assert permission_flag_for_agent_cmd("/usr/local/bin/claude") == (
+            "--dangerously-skip-permissions"
+        )
 
     @patch("subprocess.run")
     def test_claude_generate_initial_questions_keeps_dangerous_flag(self, mock_run):
@@ -142,6 +170,25 @@ class TestKnowledgeAcquirer:
         call_args = mock_run.call_args[0][0]
         assert "--dangerously-skip-permissions" not in call_args
         assert "--allow-all-tools" in call_args
+
+    @patch("subprocess.run")
+    def test_answer_question_copilot_path_uses_allow_all_tools(self, mock_run):
+        """Full copilot paths must still use the Copilot-compatible permission flag."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ANSWER: This is the answer.\nSOURCES:\n- https://example.com\n- https://test.org",
+        )
+
+        acq = KnowledgeAcquirer(agent_cmd="/usr/local/bin/copilot")
+        question = Question(text="What is this?", depth=0, parent_index=None)
+        answer, sources = acq.answer_question(question, "Topic")
+
+        assert answer == "This is the answer."
+        assert len(sources) == 2
+        call_args = mock_run.call_args[0][0]
+        assert "--dangerously-skip-permissions" not in call_args
+        assert "--allow-all-tools" in call_args
+        assert call_args[0] == "/usr/local/bin/copilot"
 
     @patch("subprocess.run")
     def test_answer_question_no_sources(self, mock_run):

--- a/tests/recipes/test_default_workflow_resumable_timeouts.py
+++ b/tests/recipes/test_default_workflow_resumable_timeouts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -112,3 +113,56 @@ def test_checkpoint_commands_are_shell_syntax_valid(
     )
 
     assert result.returncode == 0, result.stderr
+
+
+_LIST_LITERAL_IN_CONDITION = re.compile(r"\bnot\s+in\s*\[|\bin\s*\[")
+
+
+@pytest.mark.parametrize(
+    "step_id,condition",
+    [(step["id"], step["condition"]) for step in _load_recipe()["steps"] if step.get("condition")],
+)
+def test_step_conditions_do_not_use_list_literals(step_id: str, condition: str):
+    """List-literal conditions are incompatible with the Rust recipe runner parser."""
+    assert not _LIST_LITERAL_IN_CONDITION.search(condition), (
+        f"Step '{step_id}' condition uses list-literal 'in [...]' syntax "
+        f"which is incompatible with the Rust recipe runner: {condition!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "step_id,checkpoint_value,expected",
+    [
+        ("step-07-write-tests", "", True),
+        ("step-07-write-tests", "checkpoint-after-implementation", False),
+        ("step-07-write-tests", "checkpoint-after-review-feedback", False),
+        ("step-08-implement", "", True),
+        ("step-08-implement", "checkpoint-after-implementation", False),
+        ("step-08-implement", "checkpoint-after-review-feedback", False),
+        ("checkpoint-after-implementation", "", True),
+        ("checkpoint-after-implementation", "checkpoint-after-implementation", False),
+        ("checkpoint-after-implementation", "checkpoint-after-review-feedback", False),
+    ],
+)
+def test_pre_checkpoint_conditions_evaluate_correctly(
+    steps: dict[str, dict],
+    step_id: str,
+    checkpoint_value: str,
+    expected: bool,
+):
+    """The rewritten checkpoint resume conditions must preserve existing behavior."""
+    from amplihack.recipes.models import Step, StepType
+
+    raw = steps[step_id]
+    step = Step(
+        id=raw["id"],
+        step_type=StepType.AGENT if raw.get("agent") else StepType.BASH,
+        condition=raw.get("condition"),
+        prompt=raw.get("prompt", ""),
+        output=raw.get("output"),
+    )
+    result = step.evaluate_condition({"resume_checkpoint": checkpoint_value})
+    assert result is expected, (
+        f"Step '{step_id}' with resume_checkpoint={checkpoint_value!r}: "
+        f"expected {expected}, got {result}"
+    )

--- a/tests/recipes/test_rust_runner.py
+++ b/tests/recipes/test_rust_runner.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from amplihack.recipes.models import StepStatus
+from amplihack.recipes.models import RecipeResult, StepStatus
 from amplihack.recipes.rust_runner import (
     RustRunnerNotFoundError,
     _redact_command_for_log,
@@ -390,6 +390,157 @@ class TestRunRecipeViaRust:
         """PR-M5: OSError during subprocess.run propagates cleanly."""
         with pytest.raises(OSError, match="No such file or directory"):
             run_recipe_via_rust("test-recipe")
+
+
+# ============================================================================
+# Smart-orchestrator teardown hardening
+# ============================================================================
+
+
+class TestSmartOrchestratorTeardown:
+    """Teardown is finalized in Python so late bash failures stay non-fatal."""
+
+    def test_postprocess_updates_session_complete_status(self):
+        import amplihack.recipes.rust_runner as mod
+
+        result = RecipeResult(
+            recipe_name="smart-orchestrator",
+            success=True,
+            step_results=[],
+            context={"session_info": '{"session_id":"abc123","tree_id":"tree123","status":"ok"}'},
+        )
+
+        with (
+            patch(
+                "amplihack.recipes.rust_runner._best_effort_clear_smart_orchestrator_workflow_active",
+                return_value="workflow-active semaphore cleared",
+            ) as mock_clear,
+            patch(
+                "amplihack.recipes.rust_runner._best_effort_complete_smart_orchestrator_session",
+                return_value="Session abc123 completed in tree tree123",
+            ) as mock_complete,
+        ):
+            mod._postprocess_smart_orchestrator_result(result, dry_run=False)
+
+        mock_clear.assert_called_once_with()
+        mock_complete.assert_called_once_with(result.context["session_info"])
+        assert (
+            result.context["session_complete_status"]
+            == "workflow-active semaphore cleared; Session abc123 completed in tree tree123"
+        )
+
+    def test_postprocess_skips_side_effects_in_dry_run(self):
+        import amplihack.recipes.rust_runner as mod
+
+        result = RecipeResult(
+            recipe_name="smart-orchestrator",
+            success=True,
+            step_results=[],
+            context={"session_info": '{"session_id":"abc123","tree_id":"tree123","status":"ok"}'},
+        )
+
+        with (
+            patch(
+                "amplihack.recipes.rust_runner._best_effort_clear_smart_orchestrator_workflow_active"
+            ) as mock_clear,
+            patch(
+                "amplihack.recipes.rust_runner._best_effort_complete_smart_orchestrator_session"
+            ) as mock_complete,
+        ):
+            mod._postprocess_smart_orchestrator_result(result, dry_run=True)
+
+        mock_clear.assert_not_called()
+        mock_complete.assert_not_called()
+        assert "session_complete_status" not in result.context
+
+    @patch(
+        "amplihack.recipes.rust_runner._find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
+    )
+    @patch(
+        "amplihack.recipes.rust_runner._resolve_recipe_target",
+        return_value="/repo/amplifier-bundle/recipes/smart-orchestrator.yaml",
+    )
+    @patch("amplihack.recipes.rust_runner._execute_rust_command")
+    @patch("amplihack.recipes.rust_runner._postprocess_smart_orchestrator_result")
+    def test_run_recipe_via_rust_postprocesses_smart_orchestrator(
+        self,
+        mock_postprocess,
+        mock_execute,
+        mock_resolve_target,
+        mock_find_binary,
+    ):
+        expected = RecipeResult(
+            recipe_name="smart-orchestrator",
+            success=True,
+            step_results=[],
+            context={"session_info": '{"session_id":"abc123","tree_id":"tree123","status":"ok"}'},
+        )
+        mock_execute.return_value = expected
+
+        result = run_recipe_via_rust("smart-orchestrator")
+
+        assert result is expected
+        mock_postprocess.assert_called_once_with(expected, dry_run=False)
+        mock_execute.assert_called_once()
+        mock_resolve_target.assert_called_once()
+        mock_find_binary.assert_called_once()
+
+    @patch(
+        "amplihack.recipes.rust_runner._find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
+    )
+    @patch(
+        "amplihack.recipes.rust_runner._resolve_recipe_target",
+        return_value="/repo/amplifier-bundle/recipes/default-workflow.yaml",
+    )
+    @patch("amplihack.recipes.rust_runner._execute_rust_command")
+    @patch("amplihack.recipes.rust_runner._postprocess_smart_orchestrator_result")
+    def test_run_recipe_via_rust_skips_postprocess_for_other_recipes(
+        self,
+        mock_postprocess,
+        mock_execute,
+        mock_resolve_target,
+        mock_find_binary,
+    ):
+        mock_execute.return_value = RecipeResult(
+            recipe_name="default-workflow",
+            success=True,
+            step_results=[],
+            context={},
+        )
+
+        run_recipe_via_rust("default-workflow")
+
+        mock_postprocess.assert_not_called()
+        mock_execute.assert_called_once()
+        mock_resolve_target.assert_called_once()
+        mock_find_binary.assert_called_once()
+
+    @patch(
+        "amplihack.recipes.rust_runner._find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
+    )
+    @patch(
+        "amplihack.recipes.rust_runner._resolve_recipe_target",
+        return_value="/repo/amplifier-bundle/recipes/smart-orchestrator.yaml",
+    )
+    @patch("amplihack.recipes.rust_runner._execute_rust_command", side_effect=RuntimeError("boom"))
+    @patch(
+        "amplihack.recipes.rust_runner._best_effort_clear_smart_orchestrator_workflow_active",
+        return_value="workflow-active semaphore cleared",
+    )
+    def test_run_recipe_via_rust_clears_workflow_active_when_smart_orchestrator_fails(
+        self,
+        mock_clear,
+        mock_execute,
+        mock_resolve_target,
+        mock_find_binary,
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            run_recipe_via_rust("smart-orchestrator")
+
+        mock_clear.assert_called_once_with()
+        mock_execute.assert_called_once()
+        mock_resolve_target.assert_called_once()
+        mock_find_binary.assert_called_once()
 
 
 # ============================================================================

--- a/tests/recipes/test_rust_runner_binary.py
+++ b/tests/recipes/test_rust_runner_binary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from unittest.mock import patch
 
@@ -167,8 +168,10 @@ class TestRunnerVersionChecks:
         "amplihack.recipes.rust_runner.find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
     )
     @patch("amplihack.recipes.rust_runner_binary.get_runner_version", return_value="0.0.9")
+    @patch("amplihack.recipes.rust_runner_binary.ensure_rust_recipe_runner", return_value=False)
     def test_run_recipe_raises_when_runner_version_is_too_old(
         self,
+        _mock_ensure,
         _mock_get_version,
         _mock_find,
     ):
@@ -179,8 +182,10 @@ class TestRunnerVersionChecks:
         "amplihack.recipes.rust_runner.find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
     )
     @patch("amplihack.recipes.rust_runner_binary.get_runner_version", return_value=None)
+    @patch("amplihack.recipes.rust_runner_binary.ensure_rust_recipe_runner", return_value=False)
     def test_run_recipe_raises_when_runner_version_is_unknown(
         self,
+        _mock_ensure,
         _mock_get_version,
         _mock_find,
     ):
@@ -191,10 +196,75 @@ class TestRunnerVersionChecks:
         "amplihack.recipes.rust_runner.find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
     )
     @patch("amplihack.recipes.rust_runner_binary.get_runner_version", return_value="dev-build")
+    @patch("amplihack.recipes.rust_runner_binary.ensure_rust_recipe_runner", return_value=False)
     def test_run_recipe_raises_when_runner_version_is_unparseable(
         self,
+        _mock_ensure,
         _mock_get_version,
         _mock_find,
     ):
         with pytest.raises(RustRunnerVersionError, match="unparseable version 'dev-build'"):
             run_recipe_via_rust("test-recipe")
+
+
+_VALID_RUST_OUTPUT = json.dumps(
+    {
+        "recipe_name": "test-recipe",
+        "success": True,
+        "step_results": [
+            {"step_id": "s1", "status": "Completed", "output": "ok", "error": ""},
+        ],
+        "context": {},
+    }
+)
+
+
+class TestAutoUpdate:
+    """Tests for the auto-update path triggered on version mismatch in _find_rust_binary()."""
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
+    )
+    @patch(
+        "amplihack.recipes.rust_runner_binary.get_runner_version",
+        side_effect=["0.0.9", "0.3.4"],
+    )
+    @patch("amplihack.recipes.rust_runner_binary.ensure_rust_recipe_runner", return_value=True)
+    @patch("subprocess.run")
+    def test_auto_update_success_proceeds_to_execution(
+        self, mock_run, _mock_ensure, _mock_version, _mock_find
+    ):
+        """Outdated binary + successful auto-update still executes the recipe."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_VALID_RUST_OUTPUT, stderr=""
+        )
+
+        result = run_recipe_via_rust("test-recipe")
+
+        assert result.success is True
+        _mock_ensure.assert_called_once()
+
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
+    )
+    @patch("amplihack.recipes.rust_runner_binary.get_runner_version", return_value="0.0.9")
+    @patch("amplihack.recipes.rust_runner_binary.ensure_rust_recipe_runner", return_value=False)
+    def test_auto_update_failure_raises_version_error(
+        self, _mock_ensure, _mock_version, _mock_find
+    ):
+        """Outdated binary + failed update still raises the version error."""
+        with pytest.raises(RustRunnerVersionError, match="0.0.9"):
+            run_recipe_via_rust("test-recipe")
+
+    @patch.dict("os.environ", {"RECIPE_RUNNER_AUTO_UPDATE": "0"})
+    @patch(
+        "amplihack.recipes.rust_runner.find_rust_binary", return_value="/usr/bin/recipe-runner-rs"
+    )
+    @patch("amplihack.recipes.rust_runner_binary.get_runner_version", return_value="0.0.9")
+    @patch("amplihack.recipes.rust_runner_binary.ensure_rust_recipe_runner", return_value=True)
+    def test_auto_update_disabled_raises_immediately(self, mock_ensure, _mock_version, _mock_find):
+        """RECIPE_RUNNER_AUTO_UPDATE=0 skips auto-update and raises immediately."""
+        with pytest.raises(RustRunnerVersionError, match="0.0.9"):
+            run_recipe_via_rust("test-recipe")
+
+        mock_ensure.assert_not_called()

--- a/tests/recipes/test_smart_orchestrator_bundle_sync.py
+++ b/tests/recipes/test_smart_orchestrator_bundle_sync.py
@@ -1,0 +1,26 @@
+"""Keep the packaged smart-orchestrator bundle in lockstep with repo source."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_RECIPE = REPO_ROOT / "amplifier-bundle" / "recipes" / "smart-orchestrator.yaml"
+PACKAGED_RECIPE = (
+    REPO_ROOT / "src" / "amplihack" / "amplifier-bundle" / "recipes" / "smart-orchestrator.yaml"
+)
+
+
+def test_packaged_smart_orchestrator_matches_repo_source():
+    assert PACKAGED_RECIPE.read_text(encoding="utf-8") == SOURCE_RECIPE.read_text(
+        encoding="utf-8"
+    ), "Packaged smart-orchestrator.yaml drifted from amplifier-bundle source"
+
+
+def test_complete_session_step_is_nonfatal():
+    content = SOURCE_RECIPE.read_text(encoding="utf-8")
+    assert re.search(
+        r'- id: "complete-session"\n\s+fatal: false\n\s+type: "bash"',
+        content,
+    ), "complete-session must stay non-fatal so wrapper teardown owns finalization"


### PR DESCRIPTION
## Summary

Fix smart-orchestrator teardown brittleness so a late `complete-session` failure no longer flips a successful run red, keep the bundled workflow/parser surfaces in sync, refresh the affected Atlas docs, and harden Knowledge Builder agent invocation for Copilot/Codex full-path binaries.

### Changes
- `src/amplihack/recipes/rust_runner.py`: Python-side smart-orchestrator teardown hardening and recipe-runner auto-update handling
- `amplifier-bundle/recipes/smart-orchestrator.yaml`: `fatal: false` on `complete-session`
- `amplifier-bundle/recipes/default-workflow.yaml`: parser-safe condition rewrite for Rust runner compatibility
- `src/amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml`: packaged bundle sync
- `src/amplihack/knowledge_builder/modules/*`: Copilot/Codex path-safe permission flag handling plus timeout/failure visibility improvements
- `docs/atlas/ast-lsp-bindings/*`: atlas refresh for the `rust_runner.py` shape change
- `tests/recipes/*`, `tests/knowledge_builder/test_kb_modules.py`, `tests/gadugi/merge-ready/*`: regression and outside-in coverage
- `.claude/skills/merge-ready/*`: corrected gadugi CLI usage in merge-ready docs/template

## Merge readiness

### QA-team evidence
- Scenario files: `tests/gadugi/merge-ready/smart-orchestrator-teardown-and-atlas-refresh.yaml`
- Validation command: `gadugi-test validate -f tests/gadugi/merge-ready/smart-orchestrator-teardown-and-atlas-refresh.yaml`
- Validation result: passed
- Run command: `gadugi-test run -d tests/gadugi/merge-ready -s "smart-orchestrator-teardown-and-atlas-refresh" --verbose`
- Run target: local env (`/tmp/pr4203-audit` worktree)
- Run result: passed
- Evidence location: `outputs/sessions/session_66e9012f-7ebf-4911-af88-49cf6341d8bb_2026-04-03T04-22-44-120Z.json` (latest passing rerun after the KB reliability fixes); prior passing run: `outputs/sessions/session_b541e8c5-3d4a-419c-8e31-79795ff33afd_2026-04-03T04-21-33-559Z.json`

### Documentation
- User-facing docs impact: yes
- Updated docs: `.claude/skills/merge-ready/SKILL.md`, `.claude/skills/merge-ready/pr-description-template.md`, `docs/atlas/ast-lsp-bindings/index.md`, `docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd`, `docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot`
- PR description links added: repo paths listed in this section
- Rationale if not applicable: n/a

### Quality-audit
- Cycle 1 summary: scoped audit against mirrored PR files completed SEEK + 3 validators; validator quorum reduced the findings to low-severity `rust_runner.py` helper observations only, with no medium/high correctness or security findings surviving thresholding, so `fix` and `verify-fixes` were skipped. Logs: `/tmp/amplihack-recipe-quality_audit_cycle-3407356.log`, `/tmp/amplihack-recipe-quality-audit-cycle-3407358.log`
- Cycle 2 summary: deeper pass re-checked dead-code, hardcoded-limit, and doc-staleness candidates; recursive cycle continued without entering `fix`, so no medium/high merge blocker survived merge-validation. Logs: `/tmp/amplihack-recipe-quality_audit_cycle-3412557.log`, `/tmp/amplihack-recipe-quality-audit-cycle-3412559.log`
- Cycle 3 summary: final pass completed through `summary`, `self-improvement`, and `final-report`; recursion stopped, no `fix` step was needed, and the recipe completed successfully. Logs: `/tmp/amplihack-recipe-quality_audit_cycle-3414765.log`, `/tmp/amplihack-recipe-quality-audit-cycle-3414767.log`
- Additional cycles: none
- Final clean cycle: 3
- Fixes followed default-workflow: yes — follow-up fixes landed as `92bbe60dc` (`fix(#4118): handle copilot binary paths in knowledge builder`) and `952cdd810` (`fix(#4169): tighten KB subprocess reliability`)
- Convergence summary: `quality-audit-cycle` completed with `RecipeResult(quality-audit-cycle: SUCCESS, 13 steps)` after 3 cycles. Across the scoped PR audit, no critical/high findings and no medium correctness/security findings survived validator quorum; only non-blocking low-severity observations remained.

### CI
- Checks command: `gh pr checks 4203`
- Result: all green
- Skipped checks:
  - `Bot Detection/activation`, `Bot Detection/agent`, `Bot Detection/conclusion`, `Bot Detection/safe_outputs` — conditional bot-only branches not applicable to this PR
  - `Code Atlas CI/Atlas Staleness Gate` — conditional gate path not applicable on this PR event
  - `Code Atlas CI/Scheduled Full Atlas Rebuild` — scheduled workflow, not applicable to pull requests
  - `Invisible Character Scan/scan` — conditional workflow path skipped on this event
- Flaky reruns performed: none
- Real failures fixed: the branch rerun initially exposed the Knowledge Builder full-path Copilot flag bug; fixed in `92bbe60dc`, then tightened timeout/failure visibility and atlas framing in `952cdd810`

### Scope
- Changed files reviewed: `git diff --name-only origin/main...HEAD`
  - `.claude/skills/merge-ready/SKILL.md`
  - `.claude/skills/merge-ready/pr-description-template.md`
  - `amplifier-bundle/recipes/default-workflow.yaml`
  - `amplifier-bundle/recipes/smart-orchestrator.yaml`
  - `docs/atlas/ast-lsp-bindings/ast-lsp-bindings.dot`
  - `docs/atlas/ast-lsp-bindings/ast-lsp-bindings.mmd`
  - `docs/atlas/ast-lsp-bindings/index.md`
  - `src/amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml`
  - `src/amplihack/knowledge_builder/modules/_agent_flags.py`
  - `src/amplihack/knowledge_builder/modules/knowledge_acquirer.py`
  - `src/amplihack/knowledge_builder/modules/question_generator.py`
  - `src/amplihack/recipes/rust_runner.py`
  - `tests/gadugi/merge-ready/smart-orchestrator-teardown-and-atlas-refresh.yaml`
  - `tests/knowledge_builder/test_kb_modules.py`
  - `tests/recipes/test_default_workflow_resumable_timeouts.py`
  - `tests/recipes/test_rust_runner.py`
  - `tests/recipes/test_rust_runner_binary.py`
  - `tests/recipes/test_smart_orchestrator_bundle_sync.py`
- Unrelated changes: none
- Files intentionally excluded: `CLAUDE.md`

### Verdict
- Merge-ready: yes
- Remaining blockers: none
