### PR TITLE
fix: guard copytree_manifest against self-copy when source==dest

### DIFF
--- a/src/amplihack/cli.py
+++ b/src/amplihack/cli.py
@@ -877,6 +877,12 @@ def _sync_home_runtime_directory(source_dir: Path, target_dir: Path, description
         print(f"❌ Required runtime directory missing: {source_dir}")
         sys.exit(1)
 
+    # Guard: skip when source and destination resolve to the same path.
+    # This happens when AMPLIHACK_HOME=~/.amplihack and the package is
+    # already installed there (amplihack_src == home_root/src/amplihack).
+    if os.path.realpath(source_dir) == os.path.realpath(target_dir):
+        return
+
     target_dir.parent.mkdir(parents=True, exist_ok=True)
     try:
         shutil.copytree(source_dir, target_dir, dirs_exist_ok=True)

--- a/src/amplihack/install.py
+++ b/src/amplihack/install.py
@@ -73,6 +73,15 @@ def copytree_manifest(
             print(f"     {candidate}")
         return []
 
+    # Guard: skip copy when source and destination resolve to the same path.
+    # This happens when AMPLIHACK_HOME=~/.amplihack and the grandparent search
+    # finds ~/.amplihack/.claude which IS the staging_dir, causing SameFileError.
+    if os.path.realpath(base) == os.path.realpath(dst):
+        return list(
+            d for d in (manifest.dirs_to_stage if manifest else ESSENTIAL_DIRS)
+            if os.path.isdir(os.path.join(base, d))
+        )
+
     copied = []
 
     # Use manifest dirs if provided, otherwise use ESSENTIAL_DIRS


### PR DESCRIPTION
## Problem

When `AMPLIHACK_HOME=~/.amplihack` (the default deployment layout), **two** staging functions try to copy directories onto themselves, causing `SameFileError`:

### Bug 1: `copytree_manifest()` in `install.py`
- `amplihack_src` = `~/.amplihack/src/amplihack`
- Grandparent search finds `~/.amplihack/.claude` as source
- `staging_dir` = `~/.amplihack/.claude`
- **Source == destination** → `SameFileError`

### Bug 2: `_sync_home_runtime_directory()` in `cli.py`
- Stages `amplihack_src` to `home_root/src/amplihack`
- When both resolve to `~/.amplihack/src/amplihack`: **Source == destination** → `SameFileError`

This **blocks ALL recipe runner agent steps** because every nested `amplihack copilot` invocation hits this on startup. The error manifests as:
```
amplihack copilot failed (exit 1): .../.amplihack/src/amplihack/worktree/__pycache__/git_utils.cpython-312.pyc 'are the same file'
```

## Fix

Add `realpath` equality checks to both functions. When source and destination resolve to the same path, short-circuit with a no-op instead of attempting the copy.

## Testing

Verified locally — recipe runner agent steps now succeed through step-02 and beyond where they previously failed immediately with SameFileError.