### PR TITLE
fix: update default-workflow and investigation-workflow skills to use recipe runner

### DIFF
--- a/.claude/skills/default-workflow/SKILL.md
+++ b/.claude/skills/default-workflow/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: default-workflow
-version: 1.1.0
-description: Development workflow for features, bugs, refactoring. Auto-activates for multi-file implementations.
+version: 2.0.0
+description: |
+  Development workflow for features, bugs, refactoring. Normally executed as a
+  sub-recipe by dev-orchestrator/smart-orchestrator. Supports direct invocation
+  via recipe runner for standalone use.
 auto_activates:
   - "implement feature spanning multiple files"
   - "complex integration across components"
   - "refactor affecting 5+ files"
 explicit_triggers:
-  - /ultrathink
   - /amplihack:default-workflow
 confirmation_required: true
 skip_confirmation_if_explicit: true
@@ -15,6 +17,21 @@ token_budget: 4500
 ---
 
 # Default Workflow Skill
+
+## Relationship to Dev Orchestrator
+
+**Normal execution path**: This workflow is invoked as a sub-recipe by the
+`dev-orchestrator` skill via `smart-orchestrator`. You do NOT normally need
+to activate this skill directly.
+
+```
+User request → dev-orchestrator → smart-orchestrator recipe
+    → default-workflow recipe (this skill's recipe)
+```
+
+**Direct invocation** is supported as a compatibility path when the
+dev-orchestrator is unavailable or when explicitly requested. In that case,
+use the recipe runner (see Execution Instructions below).
 
 ## Workflow Graph
 
@@ -100,56 +117,72 @@ flowchart TD
 
 ## Purpose
 
-This skill provides the standard development workflow for all non-trivial code changes in amplihack. It auto-activates when detecting multi-file implementations, complex integrations, or significant refactoring work.
+This skill provides the standard development workflow for all non-trivial code changes
+in amplihack. It is normally executed as a sub-recipe by the `dev-orchestrator` via
+`smart-orchestrator`, but can also be invoked directly via the recipe runner.
 
-The workflow defines the canonical execution process: from requirements clarification through design, implementation, testing, review, and merge. It ensures consistent quality by orchestrating specialized agents at each step and enforcing philosophy compliance throughout.
+The workflow defines the canonical execution process: from requirements clarification
+through design, implementation, testing, review, and merge. It ensures consistent
+quality by orchestrating specialized agents at each step and enforcing philosophy
+compliance throughout.
 
-This is a thin wrapper that references the complete workflow definition stored in a single canonical location, ensuring no duplication or drift between the skill interface and the workflow specification.
+## Canonical Sources
 
-## Canonical Source
+- **Executable source (recipe)**: `amplifier-bundle/recipes/default-workflow.yaml`
+- **Reference documentation**: `.claude/workflow/DEFAULT_WORKFLOW.md`
 
-**This skill is a thin wrapper that references the canonical workflow:**
-
-**Source**: `~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md` (471+ lines)
-
-The canonical workflow contains the complete development process with all details, agent specifications, and execution guidance.
+The recipe YAML is the authoritative execution definition. The `.md` file serves as
+human-readable reference documentation for the workflow steps.
 
 ## Execution Instructions
 
-When this skill is activated, you MUST:
+### Normal path (via dev-orchestrator)
 
-1. **Read the canonical workflow** immediately:
+If you reached this skill via `dev-orchestrator` / `smart-orchestrator`, the recipe
+runner is already managing execution. **Do not re-invoke the recipe runner.** The
+orchestrator handles the full lifecycle including goal-seeking reflection loops.
 
-   ```
-   Read(file_path="~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md")
-   ```
+### Direct invocation (standalone)
 
-   Note: Path is relative to project root. Claude Code resolves this automatically.
+If this skill is activated directly (not via dev-orchestrator), you MUST use the
+recipe runner — **do NOT read the .md file and follow steps manually**:
 
-2. **Follow all steps** exactly as specified in the canonical workflow
+```python
+from amplihack.recipes import run_recipe_by_name
 
-3. **Use TodoWrite** to track progress through workflow steps with format:
-   - `Step N: [Step Name] - [Specific Action]`
-   - Example: `Step 1: Rewrite and Clarify Requirements - Use prompt-writer agent`
-   - This helps users track exactly which workflow step is active
+result = run_recipe_by_name(
+    "default-workflow",
+    user_context={
+        "task_description": "TASK_DESCRIPTION_HERE",
+        "repo_path": ".",
+    },
+    progress=True,
+)
+```
 
-4. **Invoke specialized agents** as specified in each workflow step:
-   - Step 1: prompt-writer, analyzer, ambiguity agents
-   - Step 4: architect, api-designer, database, tester, security agents
-   - Step 5: builder, integration agents
-   - Step 6: cleanup, optimizer agents
-   - Step 7: pre-commit-diagnostic agent
-   - Step 9-15: Review and merge agents
+Or via shell:
 
-## Why This Pattern
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
+from amplihack.recipes import run_recipe_by_name
+result = run_recipe_by_name('default-workflow', user_context={
+    'task_description': '''TASK_DESCRIPTION_HERE''',
+    'repo_path': '.',
+}, progress=True)
+print(f'Recipe result: {result}')
+"
+```
 
-**Benefits:**
+**Do NOT** read `DEFAULT_WORKFLOW.md` and follow steps manually. The recipe runner
+enforces step ordering, recursion guards, checkpoints, and quality gates that manual
+execution cannot replicate.
 
-- Single source of truth for workflow definition
-- No content duplication or drift
-- Changes to workflow made once in canonical location
-- Clear delegation contract between skill and workflow
-- Reduced token usage (skill is ~60 lines vs 471+ in canonical source)
+### Preferred: Use dev-orchestrator instead
+
+For most tasks, invoke `Skill(skill="dev-orchestrator")` or use `/dev <task>` rather
+than activating this skill directly. The dev-orchestrator adds goal-seeking reflection,
+workstream decomposition, and adaptive error recovery on top of this workflow.
 
 ## Auto-Activation Triggers
 
@@ -159,6 +192,9 @@ This skill auto-activates for:
 - Complex integrations across components
 - Refactoring affecting 5+ files
 - Any non-trivial code changes requiring structured workflow
+
+**Note**: The `dev-orchestrator` skill has higher priority and broader triggers.
+In most cases, it will activate first and invoke this workflow as a sub-recipe.
 
 ## Known Failure Points & Resilience Guidance
 
@@ -204,17 +240,18 @@ MUST apply the documented resilience patterns when encountering these steps.
 
 The workflow creates automatic checkpoints at these points to prevent work loss:
 
-| Checkpoint | After Step | Preserves |
-|---|---|---|
-| `checkpoint-after-design` | 5e (Design Consolidation) | Architecture decisions, API design, DB schema |
-| `checkpoint-after-implementation` | 8b (Integration) | Tests, implementation code, integration work |
-| `checkpoint-after-review-feedback` | 11b (Implement Feedback) | Review-addressed changes |
+| Checkpoint                         | After Step                | Preserves                                     |
+| ---------------------------------- | ------------------------- | --------------------------------------------- |
+| `checkpoint-after-design`          | 5e (Design Consolidation) | Architecture decisions, API design, DB schema |
+| `checkpoint-after-implementation`  | 8b (Integration)          | Tests, implementation code, integration work  |
+| `checkpoint-after-review-feedback` | 11b (Implement Feedback)  | Review-addressed changes                      |
 
 If a step fails after a checkpoint, the worktree branch retains all committed work. Agents can resume from the latest checkpoint by re-running the workflow with the existing worktree.
 
 ## Related Files
 
-- **Canonical Workflow**: `~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md`
-- **Command Interface**: `~/.amplihack/.claude/commands/amplihack/ultrathink.md`
-- **Orchestrator Skill**: `~/.amplihack/.claude/skills/ultrathink-orchestrator/`
-- **Investigation Workflow**: `~/.amplihack/.claude/skills/investigation-workflow/`
+- **Recipe (executable)**: `amplifier-bundle/recipes/default-workflow.yaml`
+- **Reference docs**: `.claude/workflow/DEFAULT_WORKFLOW.md`
+- **Command Interface**: `.claude/commands/amplihack/dev.md`
+- **Orchestrator Skill**: `.claude/skills/dev-orchestrator/`
+- **Investigation Workflow**: `.claude/skills/investigation-workflow/`

--- a/.claude/skills/investigation-workflow/SKILL.md
+++ b/.claude/skills/investigation-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: investigation-workflow
-version: 1.0.0
+version: 2.0.0
 description: |
-  6-phase investigation workflow for understanding existing systems. Auto-activates for research tasks.
-  Optimized for exploration and understanding, not implementation. Includes parallel agent deployment
-  for efficient deep dives and automatic knowledge capture to prevent repeat investigations.
+  6-phase investigation workflow for understanding existing systems. Normally executed
+  as a sub-recipe by dev-orchestrator/smart-orchestrator. Supports direct invocation
+  via recipe runner for standalone use.
 auto_activates:
   - "investigate how"
   - "explain the architecture"
@@ -15,14 +15,28 @@ auto_activates:
   - "research"
   - "explore"
 explicit_triggers:
-  - /amplihack:investigation-workflow
-  - /investigate
+  - /amplihack:investigation
 confirmation_required: true
 skip_confirmation_if_explicit: true
 token_budget: 4000
 ---
 
 # Investigation Workflow Skill
+
+## Relationship to Dev Orchestrator
+
+**Normal execution path**: This workflow is invoked as a sub-recipe by the
+`dev-orchestrator` skill via `smart-orchestrator`. You do NOT normally need
+to activate this skill directly.
+
+```
+User request → dev-orchestrator → smart-orchestrator recipe
+    → investigation-workflow recipe (this skill's recipe)
+```
+
+**Direct invocation** is supported as a compatibility path when the
+dev-orchestrator is unavailable or when explicitly requested. In that case,
+use the recipe runner (see Execution Instructions below).
 
 ## Workflow Graph
 
@@ -79,13 +93,77 @@ flowchart TD
     EFF --> FINAL[final-output]
 
     TRANS --> TDEV{Transition to dev?}
-    TDEV -->|yes| DW[Resume DEFAULT_WORKFLOW<br/>at Step 4 or 5]
+    TDEV -->|yes| DW[Launch default-workflow<br/>recipe via recipe runner]
     TDEV -->|no| DONE[Investigation Complete]
 ```
 
 ## Purpose
 
-This skill provides a systematic 6-phase workflow for investigating and understanding existing systems, codebases, and architectures. Unlike development workflows optimized for implementation, this workflow is optimized for exploration, understanding, and knowledge capture.
+This skill provides a systematic 6-phase workflow for investigating and understanding
+existing systems, codebases, and architectures. Unlike development workflows optimized
+for implementation, this workflow is optimized for exploration, understanding, and
+knowledge capture.
+
+It is normally executed as a sub-recipe by the `dev-orchestrator` via `smart-orchestrator`,
+but can also be invoked directly via the recipe runner.
+
+## Canonical Sources
+
+- **Executable source (recipe)**: `amplifier-bundle/recipes/investigation-workflow.yaml`
+- **Reference documentation**: `.claude/workflow/INVESTIGATION_WORKFLOW.md`
+
+The recipe YAML is the authoritative execution definition. The `.md` file serves as
+human-readable reference documentation for the workflow phases.
+
+## Execution Instructions
+
+### Normal path (via dev-orchestrator)
+
+If you reached this skill via `dev-orchestrator` / `smart-orchestrator`, the recipe
+runner is already managing execution. **Do not re-invoke the recipe runner.** The
+orchestrator handles the full lifecycle including goal-seeking reflection loops.
+
+### Direct invocation (standalone)
+
+If this skill is activated directly (not via dev-orchestrator), you MUST use the
+recipe runner — **do NOT read the .md file and follow phases manually**:
+
+```python
+from amplihack.recipes import run_recipe_by_name
+
+result = run_recipe_by_name(
+    "investigation-workflow",
+    user_context={
+        "task_description": "TASK_DESCRIPTION_HERE",
+        "repo_path": ".",
+    },
+    progress=True,
+)
+```
+
+Or via shell:
+
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
+from amplihack.recipes import run_recipe_by_name
+result = run_recipe_by_name('investigation-workflow', user_context={
+    'task_description': '''TASK_DESCRIPTION_HERE''',
+    'repo_path': '.',
+}, progress=True)
+print(f'Recipe result: {result}')
+"
+```
+
+**Do NOT** read `INVESTIGATION_WORKFLOW.md` and follow phases manually. The recipe
+runner enforces phase ordering, agent deployment, and quality gates that manual
+execution cannot replicate.
+
+### Preferred: Use dev-orchestrator instead
+
+For most tasks, invoke `Skill(skill="dev-orchestrator")` or use `/dev <task>` rather
+than activating this skill directly. The dev-orchestrator adds goal-seeking reflection,
+workstream decomposition, and adaptive error recovery on top of this workflow.
 
 ## When to Use This Skill
 
@@ -97,7 +175,7 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - "Analyze the reflection system architecture"
 - "Research what hooks are triggered during session start"
 
-**Development Tasks** (use DEFAULT_WORKFLOW.md instead):
+**Development Tasks** (use default-workflow recipe instead):
 
 - "Implement OAuth support"
 - "Build a new API endpoint"
@@ -127,20 +205,6 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - Set boundaries: What's in scope vs. out of scope
 - Estimate investigation depth needed (surface-level vs. deep dive)
 
-**Success Criteria**:
-
-- Clear list of questions to answer
-- Defined scope boundaries
-- Measurable success criteria (e.g., "can explain system flow", "can diagram architecture")
-
-**Deliverables**:
-
-- Investigation scope document with:
-  - Core questions to answer
-  - Success criteria
-  - Scope boundaries (what's included/excluded)
-  - Estimated depth and timeline
-
 ### Phase 2: Exploration Strategy
 
 **Purpose**: Plan which agents to deploy and what to investigate, preventing inefficient random exploration.
@@ -151,31 +215,6 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - **Use** patterns agent to check for similar past investigations
 - Identify key areas to explore (code paths, configurations, documentation)
 - Select specialized agents for parallel deployment in Phase 3
-- Create investigation roadmap with priorities
-- Identify potential dead ends to avoid
-- Plan verification approach (how to test understanding)
-
-**Agent Selection Guidelines**:
-
-- **For code understanding**: analyzer, patterns agents
-- **For system architecture**: architect, api-designer agents
-- **For performance issues**: optimizer, analyzer agents
-- **For security concerns**: security, patterns agents
-- **For integration flows**: integration, database agents
-
-**Success Criteria**:
-
-- Clear exploration roadmap
-- List of agents to deploy in Phase 3
-- Prioritized investigation areas
-
-**Deliverables**:
-
-- Exploration strategy document with:
-  - Investigation roadmap
-  - Agent deployment plan for Phase 3
-  - Priority order for exploration
-  - Expected outputs from each exploration
 
 ### Phase 3: Parallel Deep Dives
 
@@ -183,292 +222,51 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 
 **CRITICAL**: This phase uses PARALLEL EXECUTION by default.
 
-**Tasks**:
-
-- **Deploy selected agents in PARALLEL** based on Phase 2 strategy
-- **Common parallel patterns**:
-  - `[analyzer(module1), analyzer(module2), analyzer(module3)]` - Multiple code areas
-  - `[analyzer, patterns, security]` - Multiple perspectives on same area
-  - `[architect, database, integration]` - System architecture exploration
-- Each agent explores their assigned area independently
-- Collect findings from all parallel explorations
-- Identify connections and dependencies between findings
-- Note any unexpected discoveries or anomalies
-
-**Parallel Agent Examples**:
-
-```
-Investigation: "How does the reflection system work?"
-→ [analyzer(~/.amplihack/.claude/tools/amplihack/hooks/), patterns(reflection), integration(logging)]
-
-Investigation: "Why is CI failing?"
-→ [analyzer(ci-config), patterns(ci-failures), integration(github-actions)]
-
-Investigation: "Understand authentication flow"
-→ [analyzer(auth-module), security(auth), patterns(auth), integration(external-auth)]
-```
-
-**Success Criteria**:
-
-- All planned agents deployed and completed
-- Findings from each exploration collected
-- Connections between findings identified
-
-**Deliverables**:
-
-- Findings report with:
-  - Summary from each parallel exploration
-  - Code paths and flow diagrams
-  - Architectural insights
-  - Unexpected discoveries
-  - Open questions for verification
-
 ### Phase 4: Verification & Testing
 
 **Purpose**: Test and validate understanding through practical application.
-
-**Tasks**:
-
-- Create hypotheses based on Phase 3 findings
-- **Design practical tests** to verify understanding:
-  - Trace specific code paths manually
-  - Examine logs and outputs
-  - Test edge cases and assumptions
-  - Verify configuration effects
-- Run verification tests
-- **Document what was tested and results**
-- Identify gaps in understanding
-- Refine hypotheses based on test results
-- Repeat verification for any unclear areas
-
-**Verification Examples**:
-
-```
-Understanding: "Authentication uses JWT tokens"
-Verification: Trace actual token creation and validation in code
-
-Understanding: "CI fails because of dependency conflict"
-Verification: Check CI logs, reproduce locally, verify fix works
-
-Understanding: "Reflection analyzes all user messages"
-Verification: Examine reflection logs, trace message processing
-```
-
-**Success Criteria**:
-
-- All hypotheses tested
-- Understanding verified through practical tests
-- Gaps in understanding identified and filled
-
-**Deliverables**:
-
-- Verification report with:
-  - Tests performed
-  - Results and observations
-  - Confirmed understanding
-  - Remaining gaps or uncertainties
 
 ### Phase 5: Synthesis
 
 **Purpose**: Compile findings into coherent explanation that answers original questions.
 
-**Tasks**:
-
-- **Use** reviewer agent to check completeness of findings
-- **Use** patterns agent to identify reusable patterns discovered
-- Synthesize findings from Phases 3-4 into coherent explanation
-- Create visual artifacts (diagrams, flow charts) if helpful
-- Answer each question from Phase 1 scope definition
-- Identify what worked well vs. what was unexpected
-- Note any assumptions or uncertainties remaining
-- Prepare clear explanation suitable for user
-
-**Synthesis Outputs**:
-
-1. **Executive Summary**: 2-3 sentence answer to main question
-2. **Detailed Explanation**: Complete explanation with supporting evidence
-3. **Visual Aids**: Diagrams showing system flow, architecture, etc.
-4. **Key Insights**: Non-obvious discoveries or patterns
-5. **Remaining Unknowns**: What's still unclear or uncertain
-
-**Success Criteria**:
-
-- All Phase 1 questions answered
-- Explanation is clear and complete
-- Findings supported by evidence from verification
-- Visual aids clarify complex areas
-
-**Deliverables**:
-
-- Investigation report with all 5 synthesis outputs
-- Ready for knowledge capture in Phase 6
-
 ### Phase 6: Knowledge Capture
 
 **Purpose**: Create durable documentation so this investigation never needs to be repeated.
 
-**Tasks**:
-
 - **Store discoveries in memory** using `store_discovery()` from `amplihack.memory.discoveries`
 - **Update .claude/context/PATTERNS.md** if reusable patterns found
-- Create or update relevant documentation files
-- Add inline code comments for critical understanding
-- **Optional**: Create GitHub issue for follow-up improvements
-- **Optional**: Update architecture diagrams if needed
-- Ensure future investigators can find this knowledge easily
-
-**Documentation Guidelines**:
-
-```markdown
-## Discovery: [Brief Title]
-
-**Context**: What was investigated and why
-**Key Findings**:
-
-- Main insight 1
-- Main insight 2
-  - **Supporting Evidence**: Links to code, logs, or verification tests
-  - **Implications**: How this affects the project
-  - **Related Patterns**: Links to similar patterns in PATTERNS.md
-```
-
-**Success Criteria**:
-
-- Discoveries stored in memory for future reference
-- Relevant documentation files updated
-- Knowledge is discoverable by future investigators
-- No information loss
-
-**Deliverables**:
-
-- Discoveries stored in memory
-- Updated PATTERNS.md (if applicable)
-- Updated project documentation
-- Optional: GitHub issues for improvements
-- Investigation session log in `~/.amplihack/.claude/runtime/logs/`
 
 ## Transitioning to Development Workflow
 
-**After investigation completes**, if the task requires implementation (not just understanding), transition to **DEFAULT_WORKFLOW.md**:
+**After investigation completes**, if the task requires implementation, the
+`dev-orchestrator` handles the transition automatically via its goal-seeking
+reflection loop. If running standalone, transition by launching the
+`default-workflow` recipe:
 
-1. **Resume at Step 4** (Research and Design) with the knowledge gained from investigation
-2. **Or resume at Step 5** (Implement the Solution) if the investigation already provided clear design guidance
-3. **Use investigation findings** from memory (via `get_recent_discoveries()`) and session logs to inform design decisions
-
-**Example Hybrid Workflow**:
-
-```
-User: "/ultrathink investigate how authentication works, then add OAuth support"
-
-Phase 1: Investigation
-→ Run INVESTIGATION_WORKFLOW.md (6 phases)
-→ Complete understanding of existing auth system
-→ Store findings in memory via discoveries adapter
-
-Phase 2: Development
-→ Transition to DEFAULT_WORKFLOW.md
-→ Resume at Step 4 (Research and Design)
-→ Use investigation insights to design OAuth integration
-→ Continue through Step 15 (implementation → testing → PR)
+```python
+run_recipe_by_name("default-workflow", user_context={
+    "task_description": "Implement findings from investigation...",
+    "repo_path": ".",
+}, progress=True)
 ```
 
-**When to Transition**:
+## Integration with Dev Orchestrator
 
-- Investigation reveals implementation is needed
-- User explicitly requested both investigation + development
-- Follow-up work identified during knowledge capture
-
-## Efficiency Targets
-
-**Target Efficiency**: This workflow targets a 30-40% reduction in message count compared to ad-hoc investigation.
-
-| Ad-Hoc Approach         | Investigation Workflow    |
-| ----------------------- | ------------------------- |
-| 70-90 messages          | 40-60 messages            |
-| Frequent backtracking   | Planned exploration       |
-| Redundant investigation | Parallel deep dives       |
-| Unclear scope           | Explicit scope definition |
-| Lost knowledge          | Documented insights       |
-
-**Efficiency Gains Come From**:
-
-1. **Scope Definition** prevents scope creep and wandering
-2. **Exploration Strategy** prevents random unproductive exploration
-3. **Parallel Deep Dives** maximize information gathering speed
-4. **Verification Phase** catches misunderstandings early
-5. **Synthesis** ensures all questions answered
-6. **Knowledge Capture** prevents repeat investigations
-
-## Comparison to DEFAULT_WORKFLOW.md
-
-### Similarities (Structural Consistency)
-
-Both workflows share core principles:
-
-- Explicit phases with clear deliverables
-- Agent-driven execution at each phase
-- Quality gates preventing premature progression
-- Knowledge capture and documentation
-- TodoWrite tracking for progress management
-
-### Differences (Investigation vs. Development)
-
-| Aspect             | Investigation Workflow     | DEFAULT_WORKFLOW.md      |
-| ------------------ | -------------------------- | ------------------------ |
-| **Goal**           | Understanding              | Implementation           |
-| **Phases**         | 6 phases                   | Multi-step workflow      |
-| **Execution**      | Exploration-first          | Implementation-first     |
-| **Parallel Focus** | Phase 3 (Deep Dives)       | Various steps            |
-| **Testing**        | Understanding verification | Code validation          |
-| **Deliverable**    | Documentation              | Working code             |
-| **Git Usage**      | Optional                   | Required (branches, PRs) |
-
-### Phase Mapping (For User Familiarity)
-
-| Investigation Phase           | DEFAULT_WORKFLOW Equivalent        | Purpose                              |
-| ----------------------------- | ---------------------------------- | ------------------------------------ |
-| Phase 1: Scope Definition     | Step 1: Requirements Clarification | Define what success looks like       |
-| Phase 2: Exploration Strategy | Step 4: Research and Design        | Plan the approach                    |
-| Phase 3: Parallel Deep Dives  | Step 5: Implementation             | Execute the plan (explore vs. build) |
-| Phase 4: Verification         | Steps 7-8: Testing                 | Validate results                     |
-| Phase 5: Synthesis            | Step 11: Review                    | Ensure quality and completeness      |
-| Phase 6: Knowledge Capture    | Step 15: Cleanup                   | Make results durable                 |
-
-## Integration with UltraThink
-
-**UltraThink Workflow Detection**: When `/ultrathink` is invoked, it automatically detects investigation tasks using keywords and suggests this workflow.
-
-**Automatic Workflow Suggestion**:
+The `dev-orchestrator` automatically detects investigation tasks using keywords
+and routes them to this workflow's recipe:
 
 ```
-User: "/ultrathink investigate how authentication works"
+User: "/dev investigate how authentication works"
 
-UltraThink: Detected investigation task. Using INVESTIGATION_WORKFLOW.md
-→ Reading workflow from .claude/workflow/INVESTIGATION_WORKFLOW.md
-→ Following 6-phase investigation workflow
-→ Starting Phase 1: Scope Definition
+dev-orchestrator: Classified as Investigation → launching investigation-workflow recipe
+→ Recipe runner executes 6-phase investigation workflow
+→ Results feed into goal-seeking reflection loop
 ```
 
-## Customization
-
-To customize this workflow:
-
-1. Edit `~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md` to modify, add, or remove phases
-2. Adjust agent deployment strategies for your needs
-3. Add project-specific investigation patterns
-4. Update efficiency targets based on your metrics
-
-Changes take effect immediately for future investigations.
-
-## Success Metrics
-
-Track these metrics to validate workflow effectiveness:
-
-- **Message Count**: Target 30-40% reduction vs. ad-hoc (to be validated)
-- **Investigation Time**: Track time to completion
-- **Knowledge Reuse**: How often memory retrieval prevents repeat work
-- **Completeness**: Percentage of investigations with full documentation
-- **User Satisfaction**: Clear understanding achieved
+For hybrid tasks (investigate + implement), the dev-orchestrator decomposes into
+parallel workstreams: one running `investigation-workflow`, another running
+`default-workflow`.
 
 ## Key Principles
 
@@ -478,14 +276,11 @@ Track these metrics to validate workflow effectiveness:
 - **Capture knowledge** - Always store discoveries in memory in Phase 6
 - **This workflow optimizes for understanding, not implementation**
 
-When in doubt about investigation vs. development:
-
-- **Investigation**: "I need to understand X"
-- **Development**: "I need to build/fix/implement X"
-
 ## Related Resources
 
-- **Source Workflow**: `~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md` (complete 436-line specification)
-- **Knowledge Extraction**: Use knowledge-extractor skill after investigations to capture learnings
-- **Agent Catalog**: `~/.amplihack/.claude/agents/CATALOG.md` for all available agents
-- **Pattern Library**: `~/.amplihack/.claude/context/PATTERNS.md` for reusable investigation patterns
+- **Recipe (executable)**: `amplifier-bundle/recipes/investigation-workflow.yaml`
+- **Reference docs**: `.claude/workflow/INVESTIGATION_WORKFLOW.md`
+- **Dev Orchestrator**: `.claude/skills/dev-orchestrator/`
+- **Default Workflow**: `.claude/skills/default-workflow/`
+- **Agent Catalog**: `.claude/agents/amplihack/` directory
+- **Pattern Library**: `.claude/context/PATTERNS.md`

--- a/.claude/tests/agentic/workflow-skill-recipe-runner-alignment.yaml
+++ b/.claude/tests/agentic/workflow-skill-recipe-runner-alignment.yaml
@@ -1,0 +1,105 @@
+# Workflow Skill Recipe Runner Alignment Test
+# Verifies that workflow skills direct agents to use the recipe runner
+# instead of manually reading .md workflow files.
+
+scenario:
+  name: "Workflow Skills Use Recipe Runner"
+  description: >
+    Verify default-workflow and investigation-workflow skills reference the recipe
+    runner (run_recipe_by_name) as the execution path, not manual .md file reading.
+    Also verifies no stale ultrathink references remain.
+  type: cli
+  level: 1
+
+  tags: [skills, workflow, recipe-runner, alignment, smoke]
+
+  prerequisites:
+    - "amplihack repo cloned"
+
+  agents:
+    - name: "cli-agent"
+      type: "system"
+      config:
+        shell: "bash"
+        timeout: 30000
+
+  steps:
+    - action: execute
+      params:
+        command: "grep -c 'run_recipe_by_name' .claude/skills/default-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+      description: "default-workflow references run_recipe_by_name"
+
+    - action: execute
+      params:
+        command: "grep -c 'run_recipe_by_name' .claude/skills/investigation-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+      description: "investigation-workflow references run_recipe_by_name"
+
+    - action: execute
+      params:
+        command: "! grep -qE 'Read\\(file_path.*DEFAULT_WORKFLOW|Read\\(file_path.*INVESTIGATION_WORKFLOW' .claude/skills/default-workflow/SKILL.md .claude/skills/investigation-workflow/SKILL.md 2>/dev/null && echo NO_STALE_READ"
+      expect:
+        stdout_contains: "NO_STALE_READ"
+      description: "No stale Read(file_path=...) instructions to manually read .md files"
+
+    - action: execute
+      params:
+        command: "! grep -q 'ultrathink-orchestrator' .claude/skills/default-workflow/SKILL.md .claude/skills/investigation-workflow/SKILL.md 2>/dev/null && echo NO_STALE_ULTRATHINK"
+      expect:
+        stdout_contains: "NO_STALE_ULTRATHINK"
+      description: "No stale ultrathink-orchestrator references"
+
+    - action: execute
+      params:
+        command: "grep 'recipes/default-workflow.yaml' .claude/skills/default-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+        stdout_contains: "recipes/default-workflow.yaml"
+      description: "default-workflow canonical source points to recipe yaml"
+
+    - action: execute
+      params:
+        command: "grep 'recipes/investigation-workflow.yaml' .claude/skills/investigation-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+        stdout_contains: "recipes/investigation-workflow.yaml"
+      description: "investigation-workflow canonical source points to recipe yaml"
+
+    - action: execute
+      params:
+        command: "grep -c 'dev-orchestrator' .claude/skills/default-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+      description: "default-workflow references dev-orchestrator"
+
+    - action: execute
+      params:
+        command: "grep -c 'dev-orchestrator' .claude/skills/investigation-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+      description: "investigation-workflow references dev-orchestrator"
+
+    - action: execute
+      params:
+        command: "grep 'run_recipe_by_name.*default-workflow' .claude/skills/default-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+        stdout_contains: "default-workflow"
+      description: "default-workflow passes correct recipe name to run_recipe_by_name"
+
+    - action: execute
+      params:
+        command: "grep 'run_recipe_by_name.*investigation-workflow' .claude/skills/investigation-workflow/SKILL.md"
+      expect:
+        exit_code: 0
+        stdout_contains: "investigation-workflow"
+      description: "investigation-workflow passes correct recipe name to run_recipe_by_name"
+
+  success_criteria:
+    - "All workflow skills reference run_recipe_by_name as execution path"
+    - "No stale Read(file_path=...) instructions for manual .md reading"
+    - "No ultrathink-orchestrator references remain"
+    - "Canonical sources point to recipe yaml files"

--- a/amplifier-bundle/skills/default-workflow/SKILL.md
+++ b/amplifier-bundle/skills/default-workflow/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: default-workflow
-version: 1.1.0
-description: Development workflow for features, bugs, refactoring. Auto-activates for multi-file implementations.
+version: 2.0.0
+description: |
+  Development workflow for features, bugs, refactoring. Normally executed as a
+  sub-recipe by dev-orchestrator/smart-orchestrator. Supports direct invocation
+  via recipe runner for standalone use.
 auto_activates:
   - "implement feature spanning multiple files"
   - "complex integration across components"
   - "refactor affecting 5+ files"
 explicit_triggers:
-  - /ultrathink
   - /amplihack:default-workflow
 confirmation_required: true
 skip_confirmation_if_explicit: true
@@ -15,6 +17,21 @@ token_budget: 4500
 ---
 
 # Default Workflow Skill
+
+## Relationship to Dev Orchestrator
+
+**Normal execution path**: This workflow is invoked as a sub-recipe by the
+`dev-orchestrator` skill via `smart-orchestrator`. You do NOT normally need
+to activate this skill directly.
+
+```
+User request → dev-orchestrator → smart-orchestrator recipe
+    → default-workflow recipe (this skill's recipe)
+```
+
+**Direct invocation** is supported as a compatibility path when the
+dev-orchestrator is unavailable or when explicitly requested. In that case,
+use the recipe runner (see Execution Instructions below).
 
 ## Workflow Graph
 
@@ -100,56 +117,72 @@ flowchart TD
 
 ## Purpose
 
-This skill provides the standard development workflow for all non-trivial code changes in amplihack. It auto-activates when detecting multi-file implementations, complex integrations, or significant refactoring work.
+This skill provides the standard development workflow for all non-trivial code changes
+in amplihack. It is normally executed as a sub-recipe by the `dev-orchestrator` via
+`smart-orchestrator`, but can also be invoked directly via the recipe runner.
 
-The workflow defines the canonical execution process: from requirements clarification through design, implementation, testing, review, and merge. It ensures consistent quality by orchestrating specialized agents at each step and enforcing philosophy compliance throughout.
+The workflow defines the canonical execution process: from requirements clarification
+through design, implementation, testing, review, and merge. It ensures consistent
+quality by orchestrating specialized agents at each step and enforcing philosophy
+compliance throughout.
 
-This is a thin wrapper that references the complete workflow definition stored in a single canonical location, ensuring no duplication or drift between the skill interface and the workflow specification.
+## Canonical Sources
 
-## Canonical Source
+- **Executable source (recipe)**: `amplifier-bundle/recipes/default-workflow.yaml`
+- **Reference documentation**: `.claude/workflow/DEFAULT_WORKFLOW.md`
 
-**This skill is a thin wrapper that references the canonical workflow:**
-
-**Source**: `~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md` (471+ lines)
-
-The canonical workflow contains the complete development process with all details, agent specifications, and execution guidance.
+The recipe YAML is the authoritative execution definition. The `.md` file serves as
+human-readable reference documentation for the workflow steps.
 
 ## Execution Instructions
 
-When this skill is activated, you MUST:
+### Normal path (via dev-orchestrator)
 
-1. **Read the canonical workflow** immediately:
+If you reached this skill via `dev-orchestrator` / `smart-orchestrator`, the recipe
+runner is already managing execution. **Do not re-invoke the recipe runner.** The
+orchestrator handles the full lifecycle including goal-seeking reflection loops.
 
-   ```
-   Read(file_path="~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md")
-   ```
+### Direct invocation (standalone)
 
-   Note: Path is relative to project root. Claude Code resolves this automatically.
+If this skill is activated directly (not via dev-orchestrator), you MUST use the
+recipe runner — **do NOT read the .md file and follow steps manually**:
 
-2. **Follow all steps** exactly as specified in the canonical workflow
+```python
+from amplihack.recipes import run_recipe_by_name
 
-3. **Use TodoWrite** to track progress through workflow steps with format:
-   - `Step N: [Step Name] - [Specific Action]`
-   - Example: `Step 1: Rewrite and Clarify Requirements - Use prompt-writer agent`
-   - This helps users track exactly which workflow step is active
+result = run_recipe_by_name(
+    "default-workflow",
+    user_context={
+        "task_description": "TASK_DESCRIPTION_HERE",
+        "repo_path": ".",
+    },
+    progress=True,
+)
+```
 
-4. **Invoke specialized agents** as specified in each workflow step:
-   - Step 1: prompt-writer, analyzer, ambiguity agents
-   - Step 4: architect, api-designer, database, tester, security agents
-   - Step 5: builder, integration agents
-   - Step 6: cleanup, optimizer agents
-   - Step 7: pre-commit-diagnostic agent
-   - Step 9-15: Review and merge agents
+Or via shell:
 
-## Why This Pattern
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
+from amplihack.recipes import run_recipe_by_name
+result = run_recipe_by_name('default-workflow', user_context={
+    'task_description': '''TASK_DESCRIPTION_HERE''',
+    'repo_path': '.',
+}, progress=True)
+print(f'Recipe result: {result}')
+"
+```
 
-**Benefits:**
+**Do NOT** read `DEFAULT_WORKFLOW.md` and follow steps manually. The recipe runner
+enforces step ordering, recursion guards, checkpoints, and quality gates that manual
+execution cannot replicate.
 
-- Single source of truth for workflow definition
-- No content duplication or drift
-- Changes to workflow made once in canonical location
-- Clear delegation contract between skill and workflow
-- Reduced token usage (skill is ~60 lines vs 471+ in canonical source)
+### Preferred: Use dev-orchestrator instead
+
+For most tasks, invoke `Skill(skill="dev-orchestrator")` or use `/dev <task>` rather
+than activating this skill directly. The dev-orchestrator adds goal-seeking reflection,
+workstream decomposition, and adaptive error recovery on top of this workflow.
 
 ## Auto-Activation Triggers
 
@@ -159,6 +192,9 @@ This skill auto-activates for:
 - Complex integrations across components
 - Refactoring affecting 5+ files
 - Any non-trivial code changes requiring structured workflow
+
+**Note**: The `dev-orchestrator` skill has higher priority and broader triggers.
+In most cases, it will activate first and invoke this workflow as a sub-recipe.
 
 ## Known Failure Points & Resilience Guidance
 
@@ -204,17 +240,18 @@ MUST apply the documented resilience patterns when encountering these steps.
 
 The workflow creates automatic checkpoints at these points to prevent work loss:
 
-| Checkpoint | After Step | Preserves |
-|---|---|---|
-| `checkpoint-after-design` | 5e (Design Consolidation) | Architecture decisions, API design, DB schema |
-| `checkpoint-after-implementation` | 8b (Integration) | Tests, implementation code, integration work |
-| `checkpoint-after-review-feedback` | 11b (Implement Feedback) | Review-addressed changes |
+| Checkpoint                         | After Step                | Preserves                                     |
+| ---------------------------------- | ------------------------- | --------------------------------------------- |
+| `checkpoint-after-design`          | 5e (Design Consolidation) | Architecture decisions, API design, DB schema |
+| `checkpoint-after-implementation`  | 8b (Integration)          | Tests, implementation code, integration work  |
+| `checkpoint-after-review-feedback` | 11b (Implement Feedback)  | Review-addressed changes                      |
 
 If a step fails after a checkpoint, the worktree branch retains all committed work. Agents can resume from the latest checkpoint by re-running the workflow with the existing worktree.
 
 ## Related Files
 
-- **Canonical Workflow**: `~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md`
-- **Command Interface**: `~/.amplihack/.claude/commands/amplihack/ultrathink.md`
-- **Orchestrator Skill**: `~/.amplihack/.claude/skills/ultrathink-orchestrator/`
-- **Investigation Workflow**: `~/.amplihack/.claude/skills/investigation-workflow/`
+- **Recipe (executable)**: `amplifier-bundle/recipes/default-workflow.yaml`
+- **Reference docs**: `.claude/workflow/DEFAULT_WORKFLOW.md`
+- **Command Interface**: `.claude/commands/amplihack/dev.md`
+- **Orchestrator Skill**: `.claude/skills/dev-orchestrator/`
+- **Investigation Workflow**: `.claude/skills/investigation-workflow/`

--- a/amplifier-bundle/skills/investigation-workflow/SKILL.md
+++ b/amplifier-bundle/skills/investigation-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: investigation-workflow
-version: 1.0.0
+version: 2.0.0
 description: |
-  6-phase investigation workflow for understanding existing systems. Auto-activates for research tasks.
-  Optimized for exploration and understanding, not implementation. Includes parallel agent deployment
-  for efficient deep dives and automatic knowledge capture to prevent repeat investigations.
+  6-phase investigation workflow for understanding existing systems. Normally executed
+  as a sub-recipe by dev-orchestrator/smart-orchestrator. Supports direct invocation
+  via recipe runner for standalone use.
 auto_activates:
   - "investigate how"
   - "explain the architecture"
@@ -15,14 +15,28 @@ auto_activates:
   - "research"
   - "explore"
 explicit_triggers:
-  - /amplihack:investigation-workflow
-  - /investigate
+  - /amplihack:investigation
 confirmation_required: true
 skip_confirmation_if_explicit: true
 token_budget: 4000
 ---
 
 # Investigation Workflow Skill
+
+## Relationship to Dev Orchestrator
+
+**Normal execution path**: This workflow is invoked as a sub-recipe by the
+`dev-orchestrator` skill via `smart-orchestrator`. You do NOT normally need
+to activate this skill directly.
+
+```
+User request → dev-orchestrator → smart-orchestrator recipe
+    → investigation-workflow recipe (this skill's recipe)
+```
+
+**Direct invocation** is supported as a compatibility path when the
+dev-orchestrator is unavailable or when explicitly requested. In that case,
+use the recipe runner (see Execution Instructions below).
 
 ## Workflow Graph
 
@@ -79,13 +93,77 @@ flowchart TD
     EFF --> FINAL[final-output]
 
     TRANS --> TDEV{Transition to dev?}
-    TDEV -->|yes| DW[Resume DEFAULT_WORKFLOW<br/>at Step 4 or 5]
+    TDEV -->|yes| DW[Launch default-workflow<br/>recipe via recipe runner]
     TDEV -->|no| DONE[Investigation Complete]
 ```
 
 ## Purpose
 
-This skill provides a systematic 6-phase workflow for investigating and understanding existing systems, codebases, and architectures. Unlike development workflows optimized for implementation, this workflow is optimized for exploration, understanding, and knowledge capture.
+This skill provides a systematic 6-phase workflow for investigating and understanding
+existing systems, codebases, and architectures. Unlike development workflows optimized
+for implementation, this workflow is optimized for exploration, understanding, and
+knowledge capture.
+
+It is normally executed as a sub-recipe by the `dev-orchestrator` via `smart-orchestrator`,
+but can also be invoked directly via the recipe runner.
+
+## Canonical Sources
+
+- **Executable source (recipe)**: `amplifier-bundle/recipes/investigation-workflow.yaml`
+- **Reference documentation**: `.claude/workflow/INVESTIGATION_WORKFLOW.md`
+
+The recipe YAML is the authoritative execution definition. The `.md` file serves as
+human-readable reference documentation for the workflow phases.
+
+## Execution Instructions
+
+### Normal path (via dev-orchestrator)
+
+If you reached this skill via `dev-orchestrator` / `smart-orchestrator`, the recipe
+runner is already managing execution. **Do not re-invoke the recipe runner.** The
+orchestrator handles the full lifecycle including goal-seeking reflection loops.
+
+### Direct invocation (standalone)
+
+If this skill is activated directly (not via dev-orchestrator), you MUST use the
+recipe runner — **do NOT read the .md file and follow phases manually**:
+
+```python
+from amplihack.recipes import run_recipe_by_name
+
+result = run_recipe_by_name(
+    "investigation-workflow",
+    user_context={
+        "task_description": "TASK_DESCRIPTION_HERE",
+        "repo_path": ".",
+    },
+    progress=True,
+)
+```
+
+Or via shell:
+
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
+from amplihack.recipes import run_recipe_by_name
+result = run_recipe_by_name('investigation-workflow', user_context={
+    'task_description': '''TASK_DESCRIPTION_HERE''',
+    'repo_path': '.',
+}, progress=True)
+print(f'Recipe result: {result}')
+"
+```
+
+**Do NOT** read `INVESTIGATION_WORKFLOW.md` and follow phases manually. The recipe
+runner enforces phase ordering, agent deployment, and quality gates that manual
+execution cannot replicate.
+
+### Preferred: Use dev-orchestrator instead
+
+For most tasks, invoke `Skill(skill="dev-orchestrator")` or use `/dev <task>` rather
+than activating this skill directly. The dev-orchestrator adds goal-seeking reflection,
+workstream decomposition, and adaptive error recovery on top of this workflow.
 
 ## When to Use This Skill
 
@@ -97,7 +175,7 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - "Analyze the reflection system architecture"
 - "Research what hooks are triggered during session start"
 
-**Development Tasks** (use DEFAULT_WORKFLOW.md instead):
+**Development Tasks** (use default-workflow recipe instead):
 
 - "Implement OAuth support"
 - "Build a new API endpoint"
@@ -127,20 +205,6 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - Set boundaries: What's in scope vs. out of scope
 - Estimate investigation depth needed (surface-level vs. deep dive)
 
-**Success Criteria**:
-
-- Clear list of questions to answer
-- Defined scope boundaries
-- Measurable success criteria (e.g., "can explain system flow", "can diagram architecture")
-
-**Deliverables**:
-
-- Investigation scope document with:
-  - Core questions to answer
-  - Success criteria
-  - Scope boundaries (what's included/excluded)
-  - Estimated depth and timeline
-
 ### Phase 2: Exploration Strategy
 
 **Purpose**: Plan which agents to deploy and what to investigate, preventing inefficient random exploration.
@@ -151,31 +215,6 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - **Use** patterns agent to check for similar past investigations
 - Identify key areas to explore (code paths, configurations, documentation)
 - Select specialized agents for parallel deployment in Phase 3
-- Create investigation roadmap with priorities
-- Identify potential dead ends to avoid
-- Plan verification approach (how to test understanding)
-
-**Agent Selection Guidelines**:
-
-- **For code understanding**: analyzer, patterns agents
-- **For system architecture**: architect, api-designer agents
-- **For performance issues**: optimizer, analyzer agents
-- **For security concerns**: security, patterns agents
-- **For integration flows**: integration, database agents
-
-**Success Criteria**:
-
-- Clear exploration roadmap
-- List of agents to deploy in Phase 3
-- Prioritized investigation areas
-
-**Deliverables**:
-
-- Exploration strategy document with:
-  - Investigation roadmap
-  - Agent deployment plan for Phase 3
-  - Priority order for exploration
-  - Expected outputs from each exploration
 
 ### Phase 3: Parallel Deep Dives
 
@@ -183,292 +222,51 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 
 **CRITICAL**: This phase uses PARALLEL EXECUTION by default.
 
-**Tasks**:
-
-- **Deploy selected agents in PARALLEL** based on Phase 2 strategy
-- **Common parallel patterns**:
-  - `[analyzer(module1), analyzer(module2), analyzer(module3)]` - Multiple code areas
-  - `[analyzer, patterns, security]` - Multiple perspectives on same area
-  - `[architect, database, integration]` - System architecture exploration
-- Each agent explores their assigned area independently
-- Collect findings from all parallel explorations
-- Identify connections and dependencies between findings
-- Note any unexpected discoveries or anomalies
-
-**Parallel Agent Examples**:
-
-```
-Investigation: "How does the reflection system work?"
-→ [analyzer(~/.amplihack/.claude/tools/amplihack/hooks/), patterns(reflection), integration(logging)]
-
-Investigation: "Why is CI failing?"
-→ [analyzer(ci-config), patterns(ci-failures), integration(github-actions)]
-
-Investigation: "Understand authentication flow"
-→ [analyzer(auth-module), security(auth), patterns(auth), integration(external-auth)]
-```
-
-**Success Criteria**:
-
-- All planned agents deployed and completed
-- Findings from each exploration collected
-- Connections between findings identified
-
-**Deliverables**:
-
-- Findings report with:
-  - Summary from each parallel exploration
-  - Code paths and flow diagrams
-  - Architectural insights
-  - Unexpected discoveries
-  - Open questions for verification
-
 ### Phase 4: Verification & Testing
 
 **Purpose**: Test and validate understanding through practical application.
-
-**Tasks**:
-
-- Create hypotheses based on Phase 3 findings
-- **Design practical tests** to verify understanding:
-  - Trace specific code paths manually
-  - Examine logs and outputs
-  - Test edge cases and assumptions
-  - Verify configuration effects
-- Run verification tests
-- **Document what was tested and results**
-- Identify gaps in understanding
-- Refine hypotheses based on test results
-- Repeat verification for any unclear areas
-
-**Verification Examples**:
-
-```
-Understanding: "Authentication uses JWT tokens"
-Verification: Trace actual token creation and validation in code
-
-Understanding: "CI fails because of dependency conflict"
-Verification: Check CI logs, reproduce locally, verify fix works
-
-Understanding: "Reflection analyzes all user messages"
-Verification: Examine reflection logs, trace message processing
-```
-
-**Success Criteria**:
-
-- All hypotheses tested
-- Understanding verified through practical tests
-- Gaps in understanding identified and filled
-
-**Deliverables**:
-
-- Verification report with:
-  - Tests performed
-  - Results and observations
-  - Confirmed understanding
-  - Remaining gaps or uncertainties
 
 ### Phase 5: Synthesis
 
 **Purpose**: Compile findings into coherent explanation that answers original questions.
 
-**Tasks**:
-
-- **Use** reviewer agent to check completeness of findings
-- **Use** patterns agent to identify reusable patterns discovered
-- Synthesize findings from Phases 3-4 into coherent explanation
-- Create visual artifacts (diagrams, flow charts) if helpful
-- Answer each question from Phase 1 scope definition
-- Identify what worked well vs. what was unexpected
-- Note any assumptions or uncertainties remaining
-- Prepare clear explanation suitable for user
-
-**Synthesis Outputs**:
-
-1. **Executive Summary**: 2-3 sentence answer to main question
-2. **Detailed Explanation**: Complete explanation with supporting evidence
-3. **Visual Aids**: Diagrams showing system flow, architecture, etc.
-4. **Key Insights**: Non-obvious discoveries or patterns
-5. **Remaining Unknowns**: What's still unclear or uncertain
-
-**Success Criteria**:
-
-- All Phase 1 questions answered
-- Explanation is clear and complete
-- Findings supported by evidence from verification
-- Visual aids clarify complex areas
-
-**Deliverables**:
-
-- Investigation report with all 5 synthesis outputs
-- Ready for knowledge capture in Phase 6
-
 ### Phase 6: Knowledge Capture
 
 **Purpose**: Create durable documentation so this investigation never needs to be repeated.
 
-**Tasks**:
-
 - **Store discoveries in memory** using `store_discovery()` from `amplihack.memory.discoveries`
 - **Update .claude/context/PATTERNS.md** if reusable patterns found
-- Create or update relevant documentation files
-- Add inline code comments for critical understanding
-- **Optional**: Create GitHub issue for follow-up improvements
-- **Optional**: Update architecture diagrams if needed
-- Ensure future investigators can find this knowledge easily
-
-**Documentation Guidelines**:
-
-```markdown
-## Discovery: [Brief Title]
-
-**Context**: What was investigated and why
-**Key Findings**:
-
-- Main insight 1
-- Main insight 2
-  - **Supporting Evidence**: Links to code, logs, or verification tests
-  - **Implications**: How this affects the project
-  - **Related Patterns**: Links to similar patterns in PATTERNS.md
-```
-
-**Success Criteria**:
-
-- Discoveries stored in memory for future reference
-- Relevant documentation files updated
-- Knowledge is discoverable by future investigators
-- No information loss
-
-**Deliverables**:
-
-- Discoveries stored in memory
-- Updated PATTERNS.md (if applicable)
-- Updated project documentation
-- Optional: GitHub issues for improvements
-- Investigation session log in `~/.amplihack/.claude/runtime/logs/`
 
 ## Transitioning to Development Workflow
 
-**After investigation completes**, if the task requires implementation (not just understanding), transition to **DEFAULT_WORKFLOW.md**:
+**After investigation completes**, if the task requires implementation, the
+`dev-orchestrator` handles the transition automatically via its goal-seeking
+reflection loop. If running standalone, transition by launching the
+`default-workflow` recipe:
 
-1. **Resume at Step 4** (Research and Design) with the knowledge gained from investigation
-2. **Or resume at Step 5** (Implement the Solution) if the investigation already provided clear design guidance
-3. **Use investigation findings** from memory (via `get_recent_discoveries()`) and session logs to inform design decisions
-
-**Example Hybrid Workflow**:
-
-```
-User: "/ultrathink investigate how authentication works, then add OAuth support"
-
-Phase 1: Investigation
-→ Run INVESTIGATION_WORKFLOW.md (6 phases)
-→ Complete understanding of existing auth system
-→ Store findings in memory via discoveries adapter
-
-Phase 2: Development
-→ Transition to DEFAULT_WORKFLOW.md
-→ Resume at Step 4 (Research and Design)
-→ Use investigation insights to design OAuth integration
-→ Continue through Step 15 (implementation → testing → PR)
+```python
+run_recipe_by_name("default-workflow", user_context={
+    "task_description": "Implement findings from investigation...",
+    "repo_path": ".",
+}, progress=True)
 ```
 
-**When to Transition**:
+## Integration with Dev Orchestrator
 
-- Investigation reveals implementation is needed
-- User explicitly requested both investigation + development
-- Follow-up work identified during knowledge capture
-
-## Efficiency Targets
-
-**Target Efficiency**: This workflow targets a 30-40% reduction in message count compared to ad-hoc investigation.
-
-| Ad-Hoc Approach         | Investigation Workflow    |
-| ----------------------- | ------------------------- |
-| 70-90 messages          | 40-60 messages            |
-| Frequent backtracking   | Planned exploration       |
-| Redundant investigation | Parallel deep dives       |
-| Unclear scope           | Explicit scope definition |
-| Lost knowledge          | Documented insights       |
-
-**Efficiency Gains Come From**:
-
-1. **Scope Definition** prevents scope creep and wandering
-2. **Exploration Strategy** prevents random unproductive exploration
-3. **Parallel Deep Dives** maximize information gathering speed
-4. **Verification Phase** catches misunderstandings early
-5. **Synthesis** ensures all questions answered
-6. **Knowledge Capture** prevents repeat investigations
-
-## Comparison to DEFAULT_WORKFLOW.md
-
-### Similarities (Structural Consistency)
-
-Both workflows share core principles:
-
-- Explicit phases with clear deliverables
-- Agent-driven execution at each phase
-- Quality gates preventing premature progression
-- Knowledge capture and documentation
-- TodoWrite tracking for progress management
-
-### Differences (Investigation vs. Development)
-
-| Aspect             | Investigation Workflow     | DEFAULT_WORKFLOW.md      |
-| ------------------ | -------------------------- | ------------------------ |
-| **Goal**           | Understanding              | Implementation           |
-| **Phases**         | 6 phases                   | Multi-step workflow      |
-| **Execution**      | Exploration-first          | Implementation-first     |
-| **Parallel Focus** | Phase 3 (Deep Dives)       | Various steps            |
-| **Testing**        | Understanding verification | Code validation          |
-| **Deliverable**    | Documentation              | Working code             |
-| **Git Usage**      | Optional                   | Required (branches, PRs) |
-
-### Phase Mapping (For User Familiarity)
-
-| Investigation Phase           | DEFAULT_WORKFLOW Equivalent        | Purpose                              |
-| ----------------------------- | ---------------------------------- | ------------------------------------ |
-| Phase 1: Scope Definition     | Step 1: Requirements Clarification | Define what success looks like       |
-| Phase 2: Exploration Strategy | Step 4: Research and Design        | Plan the approach                    |
-| Phase 3: Parallel Deep Dives  | Step 5: Implementation             | Execute the plan (explore vs. build) |
-| Phase 4: Verification         | Steps 7-8: Testing                 | Validate results                     |
-| Phase 5: Synthesis            | Step 11: Review                    | Ensure quality and completeness      |
-| Phase 6: Knowledge Capture    | Step 15: Cleanup                   | Make results durable                 |
-
-## Integration with UltraThink
-
-**UltraThink Workflow Detection**: When `/ultrathink` is invoked, it automatically detects investigation tasks using keywords and suggests this workflow.
-
-**Automatic Workflow Suggestion**:
+The `dev-orchestrator` automatically detects investigation tasks using keywords
+and routes them to this workflow's recipe:
 
 ```
-User: "/ultrathink investigate how authentication works"
+User: "/dev investigate how authentication works"
 
-UltraThink: Detected investigation task. Using INVESTIGATION_WORKFLOW.md
-→ Reading workflow from .claude/workflow/INVESTIGATION_WORKFLOW.md
-→ Following 6-phase investigation workflow
-→ Starting Phase 1: Scope Definition
+dev-orchestrator: Classified as Investigation → launching investigation-workflow recipe
+→ Recipe runner executes 6-phase investigation workflow
+→ Results feed into goal-seeking reflection loop
 ```
 
-## Customization
-
-To customize this workflow:
-
-1. Edit `~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md` to modify, add, or remove phases
-2. Adjust agent deployment strategies for your needs
-3. Add project-specific investigation patterns
-4. Update efficiency targets based on your metrics
-
-Changes take effect immediately for future investigations.
-
-## Success Metrics
-
-Track these metrics to validate workflow effectiveness:
-
-- **Message Count**: Target 30-40% reduction vs. ad-hoc (to be validated)
-- **Investigation Time**: Track time to completion
-- **Knowledge Reuse**: How often memory retrieval prevents repeat work
-- **Completeness**: Percentage of investigations with full documentation
-- **User Satisfaction**: Clear understanding achieved
+For hybrid tasks (investigate + implement), the dev-orchestrator decomposes into
+parallel workstreams: one running `investigation-workflow`, another running
+`default-workflow`.
 
 ## Key Principles
 
@@ -478,14 +276,11 @@ Track these metrics to validate workflow effectiveness:
 - **Capture knowledge** - Always store discoveries in memory in Phase 6
 - **This workflow optimizes for understanding, not implementation**
 
-When in doubt about investigation vs. development:
-
-- **Investigation**: "I need to understand X"
-- **Development**: "I need to build/fix/implement X"
-
 ## Related Resources
 
-- **Source Workflow**: `~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md` (complete 436-line specification)
-- **Knowledge Extraction**: Use knowledge-extractor skill after investigations to capture learnings
-- **Agent Catalog**: `~/.amplihack/.claude/agents/CATALOG.md` for all available agents
-- **Pattern Library**: `~/.amplihack/.claude/context/PATTERNS.md` for reusable investigation patterns
+- **Recipe (executable)**: `amplifier-bundle/recipes/investigation-workflow.yaml`
+- **Reference docs**: `.claude/workflow/INVESTIGATION_WORKFLOW.md`
+- **Dev Orchestrator**: `.claude/skills/dev-orchestrator/`
+- **Default Workflow**: `.claude/skills/default-workflow/`
+- **Agent Catalog**: `.claude/agents/amplihack/` directory
+- **Pattern Library**: `.claude/context/PATTERNS.md`

--- a/docs/claude/skills/default-workflow/SKILL.md
+++ b/docs/claude/skills/default-workflow/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: default-workflow
-version: 1.1.0
-description: Development workflow for features, bugs, refactoring. Auto-activates for multi-file implementations.
+version: 2.0.0
+description: |
+  Development workflow for features, bugs, refactoring. Normally executed as a
+  sub-recipe by dev-orchestrator/smart-orchestrator. Supports direct invocation
+  via recipe runner for standalone use.
 auto_activates:
   - "implement feature spanning multiple files"
   - "complex integration across components"
   - "refactor affecting 5+ files"
 explicit_triggers:
-  - /ultrathink
   - /amplihack:default-workflow
 confirmation_required: true
 skip_confirmation_if_explicit: true
@@ -15,6 +17,21 @@ token_budget: 4500
 ---
 
 # Default Workflow Skill
+
+## Relationship to Dev Orchestrator
+
+**Normal execution path**: This workflow is invoked as a sub-recipe by the
+`dev-orchestrator` skill via `smart-orchestrator`. You do NOT normally need
+to activate this skill directly.
+
+```
+User request → dev-orchestrator → smart-orchestrator recipe
+    → default-workflow recipe (this skill's recipe)
+```
+
+**Direct invocation** is supported as a compatibility path when the
+dev-orchestrator is unavailable or when explicitly requested. In that case,
+use the recipe runner (see Execution Instructions below).
 
 ## Workflow Graph
 
@@ -100,56 +117,72 @@ flowchart TD
 
 ## Purpose
 
-This skill provides the standard development workflow for all non-trivial code changes in amplihack. It auto-activates when detecting multi-file implementations, complex integrations, or significant refactoring work.
+This skill provides the standard development workflow for all non-trivial code changes
+in amplihack. It is normally executed as a sub-recipe by the `dev-orchestrator` via
+`smart-orchestrator`, but can also be invoked directly via the recipe runner.
 
-The workflow defines the canonical execution process: from requirements clarification through design, implementation, testing, review, and merge. It ensures consistent quality by orchestrating specialized agents at each step and enforcing philosophy compliance throughout.
+The workflow defines the canonical execution process: from requirements clarification
+through design, implementation, testing, review, and merge. It ensures consistent
+quality by orchestrating specialized agents at each step and enforcing philosophy
+compliance throughout.
 
-This is a thin wrapper that references the complete workflow definition stored in a single canonical location, ensuring no duplication or drift between the skill interface and the workflow specification.
+## Canonical Sources
 
-## Canonical Source
+- **Executable source (recipe)**: `amplifier-bundle/recipes/default-workflow.yaml`
+- **Reference documentation**: `.claude/workflow/DEFAULT_WORKFLOW.md`
 
-**This skill is a thin wrapper that references the canonical workflow:**
-
-**Source**: `~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md` (471+ lines)
-
-The canonical workflow contains the complete development process with all details, agent specifications, and execution guidance.
+The recipe YAML is the authoritative execution definition. The `.md` file serves as
+human-readable reference documentation for the workflow steps.
 
 ## Execution Instructions
 
-When this skill is activated, you MUST:
+### Normal path (via dev-orchestrator)
 
-1. **Read the canonical workflow** immediately:
+If you reached this skill via `dev-orchestrator` / `smart-orchestrator`, the recipe
+runner is already managing execution. **Do not re-invoke the recipe runner.** The
+orchestrator handles the full lifecycle including goal-seeking reflection loops.
 
-   ```
-   Read(file_path="~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md")
-   ```
+### Direct invocation (standalone)
 
-   Note: Path is relative to project root. Claude Code resolves this automatically.
+If this skill is activated directly (not via dev-orchestrator), you MUST use the
+recipe runner — **do NOT read the .md file and follow steps manually**:
 
-2. **Follow all steps** exactly as specified in the canonical workflow
+```python
+from amplihack.recipes import run_recipe_by_name
 
-3. **Use TodoWrite** to track progress through workflow steps with format:
-   - `Step N: [Step Name] - [Specific Action]`
-   - Example: `Step 1: Rewrite and Clarify Requirements - Use prompt-writer agent`
-   - This helps users track exactly which workflow step is active
+result = run_recipe_by_name(
+    "default-workflow",
+    user_context={
+        "task_description": "TASK_DESCRIPTION_HERE",
+        "repo_path": ".",
+    },
+    progress=True,
+)
+```
 
-4. **Invoke specialized agents** as specified in each workflow step:
-   - Step 1: prompt-writer, analyzer, ambiguity agents
-   - Step 4: architect, api-designer, database, tester, security agents
-   - Step 5: builder, integration agents
-   - Step 6: cleanup, optimizer agents
-   - Step 7: pre-commit-diagnostic agent
-   - Step 9-15: Review and merge agents
+Or via shell:
 
-## Why This Pattern
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
+from amplihack.recipes import run_recipe_by_name
+result = run_recipe_by_name('default-workflow', user_context={
+    'task_description': '''TASK_DESCRIPTION_HERE''',
+    'repo_path': '.',
+}, progress=True)
+print(f'Recipe result: {result}')
+"
+```
 
-**Benefits:**
+**Do NOT** read `DEFAULT_WORKFLOW.md` and follow steps manually. The recipe runner
+enforces step ordering, recursion guards, checkpoints, and quality gates that manual
+execution cannot replicate.
 
-- Single source of truth for workflow definition
-- No content duplication or drift
-- Changes to workflow made once in canonical location
-- Clear delegation contract between skill and workflow
-- Reduced token usage (skill is ~60 lines vs 471+ in canonical source)
+### Preferred: Use dev-orchestrator instead
+
+For most tasks, invoke `Skill(skill="dev-orchestrator")` or use `/dev <task>` rather
+than activating this skill directly. The dev-orchestrator adds goal-seeking reflection,
+workstream decomposition, and adaptive error recovery on top of this workflow.
 
 ## Auto-Activation Triggers
 
@@ -159,6 +192,9 @@ This skill auto-activates for:
 - Complex integrations across components
 - Refactoring affecting 5+ files
 - Any non-trivial code changes requiring structured workflow
+
+**Note**: The `dev-orchestrator` skill has higher priority and broader triggers.
+In most cases, it will activate first and invoke this workflow as a sub-recipe.
 
 ## Known Failure Points & Resilience Guidance
 
@@ -204,17 +240,18 @@ MUST apply the documented resilience patterns when encountering these steps.
 
 The workflow creates automatic checkpoints at these points to prevent work loss:
 
-| Checkpoint | After Step | Preserves |
-|---|---|---|
-| `checkpoint-after-design` | 5e (Design Consolidation) | Architecture decisions, API design, DB schema |
-| `checkpoint-after-implementation` | 8b (Integration) | Tests, implementation code, integration work |
-| `checkpoint-after-review-feedback` | 11b (Implement Feedback) | Review-addressed changes |
+| Checkpoint                         | After Step                | Preserves                                     |
+| ---------------------------------- | ------------------------- | --------------------------------------------- |
+| `checkpoint-after-design`          | 5e (Design Consolidation) | Architecture decisions, API design, DB schema |
+| `checkpoint-after-implementation`  | 8b (Integration)          | Tests, implementation code, integration work  |
+| `checkpoint-after-review-feedback` | 11b (Implement Feedback)  | Review-addressed changes                      |
 
 If a step fails after a checkpoint, the worktree branch retains all committed work. Agents can resume from the latest checkpoint by re-running the workflow with the existing worktree.
 
 ## Related Files
 
-- **Canonical Workflow**: `~/.amplihack/.claude/workflow/DEFAULT_WORKFLOW.md`
-- **Command Interface**: `~/.amplihack/.claude/commands/amplihack/ultrathink.md`
-- **Orchestrator Skill**: `~/.amplihack/.claude/skills/ultrathink-orchestrator/`
-- **Investigation Workflow**: `~/.amplihack/.claude/skills/investigation-workflow/`
+- **Recipe (executable)**: `amplifier-bundle/recipes/default-workflow.yaml`
+- **Reference docs**: `.claude/workflow/DEFAULT_WORKFLOW.md`
+- **Command Interface**: `.claude/commands/amplihack/dev.md`
+- **Orchestrator Skill**: `.claude/skills/dev-orchestrator/`
+- **Investigation Workflow**: `.claude/skills/investigation-workflow/`

--- a/docs/claude/skills/investigation-workflow/SKILL.md
+++ b/docs/claude/skills/investigation-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: investigation-workflow
-version: 1.0.0
+version: 2.0.0
 description: |
-  6-phase investigation workflow for understanding existing systems. Auto-activates for research tasks.
-  Optimized for exploration and understanding, not implementation. Includes parallel agent deployment
-  for efficient deep dives and automatic knowledge capture to prevent repeat investigations.
+  6-phase investigation workflow for understanding existing systems. Normally executed
+  as a sub-recipe by dev-orchestrator/smart-orchestrator. Supports direct invocation
+  via recipe runner for standalone use.
 auto_activates:
   - "investigate how"
   - "explain the architecture"
@@ -15,14 +15,28 @@ auto_activates:
   - "research"
   - "explore"
 explicit_triggers:
-  - /amplihack:investigation-workflow
-  - /investigate
+  - /amplihack:investigation
 confirmation_required: true
 skip_confirmation_if_explicit: true
 token_budget: 4000
 ---
 
 # Investigation Workflow Skill
+
+## Relationship to Dev Orchestrator
+
+**Normal execution path**: This workflow is invoked as a sub-recipe by the
+`dev-orchestrator` skill via `smart-orchestrator`. You do NOT normally need
+to activate this skill directly.
+
+```
+User request → dev-orchestrator → smart-orchestrator recipe
+    → investigation-workflow recipe (this skill's recipe)
+```
+
+**Direct invocation** is supported as a compatibility path when the
+dev-orchestrator is unavailable or when explicitly requested. In that case,
+use the recipe runner (see Execution Instructions below).
 
 ## Workflow Graph
 
@@ -79,13 +93,77 @@ flowchart TD
     EFF --> FINAL[final-output]
 
     TRANS --> TDEV{Transition to dev?}
-    TDEV -->|yes| DW[Resume DEFAULT_WORKFLOW<br/>at Step 4 or 5]
+    TDEV -->|yes| DW[Launch default-workflow<br/>recipe via recipe runner]
     TDEV -->|no| DONE[Investigation Complete]
 ```
 
 ## Purpose
 
-This skill provides a systematic 6-phase workflow for investigating and understanding existing systems, codebases, and architectures. Unlike development workflows optimized for implementation, this workflow is optimized for exploration, understanding, and knowledge capture.
+This skill provides a systematic 6-phase workflow for investigating and understanding
+existing systems, codebases, and architectures. Unlike development workflows optimized
+for implementation, this workflow is optimized for exploration, understanding, and
+knowledge capture.
+
+It is normally executed as a sub-recipe by the `dev-orchestrator` via `smart-orchestrator`,
+but can also be invoked directly via the recipe runner.
+
+## Canonical Sources
+
+- **Executable source (recipe)**: `amplifier-bundle/recipes/investigation-workflow.yaml`
+- **Reference documentation**: `.claude/workflow/INVESTIGATION_WORKFLOW.md`
+
+The recipe YAML is the authoritative execution definition. The `.md` file serves as
+human-readable reference documentation for the workflow phases.
+
+## Execution Instructions
+
+### Normal path (via dev-orchestrator)
+
+If you reached this skill via `dev-orchestrator` / `smart-orchestrator`, the recipe
+runner is already managing execution. **Do not re-invoke the recipe runner.** The
+orchestrator handles the full lifecycle including goal-seeking reflection loops.
+
+### Direct invocation (standalone)
+
+If this skill is activated directly (not via dev-orchestrator), you MUST use the
+recipe runner — **do NOT read the .md file and follow phases manually**:
+
+```python
+from amplihack.recipes import run_recipe_by_name
+
+result = run_recipe_by_name(
+    "investigation-workflow",
+    user_context={
+        "task_description": "TASK_DESCRIPTION_HERE",
+        "repo_path": ".",
+    },
+    progress=True,
+)
+```
+
+Or via shell:
+
+```bash
+cd /path/to/repo && env -u CLAUDECODE \
+  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
+from amplihack.recipes import run_recipe_by_name
+result = run_recipe_by_name('investigation-workflow', user_context={
+    'task_description': '''TASK_DESCRIPTION_HERE''',
+    'repo_path': '.',
+}, progress=True)
+print(f'Recipe result: {result}')
+"
+```
+
+**Do NOT** read `INVESTIGATION_WORKFLOW.md` and follow phases manually. The recipe
+runner enforces phase ordering, agent deployment, and quality gates that manual
+execution cannot replicate.
+
+### Preferred: Use dev-orchestrator instead
+
+For most tasks, invoke `Skill(skill="dev-orchestrator")` or use `/dev <task>` rather
+than activating this skill directly. The dev-orchestrator adds goal-seeking reflection,
+workstream decomposition, and adaptive error recovery on top of this workflow.
 
 ## When to Use This Skill
 
@@ -97,7 +175,7 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - "Analyze the reflection system architecture"
 - "Research what hooks are triggered during session start"
 
-**Development Tasks** (use DEFAULT_WORKFLOW.md instead):
+**Development Tasks** (use default-workflow recipe instead):
 
 - "Implement OAuth support"
 - "Build a new API endpoint"
@@ -127,20 +205,6 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - Set boundaries: What's in scope vs. out of scope
 - Estimate investigation depth needed (surface-level vs. deep dive)
 
-**Success Criteria**:
-
-- Clear list of questions to answer
-- Defined scope boundaries
-- Measurable success criteria (e.g., "can explain system flow", "can diagram architecture")
-
-**Deliverables**:
-
-- Investigation scope document with:
-  - Core questions to answer
-  - Success criteria
-  - Scope boundaries (what's included/excluded)
-  - Estimated depth and timeline
-
 ### Phase 2: Exploration Strategy
 
 **Purpose**: Plan which agents to deploy and what to investigate, preventing inefficient random exploration.
@@ -151,31 +215,6 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 - **Use** patterns agent to check for similar past investigations
 - Identify key areas to explore (code paths, configurations, documentation)
 - Select specialized agents for parallel deployment in Phase 3
-- Create investigation roadmap with priorities
-- Identify potential dead ends to avoid
-- Plan verification approach (how to test understanding)
-
-**Agent Selection Guidelines**:
-
-- **For code understanding**: analyzer, patterns agents
-- **For system architecture**: architect, api-designer agents
-- **For performance issues**: optimizer, analyzer agents
-- **For security concerns**: security, patterns agents
-- **For integration flows**: integration, database agents
-
-**Success Criteria**:
-
-- Clear exploration roadmap
-- List of agents to deploy in Phase 3
-- Prioritized investigation areas
-
-**Deliverables**:
-
-- Exploration strategy document with:
-  - Investigation roadmap
-  - Agent deployment plan for Phase 3
-  - Priority order for exploration
-  - Expected outputs from each exploration
 
 ### Phase 3: Parallel Deep Dives
 
@@ -183,292 +222,51 @@ This skill provides a systematic 6-phase workflow for investigating and understa
 
 **CRITICAL**: This phase uses PARALLEL EXECUTION by default.
 
-**Tasks**:
-
-- **Deploy selected agents in PARALLEL** based on Phase 2 strategy
-- **Common parallel patterns**:
-  - `[analyzer(module1), analyzer(module2), analyzer(module3)]` - Multiple code areas
-  - `[analyzer, patterns, security]` - Multiple perspectives on same area
-  - `[architect, database, integration]` - System architecture exploration
-- Each agent explores their assigned area independently
-- Collect findings from all parallel explorations
-- Identify connections and dependencies between findings
-- Note any unexpected discoveries or anomalies
-
-**Parallel Agent Examples**:
-
-```
-Investigation: "How does the reflection system work?"
-→ [analyzer(~/.amplihack/.claude/tools/amplihack/hooks/), patterns(reflection), integration(logging)]
-
-Investigation: "Why is CI failing?"
-→ [analyzer(ci-config), patterns(ci-failures), integration(github-actions)]
-
-Investigation: "Understand authentication flow"
-→ [analyzer(auth-module), security(auth), patterns(auth), integration(external-auth)]
-```
-
-**Success Criteria**:
-
-- All planned agents deployed and completed
-- Findings from each exploration collected
-- Connections between findings identified
-
-**Deliverables**:
-
-- Findings report with:
-  - Summary from each parallel exploration
-  - Code paths and flow diagrams
-  - Architectural insights
-  - Unexpected discoveries
-  - Open questions for verification
-
 ### Phase 4: Verification & Testing
 
 **Purpose**: Test and validate understanding through practical application.
-
-**Tasks**:
-
-- Create hypotheses based on Phase 3 findings
-- **Design practical tests** to verify understanding:
-  - Trace specific code paths manually
-  - Examine logs and outputs
-  - Test edge cases and assumptions
-  - Verify configuration effects
-- Run verification tests
-- **Document what was tested and results**
-- Identify gaps in understanding
-- Refine hypotheses based on test results
-- Repeat verification for any unclear areas
-
-**Verification Examples**:
-
-```
-Understanding: "Authentication uses JWT tokens"
-Verification: Trace actual token creation and validation in code
-
-Understanding: "CI fails because of dependency conflict"
-Verification: Check CI logs, reproduce locally, verify fix works
-
-Understanding: "Reflection analyzes all user messages"
-Verification: Examine reflection logs, trace message processing
-```
-
-**Success Criteria**:
-
-- All hypotheses tested
-- Understanding verified through practical tests
-- Gaps in understanding identified and filled
-
-**Deliverables**:
-
-- Verification report with:
-  - Tests performed
-  - Results and observations
-  - Confirmed understanding
-  - Remaining gaps or uncertainties
 
 ### Phase 5: Synthesis
 
 **Purpose**: Compile findings into coherent explanation that answers original questions.
 
-**Tasks**:
-
-- **Use** reviewer agent to check completeness of findings
-- **Use** patterns agent to identify reusable patterns discovered
-- Synthesize findings from Phases 3-4 into coherent explanation
-- Create visual artifacts (diagrams, flow charts) if helpful
-- Answer each question from Phase 1 scope definition
-- Identify what worked well vs. what was unexpected
-- Note any assumptions or uncertainties remaining
-- Prepare clear explanation suitable for user
-
-**Synthesis Outputs**:
-
-1. **Executive Summary**: 2-3 sentence answer to main question
-2. **Detailed Explanation**: Complete explanation with supporting evidence
-3. **Visual Aids**: Diagrams showing system flow, architecture, etc.
-4. **Key Insights**: Non-obvious discoveries or patterns
-5. **Remaining Unknowns**: What's still unclear or uncertain
-
-**Success Criteria**:
-
-- All Phase 1 questions answered
-- Explanation is clear and complete
-- Findings supported by evidence from verification
-- Visual aids clarify complex areas
-
-**Deliverables**:
-
-- Investigation report with all 5 synthesis outputs
-- Ready for knowledge capture in Phase 6
-
 ### Phase 6: Knowledge Capture
 
 **Purpose**: Create durable documentation so this investigation never needs to be repeated.
 
-**Tasks**:
-
 - **Store discoveries in memory** using `store_discovery()` from `amplihack.memory.discoveries`
 - **Update .claude/context/PATTERNS.md** if reusable patterns found
-- Create or update relevant documentation files
-- Add inline code comments for critical understanding
-- **Optional**: Create GitHub issue for follow-up improvements
-- **Optional**: Update architecture diagrams if needed
-- Ensure future investigators can find this knowledge easily
-
-**Documentation Guidelines**:
-
-```markdown
-## Discovery: [Brief Title]
-
-**Context**: What was investigated and why
-**Key Findings**:
-
-- Main insight 1
-- Main insight 2
-  - **Supporting Evidence**: Links to code, logs, or verification tests
-  - **Implications**: How this affects the project
-  - **Related Patterns**: Links to similar patterns in PATTERNS.md
-```
-
-**Success Criteria**:
-
-- Discoveries stored in memory for future reference
-- Relevant documentation files updated
-- Knowledge is discoverable by future investigators
-- No information loss
-
-**Deliverables**:
-
-- Discoveries stored in memory
-- Updated PATTERNS.md (if applicable)
-- Updated project documentation
-- Optional: GitHub issues for improvements
-- Investigation session log in `~/.amplihack/.claude/runtime/logs/`
 
 ## Transitioning to Development Workflow
 
-**After investigation completes**, if the task requires implementation (not just understanding), transition to **DEFAULT_WORKFLOW.md**:
+**After investigation completes**, if the task requires implementation, the
+`dev-orchestrator` handles the transition automatically via its goal-seeking
+reflection loop. If running standalone, transition by launching the
+`default-workflow` recipe:
 
-1. **Resume at Step 4** (Research and Design) with the knowledge gained from investigation
-2. **Or resume at Step 5** (Implement the Solution) if the investigation already provided clear design guidance
-3. **Use investigation findings** from memory (via `get_recent_discoveries()`) and session logs to inform design decisions
-
-**Example Hybrid Workflow**:
-
-```
-User: "/ultrathink investigate how authentication works, then add OAuth support"
-
-Phase 1: Investigation
-→ Run INVESTIGATION_WORKFLOW.md (6 phases)
-→ Complete understanding of existing auth system
-→ Store findings in memory via discoveries adapter
-
-Phase 2: Development
-→ Transition to DEFAULT_WORKFLOW.md
-→ Resume at Step 4 (Research and Design)
-→ Use investigation insights to design OAuth integration
-→ Continue through Step 15 (implementation → testing → PR)
+```python
+run_recipe_by_name("default-workflow", user_context={
+    "task_description": "Implement findings from investigation...",
+    "repo_path": ".",
+}, progress=True)
 ```
 
-**When to Transition**:
+## Integration with Dev Orchestrator
 
-- Investigation reveals implementation is needed
-- User explicitly requested both investigation + development
-- Follow-up work identified during knowledge capture
-
-## Efficiency Targets
-
-**Target Efficiency**: This workflow targets a 30-40% reduction in message count compared to ad-hoc investigation.
-
-| Ad-Hoc Approach         | Investigation Workflow    |
-| ----------------------- | ------------------------- |
-| 70-90 messages          | 40-60 messages            |
-| Frequent backtracking   | Planned exploration       |
-| Redundant investigation | Parallel deep dives       |
-| Unclear scope           | Explicit scope definition |
-| Lost knowledge          | Documented insights       |
-
-**Efficiency Gains Come From**:
-
-1. **Scope Definition** prevents scope creep and wandering
-2. **Exploration Strategy** prevents random unproductive exploration
-3. **Parallel Deep Dives** maximize information gathering speed
-4. **Verification Phase** catches misunderstandings early
-5. **Synthesis** ensures all questions answered
-6. **Knowledge Capture** prevents repeat investigations
-
-## Comparison to DEFAULT_WORKFLOW.md
-
-### Similarities (Structural Consistency)
-
-Both workflows share core principles:
-
-- Explicit phases with clear deliverables
-- Agent-driven execution at each phase
-- Quality gates preventing premature progression
-- Knowledge capture and documentation
-- TodoWrite tracking for progress management
-
-### Differences (Investigation vs. Development)
-
-| Aspect             | Investigation Workflow     | DEFAULT_WORKFLOW.md      |
-| ------------------ | -------------------------- | ------------------------ |
-| **Goal**           | Understanding              | Implementation           |
-| **Phases**         | 6 phases                   | Multi-step workflow      |
-| **Execution**      | Exploration-first          | Implementation-first     |
-| **Parallel Focus** | Phase 3 (Deep Dives)       | Various steps            |
-| **Testing**        | Understanding verification | Code validation          |
-| **Deliverable**    | Documentation              | Working code             |
-| **Git Usage**      | Optional                   | Required (branches, PRs) |
-
-### Phase Mapping (For User Familiarity)
-
-| Investigation Phase           | DEFAULT_WORKFLOW Equivalent        | Purpose                              |
-| ----------------------------- | ---------------------------------- | ------------------------------------ |
-| Phase 1: Scope Definition     | Step 1: Requirements Clarification | Define what success looks like       |
-| Phase 2: Exploration Strategy | Step 4: Research and Design        | Plan the approach                    |
-| Phase 3: Parallel Deep Dives  | Step 5: Implementation             | Execute the plan (explore vs. build) |
-| Phase 4: Verification         | Steps 7-8: Testing                 | Validate results                     |
-| Phase 5: Synthesis            | Step 11: Review                    | Ensure quality and completeness      |
-| Phase 6: Knowledge Capture    | Step 15: Cleanup                   | Make results durable                 |
-
-## Integration with UltraThink
-
-**UltraThink Workflow Detection**: When `/ultrathink` is invoked, it automatically detects investigation tasks using keywords and suggests this workflow.
-
-**Automatic Workflow Suggestion**:
+The `dev-orchestrator` automatically detects investigation tasks using keywords
+and routes them to this workflow's recipe:
 
 ```
-User: "/ultrathink investigate how authentication works"
+User: "/dev investigate how authentication works"
 
-UltraThink: Detected investigation task. Using INVESTIGATION_WORKFLOW.md
-→ Reading workflow from .claude/workflow/INVESTIGATION_WORKFLOW.md
-→ Following 6-phase investigation workflow
-→ Starting Phase 1: Scope Definition
+dev-orchestrator: Classified as Investigation → launching investigation-workflow recipe
+→ Recipe runner executes 6-phase investigation workflow
+→ Results feed into goal-seeking reflection loop
 ```
 
-## Customization
-
-To customize this workflow:
-
-1. Edit `~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md` to modify, add, or remove phases
-2. Adjust agent deployment strategies for your needs
-3. Add project-specific investigation patterns
-4. Update efficiency targets based on your metrics
-
-Changes take effect immediately for future investigations.
-
-## Success Metrics
-
-Track these metrics to validate workflow effectiveness:
-
-- **Message Count**: Target 30-40% reduction vs. ad-hoc (to be validated)
-- **Investigation Time**: Track time to completion
-- **Knowledge Reuse**: How often memory retrieval prevents repeat work
-- **Completeness**: Percentage of investigations with full documentation
-- **User Satisfaction**: Clear understanding achieved
+For hybrid tasks (investigate + implement), the dev-orchestrator decomposes into
+parallel workstreams: one running `investigation-workflow`, another running
+`default-workflow`.
 
 ## Key Principles
 
@@ -478,14 +276,11 @@ Track these metrics to validate workflow effectiveness:
 - **Capture knowledge** - Always store discoveries in memory in Phase 6
 - **This workflow optimizes for understanding, not implementation**
 
-When in doubt about investigation vs. development:
-
-- **Investigation**: "I need to understand X"
-- **Development**: "I need to build/fix/implement X"
-
 ## Related Resources
 
-- **Source Workflow**: `~/.amplihack/.claude/workflow/INVESTIGATION_WORKFLOW.md` (complete 436-line specification)
-- **Knowledge Extraction**: Use knowledge-extractor skill after investigations to capture learnings
-- **Agent Catalog**: `~/.amplihack/.claude/agents/CATALOG.md` for all available agents
-- **Pattern Library**: `~/.amplihack/.claude/context/PATTERNS.md` for reusable investigation patterns
+- **Recipe (executable)**: `amplifier-bundle/recipes/investigation-workflow.yaml`
+- **Reference docs**: `.claude/workflow/INVESTIGATION_WORKFLOW.md`
+- **Dev Orchestrator**: `.claude/skills/dev-orchestrator/`
+- **Default Workflow**: `.claude/skills/default-workflow/`
+- **Agent Catalog**: `.claude/agents/amplihack/` directory
+- **Pattern Library**: `.claude/context/PATTERNS.md`


### PR DESCRIPTION
## Summary

Updates default-workflow and investigation-workflow skill files to use the recipe runner pattern instead of directing agents to manually read .md workflow files. Both skills were stale - they referenced the old pattern of Read(file_path) and following steps manually, with zero mention of the recipe runner or run_recipe_by_name().

### Changes
- **default-workflow/SKILL.md**: Rewritten to use run_recipe_by_name("default-workflow"), documents relationship to dev-orchestrator, fixes triggers (removes /ultrathink and /dev conflict), version 2.0.0
- **investigation-workflow/SKILL.md**: Rewritten to use run_recipe_by_name("investigation-workflow"), trims verbose manual phases, fixes triggers (removes wrong /investigate), version 2.0.0
- All 3 copy locations synced: .claude/skills/, amplifier-bundle/skills/, docs/claude/skills/
- New gadugi-test scenario validating recipe runner alignment (10 assertions)

## Merge readiness

### QA-team evidence

- Scenario files: .claude/tests/agentic/workflow-skill-recipe-runner-alignment.yaml
- Validation command: gadugi-test validate --file .claude/tests/agentic/workflow-skill-recipe-runner-alignment.yaml
- Validation result: passed (10/10 checks)
- Run command: gadugi-test run -d .claude/tests/agentic -s workflow-skill-recipe-runner-alignment
- Run target: local env
- Run result: passed (10/10 checks)

### Documentation

- User-facing docs impact: no
- Updated docs: none (internal agent instruction files only)
- PR description links added: n/a
- Rationale if not applicable: Changed files are .claude/skills/ SKILL.md files (internal agent instructions), amplifier-bundle/skills/ (packaged copies), docs/claude/skills/ (docs mirror), and a test scenario. None are user-facing APIs, CLI commands, or configuration.

### Quality-audit

- Cycle 1 summary: 3 findings - /dev trigger conflict with dev-orchestrator, /investigate trigger doesnt match actual command, broken CATALOG.md reference. All 3 fixed.
- Cycle 2 summary: 2 findings - amplifier-bundle/skills/ copies not synced, PYTHONPATH=src wrong for non-amplihack repos. Both fixed.
- Cycle 3 summary: Clean - zero critical/high findings. Non-blocking note about test scope.
- Additional cycles: none
- Final clean cycle: 3 (zero critical/high, zero medium correctness/security findings)
- Fixes followed default-workflow: yes (adaptive strategy due to recipe runner hang in Copilot CLI runtime)
- Convergence summary: 3 cycles with monotonic decrease in findings (3 to 2 to 0), cycle 3 clean

### CI

- Checks command: gh pr checks 4365
- Result: pending (Drift Detection now passes after syncing docs/ copies; remaining checks in progress)
- Skipped checks: agent, scan, Scheduled Full Atlas Rebuild, Atlas Staleness Gate (standard skips for non-atlas PRs)
- Flaky reruns performed: none
- Real failures fixed: Drift Detection - fixed by syncing docs/claude/skills/ copies

### Scope

- Changed files reviewed: 7 files - 2 skill rewrites x 3 copy locations + 1 new test scenario
- Unrelated changes: none

### Verdict

- Merge-ready: yes (pending CI green on remaining checks)
- Remaining blockers: CI checks still running
