### PR TITLE
Harden deployment truthfulness and worktree execution

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -623,34 +623,34 @@ steps:
         exit 1
       fi
       cd "{{repo_path}}"
+      COMMON_GIT_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo '')
+      if [ -z "$COMMON_GIT_DIR" ]; then
+        echo "ERROR: Unable to resolve git common dir for worktree setup" >&2
+        exit 1
+      fi
+      COMMON_GIT_DIR=$(cd "$COMMON_GIT_DIR" && pwd)
+      WORKTREE_BASE_ROOT=$(dirname "$COMMON_GIT_DIR")
 
       echo "=== Step 4: Creating Worktree and Branch ===" >&2
       echo "" >&2
 
-      # Fetch latest refs (guarded — skip if no remote configured)
+      # Create new worktrees from the caller's current checkout, not origin/HEAD.
+      # This preserves detached integration baselines and other non-default entry points.
       HAS_REMOTE=false
-      BASE_BRANCH="main"
       BASE_WORKTREE_REF="HEAD"
       if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
         echo "ERROR: No commits in repository — create an initial commit before running the workflow." >&2
         exit 1
       fi
+      CURRENT_HEAD=$(git rev-parse --short HEAD)
+      CURRENT_BRANCH=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo '')
       if git remote get-url origin >/dev/null 2>&1; then
         HAS_REMOTE=true
-        ORIGIN_HEAD_REF=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo '')
-        if [ -n "$ORIGIN_HEAD_REF" ]; then
-          BASE_BRANCH="${ORIGIN_HEAD_REF##*/}"
-          BASE_WORKTREE_REF="origin/$BASE_BRANCH"
-          git fetch origin "$BASE_BRANCH" >&2
-        elif git show-ref --verify --quiet "refs/remotes/origin/main"; then
-          BASE_BRANCH="main"
-          BASE_WORKTREE_REF="origin/main"
-          git fetch origin main >&2
-        else
-          echo "INFO: origin/HEAD not configured and origin/main missing — using local HEAD as worktree base" >&2
-        fi
+      fi
+      if [ -n "$CURRENT_BRANCH" ]; then
+        echo "INFO: Using current branch '${CURRENT_BRANCH}' at ${CURRENT_HEAD} as worktree base" >&2
       else
-        echo "INFO: No remote configured — using local HEAD as worktree base" >&2
+        echo "INFO: Detached HEAD at ${CURRENT_HEAD} — using current commit as worktree base" >&2
       fi
 
       # NOTE: This slug pipeline is duplicated in consensus-workflow.yaml step3-setup-worktree
@@ -696,7 +696,7 @@ steps:
           BRANCH_NAME="feat/task-unnamed-$(date +%s)"
         fi
       fi
-      WORKTREE_PATH="{{repo_path}}/worktrees/${BRANCH_NAME}"
+      WORKTREE_PATH="${WORKTREE_BASE_ROOT}/worktrees/${BRANCH_NAME}"
 
       echo "Branch: ${BRANCH_NAME}" >&2
       echo "Worktree: ${WORKTREE_PATH}" >&2

--- a/deploy/azure_hive/agent_entrypoint.py
+++ b/deploy/azure_hive/agent_entrypoint.py
@@ -382,9 +382,12 @@ def main() -> None:
         if result:
             hive_store, hive_bus, shard_transport = result
 
-    if topology == "distributed" and hive_store is None:
+    distributed_runtime_required = topology == "distributed" or (
+        eh_connection_string and distributed_retrieval_enabled
+    )
+    if distributed_runtime_required and hive_store is None:
         logger.error(
-            "Agent %s requested distributed topology but distributed hive initialization failed",
+            "Agent %s requires distributed hive initialization but it failed",
             agent_name,
         )
         sys.exit(1)

--- a/deploy/azure_hive/cleanup_volumes.sh
+++ b/deploy/azure_hive/cleanup_volumes.sh
@@ -30,6 +30,7 @@ case "${1:-}" in
 esac
 
 log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+warn() { echo "WARNING: $*" >&2; }
 die()  { echo "ERROR: $*" >&2; exit 1; }
 
 command -v az >/dev/null 2>&1 || die "Azure CLI (az) is required."
@@ -39,7 +40,7 @@ if [[ -z "${STORAGE_ACCOUNT}" ]]; then
   STORAGE_ACCOUNT=$(az storage account list \
     --resource-group "${RESOURCE_GROUP}" \
     --query "[?starts_with(name, 'hivesa')].name | [0]" \
-    -o tsv 2>/dev/null)
+    -o tsv)
   [[ -n "${STORAGE_ACCOUNT}" ]] || die "Could not detect storage account in ${RESOURCE_GROUP}. Set HIVE_STORAGE_ACCOUNT."
   log "Detected storage account: ${STORAGE_ACCOUNT}"
 fi
@@ -47,7 +48,7 @@ fi
 ACCOUNT_KEY=$(az storage account keys list \
   --account-name "${STORAGE_ACCOUNT}" \
   --resource-group "${RESOURCE_GROUP}" \
-  --query "[0].value" -o tsv 2>/dev/null)
+  --query "[0].value" -o tsv)
 
 [[ -n "${ACCOUNT_KEY}" ]] || die "Could not retrieve storage account key for ${STORAGE_ACCOUNT}."
 
@@ -92,47 +93,75 @@ fi
 log "Enumerating files in share '${FILE_SHARE}'..."
 FILE_COUNT=0
 DIR_COUNT=0
+DELETE_FAILURES=0
+
+delete_share_path() {
+  local kind="$1"
+  local target="$2"
+  local delete_output=""
+
+  if [[ "${MODE}" == "dry-run" ]]; then
+    if [[ "${kind}" == "file" ]]; then
+      log "DRY-RUN: would delete: ${target}"
+    else
+      log "DRY-RUN: would delete directory: ${target}"
+    fi
+    return 0
+  fi
+
+  if [[ "${kind}" == "file" ]]; then
+    if ! delete_output="$(az storage file delete \
+      --path "${target}" \
+      --share-name "${FILE_SHARE}" \
+      --account-name "${STORAGE_ACCOUNT}" \
+      --account-key "${ACCOUNT_KEY}" \
+      --output none 2>&1)"; then
+      warn "Failed to delete file '${target}': ${delete_output}"
+      return 1
+    fi
+    return 0
+  fi
+
+  if ! delete_output="$(az storage directory delete \
+    --name "${target}" \
+    --share-name "${FILE_SHARE}" \
+    --account-name "${STORAGE_ACCOUNT}" \
+    --account-key "${ACCOUNT_KEY}" \
+    --output none 2>&1)"; then
+    warn "Failed to delete directory '${target}': ${delete_output}"
+    return 1
+  fi
+}
 
 while IFS= read -r item; do
   [[ -z "${item}" ]] && continue
-  if [[ "${MODE}" == "dry-run" ]]; then
-    log "DRY-RUN: would delete: ${item}"
-  else
-    az storage file delete \
-      --path "${item}" \
-      --share-name "${FILE_SHARE}" \
-      --account-name "${STORAGE_ACCOUNT}" \
-      --account-key "${ACCOUNT_KEY}" \
-      --output none 2>/dev/null || true
+  if ! delete_share_path "file" "${item}"; then
+    DELETE_FAILURES=$((DELETE_FAILURES + 1))
   fi
-  (( FILE_COUNT++ )) || true
+  FILE_COUNT=$((FILE_COUNT + 1))
 done < <(az storage file list \
   --share-name "${FILE_SHARE}" \
   --account-name "${STORAGE_ACCOUNT}" \
   --account-key "${ACCOUNT_KEY}" \
-  --query "[?type=='file'].name" -o tsv 2>/dev/null)
+  --query "[?type=='file'].name" -o tsv)
 
 while IFS= read -r dir; do
   [[ -z "${dir}" ]] && continue
-  if [[ "${MODE}" == "dry-run" ]]; then
-    log "DRY-RUN: would delete directory: ${dir}"
-  else
-    az storage directory delete \
-      --name "${dir}" \
-      --share-name "${FILE_SHARE}" \
-      --account-name "${STORAGE_ACCOUNT}" \
-      --account-key "${ACCOUNT_KEY}" \
-      --output none 2>/dev/null || true
+  if ! delete_share_path "dir" "${dir}"; then
+    DELETE_FAILURES=$((DELETE_FAILURES + 1))
   fi
-  (( DIR_COUNT++ )) || true
+  DIR_COUNT=$((DIR_COUNT + 1))
 done < <(az storage file list \
   --share-name "${FILE_SHARE}" \
   --account-name "${STORAGE_ACCOUNT}" \
   --account-key "${ACCOUNT_KEY}" \
-  --query "[?type=='dir'].name" -o tsv 2>/dev/null)
+  --query "[?type=='dir'].name" -o tsv)
 
 if [[ "${MODE}" == "dry-run" ]]; then
   log "DRY-RUN complete — ${FILE_COUNT} files and ${DIR_COUNT} directories would be removed."
 else
+  if [[ "${DELETE_FAILURES}" -gt 0 ]]; then
+    die "Cleanup incomplete — ${DELETE_FAILURES} delete operation(s) failed."
+  fi
   log "Cleanup complete — removed ${FILE_COUNT} files and ${DIR_COUNT} directories from '${FILE_SHARE}'."
 fi

--- a/deploy/azure_hive/deploy.sh
+++ b/deploy/azure_hive/deploy.sh
@@ -88,11 +88,14 @@ esac
 # ============================================================
 
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
+warn() { echo "WARNING: $*" >&2; }
 die() { echo "ERROR: $*" >&2; exit 1; }
 
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed."
 }
+
+require_cmd az
 
 # ============================================================
 # Cleanup
@@ -110,11 +113,14 @@ fi
 # ============================================================
 
 if [[ "$MODE" == "status" ]]; then
+  if ! az group show --name "${RESOURCE_GROUP}" --output none >/dev/null 2>&1; then
+    die "Resource group ${RESOURCE_GROUP} not found."
+  fi
   log "Deployment status for hive '${HIVE_NAME}' in ${RESOURCE_GROUP}:"
   az containerapp list \
     --resource-group "${RESOURCE_GROUP}" \
     --query "[?starts_with(name, '${HIVE_NAME}')].{name:name,status:properties.runningStatus,replicas:properties.template.scale.minReplicas}" \
-    --output table 2>/dev/null || echo "Resource group not found or no Container Apps deployed."
+    --output table
   exit 0
 fi
 
@@ -175,7 +181,6 @@ fi
 # Prerequisites
 # ============================================================
 
-require_cmd az
 [[ -n "${ANTHROPIC_API_KEY:-}" ]] || die "ANTHROPIC_API_KEY env var is required."
 
 # ============================================================
@@ -201,17 +206,41 @@ else
 fi
 
 log "Ensuring ACR ${ACR_NAME}..."
-az acr create \
-  --name "${ACR_NAME}" \
+ACR_LOGIN_SERVER="$(az acr list \
   --resource-group "${RESOURCE_GROUP}" \
-  --sku Basic \
-  --admin-enabled true \
-  --output none 2>/dev/null || true
+  --query "[?name=='${ACR_NAME}'].loginServer | [0]" \
+  -o tsv)"
 
-ACR_LOGIN_SERVER=$(az acr show \
-  --name "${ACR_NAME}" \
-  --resource-group "${RESOURCE_GROUP}" \
-  --query loginServer -o tsv)
+if [[ -z "${ACR_LOGIN_SERVER}" || "${ACR_LOGIN_SERVER}" == "null" ]]; then
+  ACR_NAME_STATUS="$(az acr check-name --name "${ACR_NAME}" --output json)"
+  ACR_NAME_AVAILABLE="$(
+    printf '%s' "${ACR_NAME_STATUS}" | python3 -c \
+      'import json,sys; data=json.load(sys.stdin); print(str(data.get("nameAvailable", False)).lower())'
+  )"
+  if [[ "${ACR_NAME_AVAILABLE}" != "true" ]]; then
+    ACR_NAME_REASON="$(
+      printf '%s' "${ACR_NAME_STATUS}" | python3 -c \
+        'import json,sys; data=json.load(sys.stdin); print(data.get("message") or data.get("reason") or "unknown reason")'
+    )"
+    die "ACR name '${ACR_NAME}' is unavailable: ${ACR_NAME_REASON}"
+  fi
+
+  if ! ACR_CREATE_OUTPUT="$(az acr create \
+    --name "${ACR_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --sku Basic \
+    --admin-enabled true \
+    --output none 2>&1)"; then
+    die "Failed to create ACR ${ACR_NAME}: ${ACR_CREATE_OUTPUT}"
+  fi
+
+  ACR_LOGIN_SERVER="$(az acr show \
+    --name "${ACR_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --query loginServer -o tsv)"
+else
+  log "Using existing ACR ${ACR_NAME} (${ACR_LOGIN_SERVER})"
+fi
 
 IMAGE="${ACR_LOGIN_SERVER}/${HIVE_NAME}:${IMAGE_TAG}"
 
@@ -256,7 +285,7 @@ log "Checking for existing Container Apps to tear down..."
 EXISTING_APPS=$(az containerapp list \
   --resource-group "${RESOURCE_GROUP}" \
   --query "[?starts_with(name, '${HIVE_NAME}')].name" \
-  -o tsv 2>/dev/null || true)
+  -o tsv)
 
 if [[ -n "${EXISTING_APPS}" ]]; then
   log "Tearing down existing Container Apps (clean deploy)..."
@@ -265,7 +294,7 @@ if [[ -n "${EXISTING_APPS}" ]]; then
     az containerapp delete \
       --name "${APP_NAME}" \
       --resource-group "${RESOURCE_GROUP}" \
-      --yes --no-wait 2>/dev/null || true
+      --yes --no-wait
   done
   # Wait for all deletions to complete
   log "Waiting for Container App deletions to complete..."
@@ -291,7 +320,7 @@ fi
 EH_NAMESPACE_NAME="$(az eventhubs namespace list \
   --resource-group "${RESOURCE_GROUP}" \
   --query "[?starts_with(name, 'hive-eh-')].name | [0]" \
-  -o tsv 2>/dev/null || true)"
+  -o tsv)"
 
 RESET_EVENT_HUBS=false
 RESET_REASON=""
@@ -301,12 +330,11 @@ if [[ "${FORCE_RECREATE_EVENT_HUBS,,}" == "true" && -n "${EH_NAMESPACE_NAME}" ]]
   RESET_REASON="forced by HIVE_FORCE_RECREATE_EVENT_HUBS=true"
 elif [[ -n "${EH_NAMESPACE_NAME}" ]]; then
   for HUB_NAME in "hive-events-${HIVE_NAME}" "hive-shards-${HIVE_NAME}" "eval-responses-${HIVE_NAME}"; do
-    CURRENT_PARTITIONS="$(az eventhubs eventhub show \
+    CURRENT_PARTITIONS="$(az eventhubs eventhub list \
       --resource-group "${RESOURCE_GROUP}" \
       --namespace-name "${EH_NAMESPACE_NAME}" \
-      --name "${HUB_NAME}" \
-      --query partitionCount \
-      -o tsv 2>/dev/null || true)"
+      --query "[?name=='${HUB_NAME}'].partitionCount | [0]" \
+      -o tsv)"
     if [[ -n "${CURRENT_PARTITIONS}" && "${CURRENT_PARTITIONS}" != "null" && "${CURRENT_PARTITIONS}" -lt "${DESIRED_EH_PARTITIONS}" ]]; then
       RESET_EVENT_HUBS=true
       RESET_REASON="hub ${HUB_NAME} has ${CURRENT_PARTITIONS} partition(s), needs ${DESIRED_EH_PARTITIONS}"
@@ -385,7 +413,14 @@ for _region in "${_REGIONS[@]}"; do
       log "All ${DEPLOY_MAX_RETRIES} attempts failed in ${_region}."
       # Clean up partial deployment before trying next region
       log "Cleaning up partial resources in ${_region}..."
-      az containerapp env delete -n "hive-env-${HIVE_NAME}" -g "${RESOURCE_GROUP}" --yes 2>/dev/null || true
+      if az containerapp env show -n "hive-env-${HIVE_NAME}" -g "${RESOURCE_GROUP}" --output none >/dev/null 2>&1; then
+        if ! CLEANUP_OUTPUT="$(az containerapp env delete \
+          -n "hive-env-${HIVE_NAME}" \
+          -g "${RESOURCE_GROUP}" \
+          --yes 2>&1)"; then
+          warn "Failed to clean up partial Container Apps environment hive-env-${HIVE_NAME}: ${CLEANUP_OUTPUT}"
+        fi
+      fi
     fi
   done
 done
@@ -399,8 +434,12 @@ fi
 log "Bicep deployment complete (region: ${LOCATION})."
 
 # Extract Event Hubs namespace name for reference
-EH_NAMESPACE=$(echo "${DEPLOY_OUTPUT}" | python3 -c \
-  "import json,sys; d=json.load(sys.stdin); print(d.get('properties',{}).get('outputs',{}).get('ehNamespaceName',{}).get('value',''))" 2>/dev/null || echo "")
+EH_NAMESPACE=""
+if ! EH_NAMESPACE="$(printf '%s' "${DEPLOY_OUTPUT}" | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); print(d.get('properties',{}).get('outputs',{}).get('ehNamespaceName',{}).get('value',''))")"; then
+  warn "Could not parse Event Hubs namespace from deployment output."
+  EH_NAMESPACE=""
+fi
 
 # ============================================================
 # Summary

--- a/deploy/azure_hive/eval_setup.py
+++ b/deploy/azure_hive/eval_setup.py
@@ -123,7 +123,12 @@ def check_agent_apps(resource_group: str, hive_name: str, expected_agents: int) 
     )
 
 
-def check_event_hub_namespace(connection_string: str, hive_name: str) -> tuple[bool, str, str]:
+def check_event_hub_namespace(
+    connection_string: str,
+    hive_name: str,
+    *,
+    check_only: bool = False,
+) -> tuple[bool, str, str]:
     """Return (ok, input_hub, response_hub)."""
     input_hub = os.environ.get("AMPLIHACK_EH_INPUT_HUB", "") or f"hive-events-{hive_name}"
     response_hub = os.environ.get("AMPLIHACK_EH_RESPONSE_HUB", "") or f"eval-responses-{hive_name}"
@@ -135,10 +140,12 @@ def check_event_hub_namespace(connection_string: str, hive_name: str) -> tuple[b
     try:
         from azure.eventhub import EventHubConsumerClient  # type: ignore[import-unresolved]
     except ImportError:
-        _warn(
-            "azure-eventhub not installed — skipping hub connectivity check (pip install azure-eventhub)"
+        _step(
+            False,
+            "azure-eventhub not installed — install it to validate Event Hubs connectivity "
+            "(pip install azure-eventhub)",
         )
-        return True, input_hub, response_hub
+        return False, input_hub, response_hub
 
     # Check input hub
     try:
@@ -173,12 +180,21 @@ def check_event_hub_namespace(connection_string: str, hive_name: str) -> tuple[b
     _step(resp_ok, resp_msg)
 
     # Check response-hub consumer groups used by the eval harness and external monitor
-    cg_ok = _ensure_response_consumer_groups(connection_string, response_hub)
+    cg_ok = _ensure_response_consumer_groups(
+        connection_string,
+        response_hub,
+        check_only=check_only,
+    )
 
     return input_ok and resp_ok and cg_ok, input_hub, response_hub
 
 
-def _ensure_response_consumer_groups(connection_string: str, response_hub: str) -> bool:
+def _ensure_response_consumer_groups(
+    connection_string: str,
+    response_hub: str,
+    *,
+    check_only: bool = False,
+) -> bool:
     """Create the response-hub consumer groups used by eval tooling if needed."""
     # Extract namespace name from connection string
     ns = ""
@@ -195,8 +211,7 @@ def _ensure_response_consumer_groups(connection_string: str, response_hub: str) 
             break
 
     if not ns:
-        _warn("Could not parse namespace from connection string — skipping consumer group check")
-        return True
+        return _step(False, "Could not parse Event Hubs namespace from connection string")
 
     # Try to get resource group from env for az CLI calls
     resource_group = os.environ.get("HIVE_RESOURCE_GROUP", "hive-mind-rg")
@@ -219,10 +234,10 @@ def _ensure_response_consumer_groups(connection_string: str, response_hub: str) 
         "json",
     )
     if not ok:
-        _warn(
-            "Could not list consumer groups (az CLI needed) — ensure 'eval-reader' and 'eval-monitor' exist manually"
+        return _step(
+            False,
+            "Could not list consumer groups on response hub — ensure az CLI access to Event Hubs",
         )
-        return True
 
     try:
         groups = json.loads(out or "[]")
@@ -233,6 +248,11 @@ def _ensure_response_consumer_groups(connection_string: str, response_hub: str) 
     missing_groups = [group for group in required_groups if group not in groups]
     if not missing_groups:
         return _step(True, "Consumer groups 'eval-reader' and 'eval-monitor' exist on response hub")
+    if check_only:
+        return _step(
+            False,
+            "Missing response-hub consumer groups: " + ", ".join(missing_groups),
+        )
 
     all_ok = True
     for group_name in missing_groups:
@@ -377,7 +397,9 @@ def main() -> int:
     # --- Event Hubs ---
     print("\nEvent Hubs:")
     eh_ok, input_hub, response_hub = check_event_hub_namespace(
-        args.connection_string, args.hive_name
+        args.connection_string,
+        args.hive_name,
+        check_only=args.check_only,
     )
     if not eh_ok:
         failures.append("event_hubs")

--- a/deploy/azure_hive/tests/test_agent_entrypoint.py
+++ b/deploy/azure_hive/tests/test_agent_entrypoint.py
@@ -977,6 +977,28 @@ class TestShardTransport:
 
         assert exc_info.value.code == 1
 
+    def test_main_exits_when_event_hubs_retrieval_is_enabled_but_hive_init_fails(
+        self, monkeypatch, tmp_path
+    ):
+        """Azure Event Hubs deployments must fail fast instead of silently degrading."""
+        mod = _load_entrypoint()
+
+        monkeypatch.setenv("AMPLIHACK_AGENT_NAME", "agent-0")
+        monkeypatch.setenv("AMPLIHACK_EH_CONNECTION_STRING", "Endpoint=sb://dummy/")
+        monkeypatch.setenv("AMPLIHACK_EH_NAME", "hive-shards-test")
+        monkeypatch.setenv("AMPLIHACK_EH_INPUT_HUB", "hive-events-test")
+        monkeypatch.setenv("AMPLIHACK_MEMORY_STORAGE_PATH", str(tmp_path / "agent-0"))
+
+        with patch.object(mod, "_init_dht_hive", return_value=None):
+            with patch(
+                "amplihack.agents.goal_seeking.runtime_factory.create_goal_agent_runtime",
+                side_effect=AssertionError("runtime startup should fail before agent creation"),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    mod.main()
+
+        assert exc_info.value.code == 1
+
     def test_main_skips_hive_init_when_distributed_retrieval_disabled(self, monkeypatch, tmp_path):
         mod = _load_entrypoint()
 

--- a/deploy/azure_hive/tests/test_eval_setup.py
+++ b/deploy/azure_hive/tests/test_eval_setup.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+
+_EVAL_SETUP_PATH = Path(__file__).parent.parent / "eval_setup.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("eval_setup", _EVAL_SETUP_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_check_event_hub_namespace_fails_when_sdk_missing():
+    mod = _load_module()
+    original_import = builtins.__import__
+
+    def _missing_eventhub(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "azure.eventhub":
+            raise ImportError("azure-eventhub missing")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=_missing_eventhub):
+        ok, input_hub, response_hub = mod.check_event_hub_namespace(
+            "Endpoint=sb://example.servicebus.windows.net/",
+            "test-hive",
+        )
+
+    assert ok is False
+    assert input_hub == "hive-events-test-hive"
+    assert response_hub == "eval-responses-test-hive"
+
+
+def test_ensure_response_consumer_groups_check_only_reports_missing_without_creating():
+    mod = _load_module()
+
+    with patch.object(mod, "_az", return_value=(True, '["$Default"]')) as az_mock:
+        ok = mod._ensure_response_consumer_groups(
+            "Endpoint=sb://example.servicebus.windows.net/;SharedAccessKeyName=x;SharedAccessKey=y",
+            "eval-responses-test",
+            check_only=True,
+        )
+
+    assert ok is False
+    assert az_mock.call_count == 1
+
+
+def test_ensure_response_consumer_groups_fails_when_list_command_fails():
+    mod = _load_module()
+
+    with patch.object(mod, "_az", return_value=(False, "")):
+        ok = mod._ensure_response_consumer_groups(
+            "Endpoint=sb://example.servicebus.windows.net/;SharedAccessKeyName=x;SharedAccessKey=y",
+            "eval-responses-test",
+        )
+
+    assert ok is False

--- a/deploy/azure_hive/tests/test_shell_deployment_scripts.py
+++ b/deploy/azure_hive/tests/test_shell_deployment_scripts.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+_AZURE_HIVE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _write_fake_az(tmp_path: Path, script: str) -> Path:
+    fake_az = tmp_path / "az"
+    fake_az.write_text(textwrap.dedent(script), encoding="utf-8")
+    fake_az.chmod(0o755)
+    return fake_az
+
+
+def _script_env(tmp_path: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["ANTHROPIC_API_KEY"] = "test-key"
+    return env
+
+
+def test_deploy_script_fails_loudly_when_acr_create_fails(tmp_path: Path):
+    _write_fake_az(
+        tmp_path,
+        """\
+        #!/usr/bin/env python3
+        import json
+        import sys
+
+        args = sys.argv[1:]
+        if args[:2] == ["group", "create"]:
+            sys.exit(0)
+        if args[:2] == ["acr", "list"]:
+            print("")
+            sys.exit(0)
+        if args[:2] == ["acr", "check-name"]:
+            print(json.dumps({"nameAvailable": True}))
+            sys.exit(0)
+        if args[:2] == ["acr", "create"]:
+            print("acr create boom", file=sys.stderr)
+            sys.exit(1)
+        raise SystemExit(f"unexpected az invocation: {args!r}")
+        """,
+    )
+
+    result = subprocess.run(
+        ["bash", str(_AZURE_HIVE_DIR / "deploy.sh"), "--infra-only"],
+        capture_output=True,
+        text=True,
+        env=_script_env(tmp_path),
+    )
+
+    assert result.returncode == 1
+    assert "Failed to create ACR" in result.stderr
+    assert "acr create boom" in result.stderr
+
+
+def test_deploy_status_fails_when_resource_group_is_missing(tmp_path: Path):
+    _write_fake_az(
+        tmp_path,
+        """\
+        #!/usr/bin/env python3
+        import sys
+
+        args = sys.argv[1:]
+        if args[:2] == ["group", "show"]:
+            print("resource group missing", file=sys.stderr)
+            sys.exit(3)
+        raise SystemExit(f"unexpected az invocation: {args!r}")
+        """,
+    )
+
+    result = subprocess.run(
+        ["bash", str(_AZURE_HIVE_DIR / "deploy.sh"), "--status"],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ, PATH=f"{tmp_path}:{os.environ['PATH']}"),
+    )
+
+    assert result.returncode == 1
+    assert "Resource group hive-mind-rg not found." in result.stderr
+
+
+def test_cleanup_volumes_fails_when_share_delete_fails(tmp_path: Path):
+    _write_fake_az(
+        tmp_path,
+        """\
+        #!/usr/bin/env python3
+        import sys
+
+        args = sys.argv[1:]
+        if args[:3] == ["storage", "account", "list"]:
+            print("hivesatest")
+            sys.exit(0)
+        if args[:4] == ["storage", "account", "keys", "list"]:
+            print("fake-key")
+            sys.exit(0)
+        if args[:3] == ["storage", "file", "list"]:
+            query = args[args.index("--query") + 1]
+            if "type=='file'" in query:
+                print("stale.db")
+            else:
+                print("")
+            sys.exit(0)
+        if args[:3] == ["storage", "file", "delete"]:
+            print("delete failed", file=sys.stderr)
+            sys.exit(1)
+        raise SystemExit(f"unexpected az invocation: {args!r}")
+        """,
+    )
+
+    result = subprocess.run(
+        ["bash", str(_AZURE_HIVE_DIR / "cleanup_volumes.sh")],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ, PATH=f"{tmp_path}:{os.environ['PATH']}"),
+    )
+
+    assert result.returncode == 1
+    assert "Failed to delete file 'stale.db'" in result.stderr
+    assert "Cleanup incomplete" in result.stderr

--- a/docs/agent_memory_architecture.md
+++ b/docs/agent_memory_architecture.md
@@ -263,7 +263,7 @@ The eval tests the production agent — same code, same OODA loop, same Memory f
 
 **Federated full (100 agents)**: 100 agents, same config. Learning parallelized (10 workers, 9x speedup: 21.6h → 2.4h). Gossip rounds after learning. Q&A with semantic expertise routing + consensus voting × 3 repeats. **Result: 45.8% median, 21.7% stddev.** Routing precision degrades at this scale.
 
-**Azure deployment context:** Production eval runs on 20 Container Apps (`amplihive-app-0`…`amplihive-app-19`) in `westus2` / `hive-mind-rg`, each hosting 5 agents (`agent-0`…`agent-99`). Transport: `azure_service_bus` via namespace `hive-sb-dj2qo2w7vu5zi`, topic `hive-graph`, 100 subscriptions. Memory backend: `cognitive` (Kuzu) on ephemeral volumes — POSIX file locks are supported, identical to local development.
+**Azure deployment context:** Production eval runs on 20 Container Apps (`amplihive-app-0`…`amplihive-app-19`) in `westus2` / `hive-mind-rg`, each hosting 5 agents (`agent-0`…`agent-99`). Transport: `azure_event_hubs` via the `hive-events-*`, `hive-shards-*`, and `eval-responses-*` hubs. Memory backend: `cognitive` (Kuzu) on ephemeral volumes — POSIX file locks are supported, identical to local development, and the live deployment fails fast if distributed retrieval cannot initialize.
 
 Scoring: LLM grader (multi-vote median) scores 0.0-1.0 across 12 cognitive levels (L1 direct recall through L12 far transfer).
 

--- a/docs/distributed_hive_mind.md
+++ b/docs/distributed_hive_mind.md
@@ -399,10 +399,13 @@ amplihack-hive stop --hive my-hive
 
 ---
 
-### Azure Service Bus transport (multi-machine)
+### Legacy multi-machine transports
 
-For production deployments where agents run on separate machines (local VMs, Docker, Azure),
+For older/manual multi-machine deployments where agents run on separate machines,
 use `azure_service_bus` or `redis` transport.
+
+For current Azure Container Apps deployments, use `deploy/azure_hive/deploy.sh`,
+which provisions and uses Event Hubs.
 
 **Create hive with Service Bus:**
 
@@ -433,9 +436,8 @@ For cloud-scale deployments (100+ agents), use the `deploy/azure_hive/` scripts.
 | Resource                                                                                     | Purpose                                                                       |
 | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | Azure Container Registry (`hivacrhivemind.azurecr.io`)                                       | Stores the amplihack agent Docker image                                       |
-| **Event Hubs Namespace** + Event Hub `hive-shards-{hiveName}` + consumer groups `cg-agent-N` | **Shard transport** — SHARD_QUERY / SHARD_RESPONSE routing                    |
-| Service Bus Namespace (`hive-sb-dj2qo2w7vu5zi`) + Topic `hive-graph` + N subscriptions       | Gossip / `NetworkGraphStore` event transport (retained)                       |
-| Azure Storage Account (`hivesadj2qo2w7vu5zi`) + File Share                                   | Provisioned for persistence; **not mounted for Kuzu** (POSIX lock limitation) |
+| **Event Hubs Namespace** + hubs `hive-events-*`, `hive-shards-*`, `eval-responses-*`        | Input events, shard routing, and eval answer collection                       |
+| Azure Storage Account (`hivesadj2qo2w7vu5zi`) + File Share                                   | Provisioned for optional cleanup/recovery workflows                           |
 | Container Apps Environment                                                                   | Managed container runtime (westus2, hive-mind-rg)                             |
 | N Container Apps (`amplihive-app-0`…`amplihive-app-N`)                                       | Each app hosts up to 5 agent containers                                       |
 
@@ -444,9 +446,10 @@ For cloud-scale deployments (100+ agents), use the `deploy/azure_hive/` scripts.
 ```bash
 export ANTHROPIC_API_KEY="<your-api-key>"
 export HIVE_NAME="prod-hive"
+export HIVE_DEPLOYMENT_PROFILE="custom"
 export HIVE_AGENT_COUNT=20
 export HIVE_AGENTS_PER_APP=5        # 4 Container Apps total
-export HIVE_TRANSPORT=azure_service_bus
+export HIVE_TRANSPORT=azure_event_hubs
 
 bash deploy/azure_hive/deploy.sh
 ```
@@ -455,10 +458,10 @@ This will:
 
 1. Create resource group `hive-mind-rg` in `westus2`
 2. Build and push the Docker image to ACR (`hivacrhivemind.azurecr.io`)
-3. Deploy Bicep template: Service Bus namespace `hive-sb-dj2qo2w7vu5zi`, Storage account `hivesadj2qo2w7vu5zi`, Container Apps Environment
+3. Deploy Bicep template: Event Hubs namespace, Storage account `hivesadj2qo2w7vu5zi`, Container Apps Environment
 4. Launch 4 Container Apps (`amplihive-app-0` through `amplihive-app-3`) with 5 agents each (20 total)
 
-> **Note:** Containers now use **ephemeral volumes** (`EmptyDir`) at `/data` so Kuzu can acquire POSIX advisory file locks. Azure Files (SMB) does not support POSIX file locks. Agents use the `cognitive` (Kuzu) backend identically in containers and local development.
+> **Note:** Containers use **ephemeral volumes** (`EmptyDir`) at `/data` so Kuzu can acquire POSIX advisory file locks. Azure Files (SMB) does not support POSIX file locks, so the provisioned file share is **not** mounted for the live agent databases.
 
 **Check deployment status:**
 
@@ -480,14 +483,15 @@ Each container receives:
 | ------------------------------------ | ------------------------------------------------------------ |
 | `AMPLIHACK_AGENT_NAME`               | `agent-N` (unique per container)                             |
 | `AMPLIHACK_AGENT_PROMPT`             | Agent role prompt                                            |
-| `AMPLIHACK_MEMORY_TRANSPORT`         | `azure_service_bus` (for gossip/hive-graph)                  |
-| `AMPLIHACK_MEMORY_CONNECTION_STRING` | Service Bus connection string (from Key Vault secret)        |
-| `AMPLIHACK_MEMORY_STORAGE_PATH`      | `/data/agent-N` (on mounted Azure File Share)                |
-| `AMPLIHACK_EH_CONNECTION_STRING`     | **Event Hubs** namespace connection string (shard transport) |
-| `AMPLIHACK_EH_NAME`                  | Event Hub name (`hive-shards-{hiveName}`)                    |
+| `AMPLIHACK_MEMORY_TRANSPORT`         | `azure_event_hubs`                                           |
+| `AMPLIHACK_MEMORY_STORAGE_PATH`      | `/data/agent-N` (ephemeral EmptyDir volume)                  |
+| `AMPLIHACK_EH_CONNECTION_STRING`     | **Event Hubs** namespace connection string                   |
+| `AMPLIHACK_EH_NAME`                  | Shard hub name (`hive-shards-{hiveName}`)                    |
+| `AMPLIHACK_EH_INPUT_HUB`             | Input hub name (`hive-events-{hiveName}`)                    |
+| `AMPLIHACK_EVAL_RESPONSE_HUB`        | Eval response hub name (`eval-responses-{hiveName}`)         |
 | `ANTHROPIC_API_KEY`                  | From Container Apps secret                                   |
 
-When `AMPLIHACK_EH_CONNECTION_STRING` and `AMPLIHACK_EH_NAME` are set, `agent_entrypoint.py` automatically selects `EventHubsShardTransport`; otherwise it falls back to `ServiceBusShardTransport`.
+When distributed retrieval is enabled, `agent_entrypoint.py` now fails fast if the Event Hubs shard transport cannot initialize. Azure deployment no longer silently degrades to local-only retrieval.
 
 **Dockerfile highlights:**
 

--- a/src/amplihack/agents/goal_seeking/goal_seeking_agent.py
+++ b/src/amplihack/agents/goal_seeking/goal_seeking_agent.py
@@ -29,6 +29,7 @@ Backward compatibility:
 import asyncio
 import inspect
 import logging
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -37,11 +38,53 @@ from .retrieval_constants import ORIENT_SEARCH_LIMIT
 logger = logging.getLogger(__name__)
 
 
+def _run_awaitable_in_background_thread(awaitable: Any) -> Any:
+    """Execute an awaitable to completion on a dedicated event loop thread.
+
+    GoalSeekingAgent exposes a synchronous API, but some backends now return
+    coroutines. When callers invoke that sync API from inside an already-running
+    event loop, ``asyncio.run()`` is not legal, so we bridge through a short-
+    lived thread with its own loop and surface the original result/exception.
+    """
+
+    state: dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            state["result"] = asyncio.run(awaitable)
+        except BaseException as exc:  # preserve original failure for the caller
+            state["exception"] = exc
+
+    thread = threading.Thread(
+        target=_runner,
+        name="goal-seeking-awaitable-runner",
+        daemon=True,
+    )
+    thread.start()
+    thread.join()
+
+    if "exception" in state:
+        raise state["exception"]
+    return state.get("result")
+
+
 def _run_maybe_async(value: Any) -> Any:
     """Run coroutine-like values, otherwise return them unchanged."""
     if inspect.isawaitable(value):
-        return asyncio.run(value)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(value)
+        return _run_awaitable_in_background_thread(value)
     return value
+
+
+def _log_background_task_failure(agent_name: str, task: asyncio.Task[Any]) -> None:
+    """Log exceptions from fire-and-forget async callbacks."""
+    try:
+        task.result()
+    except Exception:
+        logger.exception("Agent %s on_answer callback failed", agent_name)
 
 # Minimal sentinel so orient/decide/act can be called without prior observe()
 _NO_INPUT = object()
@@ -139,16 +182,11 @@ class GoalSeekingAgent:
             return
 
         db_path = storage_path
-        if db_path is None:
-            return
 
         if self._memory_type == "hierarchical":
             from .flat_retriever_adapter import FlatRetrieverAdapter
 
-            try:
-                self._learning_agent.memory.close()
-            except Exception:
-                pass
+            self._close_existing_memory_backend("hierarchical")
             self._learning_agent.memory = FlatRetrieverAdapter(
                 agent_name=self._agent_name,
                 db_path=db_path,
@@ -159,15 +197,59 @@ class GoalSeekingAgent:
         if self._memory_type == "cognitive":
             from .cognitive_adapter import CognitiveAdapter
 
-            try:
-                self._learning_agent.memory.close()
-            except Exception:
-                pass
+            self._close_existing_memory_backend("cognitive")
             self._learning_agent.memory = CognitiveAdapter(
                 agent_name=self._agent_name,
                 db_path=db_path,
             )
             self._learning_agent.use_hierarchical = True
+
+    def _close_existing_memory_backend(self, target_memory_type: str) -> None:
+        """Close the current memory backend before swapping implementations."""
+        memory = self._learning_agent.memory
+        if not hasattr(memory, "close"):
+            return
+
+        try:
+            memory.close()
+        except Exception:
+            logger.exception(
+                "Agent %s failed to close existing memory backend before switching to %s",
+                self._agent_name,
+                target_memory_type,
+            )
+            raise
+
+    def _emit_answer_callback(self, answer: str) -> None:
+        """Invoke the optional answer callback without dropping async handlers."""
+        if not self.on_answer:
+            return
+
+        try:
+            callback_result = self.on_answer(self._agent_name, answer)
+        except Exception:
+            logger.exception("Agent %s on_answer callback failed", self._agent_name)
+            return
+
+        if not inspect.isawaitable(callback_result):
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                _run_maybe_async(callback_result)
+            except Exception:
+                logger.exception("Agent %s async on_answer callback failed", self._agent_name)
+            return
+
+        task = loop.create_task(callback_result)
+        task.add_done_callback(
+            lambda done_task, agent_name=self._agent_name: _log_background_task_failure(
+                agent_name,
+                done_task,
+            )
+        )
 
     # ------------------------------------------------------------------
     # OODA loop — public API
@@ -292,6 +374,11 @@ class GoalSeekingAgent:
 
         Returns:
             Output string: answer text for ``'answer'``, summary for ``'store'``.
+
+        Raises:
+            Exception: Propagates underlying learning/answer failures after logging
+                so direct callers and user-like flows do not mistake them for
+                successful outputs.
         """
         text = self._current_input
         output = ""
@@ -313,16 +400,12 @@ class GoalSeekingAgent:
                 output = result[0] if isinstance(result, tuple) else str(result)
             except Exception:
                 logger.exception("Agent %s act() answer_question failed", self._agent_name)
-                output = "Error: could not synthesize answer."
+                raise
             # Write answer to stdout — Container Apps streams this to Log Analytics
             print(f"[{self._agent_name}] ANSWER: {output}", flush=True)
             logger.info("Agent %s ANSWER: %s", self._agent_name, output)
             # Fire callback for distributed eval answer collection
-            if self.on_answer:
-                try:
-                    self.on_answer(self._agent_name, output)
-                except Exception:
-                    pass  # Never let callback errors break the OODA loop
+            self._emit_answer_callback(output)
 
         else:  # "store" (or empty / unknown)
             try:
@@ -331,7 +414,7 @@ class GoalSeekingAgent:
                 output = f"Stored {stored} facts from input."
             except Exception:
                 logger.exception("Agent %s act() learn_from_content failed", self._agent_name)
-                output = "Error: could not store input."
+                raise
             logger.debug("Agent %s STORED: %s", self._agent_name, output)
 
         return output

--- a/src/amplihack/cli/hive.py
+++ b/src/amplihack/cli/hive.py
@@ -9,7 +9,7 @@ Commands:
 
 Hive config format (~/.amplihack/hives/NAME/config.yaml):
     name: my-hive
-    transport: azure_service_bus
+    transport: local
     connection_string: Endpoint=sb://...
     storage_path: /data/hive
     shard_backend: kuzu
@@ -240,6 +240,11 @@ def _start_local(hive_name: str, config: dict[str, Any]) -> int:
 
 def _start_azure(hive_name: str, config: dict[str, Any], args: argparse.Namespace) -> int:
     """Delegate Azure deployment to deploy.sh."""
+    agents = config.get("agents", [])
+    if not agents:
+        print(f"No agents defined in hive '{hive_name}'.", file=sys.stderr)
+        return 1
+
     # Find deploy.sh
     deploy_script = _find_deploy_script()
     if deploy_script is None:
@@ -250,11 +255,14 @@ def _start_azure(hive_name: str, config: dict[str, Any], args: argparse.Namespac
         return 1
 
     env = dict(os.environ)
+    agent_count = len(agents)
     env["HIVE_NAME"] = hive_name
-    env["HIVE_TRANSPORT"] = config.get("transport", "azure_service_bus")
+    env["HIVE_TRANSPORT"] = "azure_event_hubs"
     env["HIVE_CONNECTION_STRING"] = config.get("connection_string", "")
     env["HIVE_STORAGE_PATH"] = config.get("storage_path", f"/data/hive/{hive_name}")
-    env["HIVE_AGENT_COUNT"] = str(len(config.get("agents", [])))
+    env["HIVE_DEPLOYMENT_PROFILE"] = "custom"
+    env["HIVE_AGENT_COUNT"] = str(agent_count)
+    env.setdefault("HIVE_AGENTS_PER_APP", str(min(agent_count, 5)))
 
     print(f"Deploying hive '{hive_name}' to Azure...")
     result = subprocess.run(["bash", str(deploy_script)], env=env)

--- a/tests/agents/goal_seeking/test_goal_seeking_agent.py
+++ b/tests/agents/goal_seeking/test_goal_seeking_agent.py
@@ -10,6 +10,7 @@ Covers:
 - Question inputs skip duplicate orient-time memory recall
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -351,6 +352,116 @@ class TestGoalSeekingAgentFactBatch:
             record_learning=False,
         )
         assert result == expected
+
+
+class TestGoalSeekingAgentAct:
+    """Unit tests for GoalSeekingAgent.act() async bridge behavior."""
+
+    @pytest.fixture
+    def agent(self):
+        with patch(
+            "amplihack.agents.goal_seeking.goal_seeking_agent.GoalSeekingAgent.__init__",
+            lambda self, **kwargs: None,
+        ):
+            from amplihack.agents.goal_seeking.goal_seeking_agent import GoalSeekingAgent
+
+            ag = GoalSeekingAgent.__new__(GoalSeekingAgent)
+            ag._agent_name = "test_agent"
+            ag._current_input = ""
+            ag._oriented_facts = {"facts": []}
+            ag._decision = ""
+            ag._learning_agent = MagicMock()
+            ag.on_answer = None
+            return ag
+
+    @pytest.mark.asyncio
+    async def test_store_path_runs_async_learning_inside_running_loop(self, agent):
+        class AsyncLearningAgent:
+            async def learn_from_content(self, text: str):
+                assert text == "Store this from async context."
+                return {"facts_stored": 1}
+
+        agent._learning_agent = AsyncLearningAgent()
+        agent._current_input = "Store this from async context."
+        agent._decision = "store"
+
+        assert agent.act() == "Stored 1 facts from input."
+
+    @pytest.mark.asyncio
+    async def test_answer_path_schedules_async_callback_inside_running_loop(self, agent):
+        delivered: asyncio.Future[tuple[str, str]] = asyncio.Future()
+        agent._learning_agent.answer_question.return_value = "Answer text"
+        agent._current_input = "What happened?"
+        agent._decision = "answer"
+
+        async def on_answer(agent_name: str, output: str) -> None:
+            delivered.set_result((agent_name, output))
+
+        agent.on_answer = on_answer
+
+        assert agent.act() == "Answer text"
+        assert await asyncio.wait_for(delivered, timeout=1) == ("test_agent", "Answer text")
+
+    def test_store_path_propagates_learning_failures(self, agent):
+        agent._current_input = "Store this."
+        agent._decision = "store"
+        agent._learning_agent.learn_from_content.side_effect = RuntimeError("store exploded")
+
+        with pytest.raises(RuntimeError, match="store exploded"):
+            agent.act()
+
+    def test_answer_path_propagates_answer_failures(self, agent):
+        agent._current_input = "What happened?"
+        agent._decision = "answer"
+        agent._learning_agent.answer_question.side_effect = ValueError("answer exploded")
+
+        with pytest.raises(ValueError, match="answer exploded"):
+            agent.act()
+
+
+class TestGoalSeekingAgentMemoryBackendSelection:
+    """Unit tests for explicit memory backend override behavior."""
+
+    def test_explicit_hierarchical_memory_type_applies_without_storage_path(self):
+        backend = MagicMock()
+        backend.memory.close = MagicMock()
+
+        with (
+            patch(
+                "amplihack.agents.goal_seeking.learning_agent.LearningAgent",
+                return_value=backend,
+            ),
+            patch(
+                "amplihack.agents.goal_seeking.flat_retriever_adapter.FlatRetrieverAdapter",
+                return_value="hierarchical-memory",
+            ) as flat_adapter,
+        ):
+            from amplihack.agents.goal_seeking.goal_seeking_agent import GoalSeekingAgent
+
+            agent = GoalSeekingAgent(memory_type="hierarchical")
+
+        flat_adapter.assert_called_once_with(
+            agent_name="goal_seeking_agent",
+            db_path=None,
+        )
+        assert agent.memory == "hierarchical-memory"
+        assert backend.use_hierarchical is True
+
+    def test_explicit_hierarchical_memory_type_surfaces_close_failures(self):
+        backend = MagicMock()
+        backend.memory.close.side_effect = RuntimeError("close exploded")
+
+        with (
+            patch(
+                "amplihack.agents.goal_seeking.learning_agent.LearningAgent",
+                return_value=backend,
+            ),
+            patch("amplihack.agents.goal_seeking.flat_retriever_adapter.FlatRetrieverAdapter"),
+            pytest.raises(RuntimeError, match="close exploded"),
+        ):
+            from amplihack.agents.goal_seeking.goal_seeking_agent import GoalSeekingAgent
+
+            GoalSeekingAgent(memory_type="hierarchical")
 
 
 class TestGoalSeekingAgentCompatDelegates:

--- a/tests/cli/test_hive_cli.py
+++ b/tests/cli/test_hive_cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import amplihack.cli.hive as hive
+
+
+def test_start_azure_requires_agents():
+    args = argparse.Namespace(hive="prod-hive")
+
+    result = hive._start_azure("prod-hive", {"agents": []}, args)
+
+    assert result == 1
+
+
+def test_start_azure_uses_custom_profile_and_event_hubs_transport():
+    args = argparse.Namespace(hive="prod-hive")
+    config = {
+        "agents": [{"name": "agent-0"}, {"name": "agent-1"}, {"name": "agent-2"}],
+        "transport": "azure_service_bus",
+        "connection_string": "Endpoint=sb://legacy/",
+        "storage_path": "/tmp/prod-hive",
+    }
+    deploy_script = Path("/tmp/deploy.sh")
+    completed = Mock(returncode=0)
+
+    with (
+        patch.object(hive, "_find_deploy_script", return_value=deploy_script),
+        patch.object(hive.subprocess, "run", return_value=completed) as run_mock,
+    ):
+        result = hive._start_azure("prod-hive", config, args)
+
+    assert result == 0
+    env = run_mock.call_args.kwargs["env"]
+    assert env["HIVE_TRANSPORT"] == "azure_event_hubs"
+    assert env["HIVE_DEPLOYMENT_PROFILE"] == "custom"
+    assert env["HIVE_AGENT_COUNT"] == "3"
+    assert env["HIVE_AGENTS_PER_APP"] == "3"
+
+
+def test_start_azure_respects_existing_agents_per_app_env(monkeypatch):
+    args = argparse.Namespace(hive="prod-hive")
+    config = {"agents": [{"name": f"agent-{i}"} for i in range(8)]}
+    deploy_script = Path("/tmp/deploy.sh")
+    completed = Mock(returncode=0)
+
+    monkeypatch.setenv("HIVE_AGENTS_PER_APP", "2")
+
+    with (
+        patch.object(hive, "_find_deploy_script", return_value=deploy_script),
+        patch.object(hive.subprocess, "run", return_value=completed) as run_mock,
+    ):
+        result = hive._start_azure("prod-hive", config, args)
+
+    assert result == 0
+    env = run_mock.call_args.kwargs["env"]
+    assert env["HIVE_AGENTS_PER_APP"] == "2"

--- a/tests/recipes/test_step04_worktree_reuse.py
+++ b/tests/recipes/test_step04_worktree_reuse.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _run_git(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd is not None else None,
+    )
+
+
+def _load_step_04_command() -> str:
+    workflow_path = Path("amplifier-bundle/recipes/default-workflow.yaml")
+    with workflow_path.open() as handle:
+        workflow = yaml.safe_load(handle)
+
+    for step in workflow["steps"]:
+        if step["id"] == "step-04-setup-worktree":
+            return step["command"]
+
+    raise AssertionError("step-04-setup-worktree not found")
+
+
+def _render_step_04_command() -> str:
+    return (
+        _load_step_04_command()
+        .replace("{{repo_path}}", ".")
+        .replace("{{task_description}}", "existing-worktree")
+        .replace("{{branch_prefix}}", "feat")
+        .replace("{{issue_number}}", "1")
+        .replace("{{branch_slug_max_length}}", "50")
+    )
+
+
+@pytest.fixture
+def repo_with_existing_branch_worktree(tmp_path: Path) -> tuple[Path, Path, Path, str]:
+    remote_path = tmp_path / "remote.git"
+    _run_git(["init", "--bare", str(remote_path)])
+
+    repo_path = tmp_path / "repo"
+    _run_git(["init", "-b", "main", str(repo_path)])
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo_path)
+    _run_git(["config", "user.name", "Test User"], cwd=repo_path)
+
+    (repo_path / "README.md").write_text("# test\n")
+    _run_git(["add", "README.md"], cwd=repo_path)
+    _run_git(["commit", "-m", "initial"], cwd=repo_path)
+    _run_git(["remote", "add", "origin", str(remote_path)], cwd=repo_path)
+    _run_git(["push", "-u", "origin", "main"], cwd=repo_path)
+
+    branch_name = "feat/issue-1-existing-worktree"
+    existing_worktree = repo_path / "worktrees" / branch_name
+    existing_worktree.parent.mkdir(parents=True, exist_ok=True)
+    _run_git(["worktree", "add", "-b", branch_name, str(existing_worktree), "HEAD"], cwd=repo_path)
+
+    integration_worktree = repo_path / "worktrees" / "integration-live-proof"
+    integration_worktree.parent.mkdir(parents=True, exist_ok=True)
+    _run_git(["worktree", "add", str(integration_worktree), "HEAD"], cwd=repo_path)
+
+    return repo_path, existing_worktree, integration_worktree, branch_name
+
+
+def test_step_04_reuses_existing_branch_worktree_from_linked_worktree(
+    repo_with_existing_branch_worktree: tuple[Path, Path, Path, str],
+) -> None:
+    _, existing_worktree, integration_worktree, branch_name = repo_with_existing_branch_worktree
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", _render_step_04_command()],
+        capture_output=True,
+        text=True,
+        cwd=integration_worktree,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["created"] is False
+    assert payload["branch_name"] == branch_name
+    assert payload["worktree_path"] == str(existing_worktree)
+
+
+def test_step_04_uses_detached_head_instead_of_origin_default(tmp_path: Path) -> None:
+    remote_path = tmp_path / "remote.git"
+    _run_git(["init", "--bare", str(remote_path)])
+
+    repo_path = tmp_path / "repo"
+    _run_git(["init", "-b", "main", str(repo_path)])
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo_path)
+    _run_git(["config", "user.name", "Test User"], cwd=repo_path)
+
+    (repo_path / "README.md").write_text("# test\n")
+    _run_git(["add", "README.md"], cwd=repo_path)
+    _run_git(["commit", "-m", "base"], cwd=repo_path)
+    _run_git(["remote", "add", "origin", str(remote_path)], cwd=repo_path)
+    _run_git(["push", "-u", "origin", "main"], cwd=repo_path)
+
+    (repo_path / "integration.txt").write_text("integration-only\n")
+    _run_git(["add", "integration.txt"], cwd=repo_path)
+    _run_git(["commit", "-m", "integration commit"], cwd=repo_path)
+    integration_commit = _run_git(["rev-parse", "HEAD"], cwd=repo_path).stdout.strip()
+
+    integration_worktree = repo_path / "worktrees" / "integration-live-proof"
+    integration_worktree.parent.mkdir(parents=True, exist_ok=True)
+    _run_git(["worktree", "add", "--detach", str(integration_worktree), integration_commit], cwd=repo_path)
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", _render_step_04_command()],
+        capture_output=True,
+        text=True,
+        cwd=integration_worktree,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    worktree_head = _run_git(["rev-parse", "HEAD"], cwd=Path(payload["worktree_path"])).stdout.strip()
+    assert worktree_head == integration_commit

--- a/tests/test_orchestration_integration.py
+++ b/tests/test_orchestration_integration.py
@@ -12,7 +12,9 @@ and worktree path handling are correct across all three components.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -181,17 +183,15 @@ class TestDefaultWorkflowWorktree:
             f"expected at least 5: {step_ids_using_worktree}"
         )
 
-    def test_worktree_fallback_to_repo_path(self):
-        """Steps must fall back to repo_path when worktree is unavailable."""
-        # Several bash steps use: cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}}
-        fallback_count = 0
-        for step in self.steps:
-            cmd = step.get("command", "")
-            if "worktree_setup.worktree_path" in cmd and "repo_path" in cmd:
-                fallback_count += 1
-        assert fallback_count >= 2, (
-            f"Only {fallback_count} steps have worktree -> repo_path fallback, expected >= 2"
-        )
+    def test_step_04b_validates_resolved_worktree_path(self):
+        """Workflow must validate the resolved worktree path instead of silently falling back."""
+        step = _find_step(self.steps, "step-04b-validate-worktree")
+        assert step is not None, "step-04b-validate-worktree missing"
+        command = step.get("command", "")
+        assert 'WORKTREE_DIR="{{worktree_setup.worktree_path}}"' in command
+        assert 'WORKTREE_DIR="{{resume_worktree_path}}"' in command
+        assert 'echo "ERROR: No worktree path available for validation" >&2' in command
+        assert 'echo "ERROR: Worktree directory does not exist: $WORKTREE_DIR" >&2' in command
 
     def test_step_04_idempotency_guards(self):
         """Worktree setup must handle existing branch/worktree idempotently."""
@@ -202,6 +202,21 @@ class TestDefaultWorkflowWorktree:
         assert "WORKTREE_EXISTS" in command
         assert "CREATED=false" in command  # reuse path
         assert "CREATED=true" in command  # create path
+
+    def test_step_04_roots_worktrees_in_git_common_dir(self):
+        """Worktree setup must target the canonical repo worktrees dir even from linked worktrees."""
+        step = _find_step(self.steps, "step-04-setup-worktree")
+        command = step.get("command", "")
+        assert "git rev-parse --git-common-dir" in command
+        assert 'WORKTREE_PATH="${WORKTREE_BASE_ROOT}/worktrees/${BRANCH_NAME}"' in command
+
+    def test_step_04_uses_current_head_as_base(self):
+        """Worktree setup must branch from the caller's current checkout, not origin/HEAD."""
+        step = _find_step(self.steps, "step-04-setup-worktree")
+        command = step.get("command", "")
+        assert 'BASE_WORKTREE_REF="HEAD"' in command
+        assert "CURRENT_HEAD=$(git rev-parse --short HEAD)" in command
+        assert "Detached HEAD" in command
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +274,12 @@ class TestMultitaskOrchestratorContextPropagation:
         orch._write_recipe_launcher(ws)
 
         launcher = (ws.work_dir / "launcher.py").read_text()
-        assert '"repo_path": "."' in launcher
+        prefix = "user_context = json.loads("
+        start = launcher.index(prefix) + len(prefix)
+        end = launcher.index(")", start)
+        embedded_json_literal = ast.literal_eval(launcher[start:end])
+        user_context = json.loads(embedded_json_literal)
+        assert user_context["repo_path"] == "."
 
     def test_recipe_launcher_uses_specified_recipe(self, tmp_path):
         """Generated launcher must use the workstream's recipe, not hardcoded default."""


### PR DESCRIPTION
## Summary
- harden azure hive deployment and eval flows so shell and readiness failures stay visible instead of looking successful
- tighten worktree execution contracts and related orchestration tests around current-head basing, resolved worktree validation, and launcher context handling
- improve goal-seeking and hive CLI failure propagation, plus update docs and focused regression coverage for the touched surfaces

## Validation
- pytest -q deploy/azure_hive/tests/test_agent_entrypoint.py deploy/azure_hive/tests/test_eval_setup.py deploy/azure_hive/tests/test_shell_deployment_scripts.py tests/cli/test_hive_cli.py tests/agents/goal_seeking/test_goal_seeking_agent.py tests/test_orchestration_integration.py tests/recipes/test_step04_worktree_reuse.py

## Notes
- removes the stray deploy/azure_hive/tests package marker that caused pytest to import those files as tests.* and break collection
- keeps session artifacts out of the landing set