### PR TITLE
Handle PR-only step-03b references

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue4205-reland-rl4mt3z_
+## Project: amplihack
 
 ## Overview
 

--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: amplihack
+## Project: issue4205-reland-rl4mt3z_
 
 ## Overview
 

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -993,7 +993,7 @@ steps:
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -1028,7 +1028,7 @@ steps:
   - id: "step-08-implement"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -1069,7 +1069,7 @@ steps:
   - id: "step-08b-integration"
     agent: "amplihack:integration"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -1143,7 +1143,7 @@ steps:
   # --------------------------------------------------------------------------
   - id: "checkpoint-after-implementation"
     type: "bash"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     command: |
       set -euo pipefail
       WORKTREE_DIR="{{worktree_setup.worktree_path}}"

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -558,6 +558,7 @@ steps:
       # FIX (#4205): Also match ADO work item URLs: _workitems/edit/NNNN
       # Fallback: bare numeric ID (e.g. from az boards work-item create --query id output)
       EXTRACTED=$(printf '%s\n%s' "$ISSUE_CREATION" "$TASK_DESC" | grep -oE '(issues|_workitems/edit)/[0-9]+|^[0-9]+$' | grep -oE '[0-9]+' | head -1)
+      PR_NUMBER=""
       if [ -z "$EXTRACTED" ]; then
         PR_NUMBER=$(printf '%s\n%s' "$ISSUE_CREATION" "$TASK_DESC" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
         if [ -n "$PR_NUMBER" ]; then
@@ -593,6 +594,11 @@ steps:
             esac
           done < <(printf '%s\n' "$REF_CANDIDATES")
         fi
+      fi
+
+      if [ -z "$EXTRACTED" ] && [ -n "$PR_NUMBER" ]; then
+        echo "INFO: step-03b found no linked issue or task issue reference for PR #$PR_NUMBER — using PR number as reference" >&2
+        EXTRACTED="$PR_NUMBER"
       fi
 
       case "$EXTRACTED" in

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -719,11 +719,25 @@ steps:
       BRANCH_EXISTS=$(git branch --list "${BRANCH_NAME}")
       WORKTREE_EXISTS=$(git worktree list --porcelain | grep -Fx "worktree ${WORKTREE_PATH}" || true)
 
-      if [ -n "$BRANCH_EXISTS" ] && [ -n "$WORKTREE_EXISTS" ]; then
+      EXISTING_CHECKOUT=false
+      if [ -d "$WORKTREE_PATH" ] && git -C "$WORKTREE_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        EXISTING_BRANCH=$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null || true)
+        if [ "$EXISTING_BRANCH" = "$BRANCH_NAME" ]; then
+          EXISTING_CHECKOUT=true
+        else
+          echo "ERROR: worktree path '${WORKTREE_PATH}' already exists but is on branch '${EXISTING_BRANCH:-unknown}', expected '${BRANCH_NAME}'." >&2
+          exit 1
+        fi
+      elif [ -e "$WORKTREE_PATH" ]; then
+        echo "ERROR: worktree path '${WORKTREE_PATH}' already exists but is not a valid git worktree checkout." >&2
+        exit 1
+      fi
+
+      if [ -n "$BRANCH_EXISTS" ] && { [ -n "$WORKTREE_EXISTS" ] || [ "$EXISTING_CHECKOUT" = true ]; }; then
         echo "INFO: Branch '${BRANCH_NAME}' and worktree '${WORKTREE_PATH}' already exist — reusing." >&2
         CREATED=false
       elif [ -n "$BRANCH_EXISTS" ] && [ -z "$WORKTREE_EXISTS" ]; then
-        echo "INFO: Branch '${BRANCH_NAME}' exists but worktree is missing — adding worktree without -b." >&2
+        echo "INFO: Branch '${BRANCH_NAME}' exists but no reusable checkout was found — adding worktree without -b." >&2
         git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
         CREATED=true
       else

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -103,6 +103,7 @@ _BL001_FIXED_CMD = textwrap.dedent("""\
     PY
     }}
     EXTRACTED=$(printf '%s\\n%s' "$ISSUE_CREATION" "$TASK_DESC" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
+    PR_NUMBER=""
     if [ -z "$EXTRACTED" ]; then
       PR_NUMBER=$(printf '%s\\n%s' "$ISSUE_CREATION" "$TASK_DESC" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
       if [ -n "$PR_NUMBER" ]; then
@@ -135,6 +136,9 @@ _BL001_FIXED_CMD = textwrap.dedent("""\
           esac
         done < <(printf '%s\\n' "$REF_CANDIDATES")
       fi
+    fi
+    if [ -z "$EXTRACTED" ] && [ -n "$PR_NUMBER" ]; then
+      EXTRACTED="$PR_NUMBER"
     fi
     case "$EXTRACTED" in
       ''|*[!0-9]*)
@@ -904,6 +908,44 @@ class TestYAMLBugRegression(unittest.TestCase):
             "Multi-line issue_creation must be handled correctly.",
         )
 
+    def test_yaml_step03b_pr_without_linked_issue_uses_pr_number(self):
+        """A PR URL with no linked issue must still yield a numeric reference."""
+        raw_cmd = _extract_step_command(_WORKFLOW_YAML, "step-03b-extract-issue-number")
+        issue_creation_value = "https://github.com/org/repo/pull/4000\n"
+        cmd = raw_cmd.replace("{{issue_creation}}", issue_creation_value)
+
+        gh_mock = textwrap.dedent("""\
+            #!/bin/bash
+            if [[ "$1" == "pr" && "$2" == "view" && "$3" == "4000" ]]; then
+              echo ""
+              exit 0
+            fi
+            exit 1
+        """)
+
+        with tempfile.TemporaryDirectory(prefix="wf_step03b_yaml_") as tmpdir:
+            gh_path = Path(tmpdir) / "gh"
+            gh_path.write_text(gh_mock)
+            gh_path.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{tmpdir}:{env['PATH']}"
+            env["RECIPE_VAR_task_description"] = ""
+
+            result = subprocess.run(
+                ["bash", "-c", cmd],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, f"Command failed:\n{result.stderr}")
+        self.assertEqual(
+            result.stdout.strip(),
+            "4000",
+            "Expected the raw PR number when no linked issue or task issue reference exists.",
+        )
+
     # -----------------------------------------------------------------------
     # BL-002: step-04 must be idempotent
     # -----------------------------------------------------------------------
@@ -1333,6 +1375,24 @@ class TestStep03bThreeTierEdgeCases(unittest.TestCase):
         """)
         result = _run_extraction_fixed(issue_creation, task_description, gh_mock)
         self.assertEqual(result, "3983", "Should fall through to Tier 3 and find #3983")
+
+    def test_tier2_without_linked_issue_or_task_ref_uses_pr_number(self):
+        """
+        Tier 2 terminal fallback: if a PR URL exists but there is no linked issue
+        and no valid task_description issue reference, step-03b must keep moving by
+        using the PR number as the numeric reference.
+        """
+        issue_creation = "https://github.com/org/repo/pull/4000\n"
+        gh_mock = textwrap.dedent("""\
+            #!/bin/bash
+            if [[ "$1" == "pr" && "$2" == "view" && "$3" == "4000" ]]; then
+              echo ""
+              exit 0
+            fi
+            exit 1
+        """)
+        result = _run_extraction_fixed(issue_creation, task_description="", gh_mock=gh_mock)
+        self.assertEqual(result, "4000", "Should fall back to the PR number when no issue exists")
 
     def test_tier3_skips_candidate_whose_gh_url_is_a_pr(self):
         """

--- a/tests/recipes/test_default_workflow_audit_remediation_4205.py
+++ b/tests/recipes/test_default_workflow_audit_remediation_4205.py
@@ -155,6 +155,13 @@ class TestReviewGateRemediations:
         assert 'BASE_WORKTREE_REF="HEAD"' in cmd
         assert 'git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" "$BASE_WORKTREE_REF"' in cmd
 
+    def test_step_04_reuses_existing_checkout_before_adding_worktree(self, step_map):
+        cmd = _get_step(step_map, "step-04-setup-worktree").get("command", "")
+        assert 'git -C "$WORKTREE_PATH" rev-parse --is-inside-work-tree' in cmd
+        assert 'git -C "$WORKTREE_PATH" branch --show-current' in cmd
+        assert "already exists but is not a valid git worktree checkout" in cmd
+        assert "exists but no reusable checkout was found" in cmd
+
     def test_step_03_label_creation_failure_is_not_silenced(self, step_map):
         cmd = _get_step(step_map, "step-03-create-issue").get("command", "")
         assert '--description "Created by default-workflow recipe" 2>/dev/null || true' not in cmd

--- a/tests/recipes/test_default_workflow_resumable_timeouts.py
+++ b/tests/recipes/test_default_workflow_resumable_timeouts.py
@@ -60,7 +60,12 @@ def test_step_04b_validate_worktree_uses_json_encoder(steps: dict[str, dict]):
 
 @pytest.mark.parametrize(
     "step_id",
-    ["step-07-write-tests", "step-08-implement", "checkpoint-after-implementation"],
+    [
+        "step-07-write-tests",
+        "step-08-implement",
+        "step-08b-integration",
+        "checkpoint-after-implementation",
+    ],
 )
 def test_pre_checkpoint_steps_skip_when_resume_checkpoint_exists(
     steps: dict[str, dict], step_id: str
@@ -68,6 +73,11 @@ def test_pre_checkpoint_steps_skip_when_resume_checkpoint_exists(
     condition = steps[step_id].get("condition", "")
     assert "resume_checkpoint" in condition
     assert "checkpoint-after-implementation" in condition
+    assert "checkpoint-after-review-feedback" in condition
+    assert "not in [" not in condition
+    assert "[" not in condition
+    assert "resume_checkpoint !=" in condition
+    assert " and " in condition
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- keep step-03b moving when step-03 returns a PR URL with no linked issue
- preserve current priority order: direct issue URL, linked closing issue, task-description issue refs, then PR number fallback
- add helper and direct-YAML regression coverage for the PR-only case

## Validation
- PYTHONPATH=amplifier-bundle/tools python -m unittest -v test_default_workflow_fixes.TestExtractIssueNumber.test_extract_issue_number_resolves_closing_issue_from_pr_url test_default_workflow_fixes.TestStep03bThreeTierEdgeCases.test_tier2_fallback_when_closing_issues_empty_uses_tier3 test_default_workflow_fixes.TestStep03bThreeTierEdgeCases.test_tier2_without_linked_issue_or_task_ref_uses_pr_number test_default_workflow_fixes.TestYAMLBugRegression.test_yaml_step03b_pr_without_linked_issue_uses_pr_number