### PR TITLE
fix: resolve step-07-write-tests LBracket parser error

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -987,7 +987,7 @@ steps:
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -1022,7 +1022,7 @@ steps:
   - id: "step-08-implement"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -1063,7 +1063,7 @@ steps:
   - id: "step-08b-integration"
     agent: "amplihack:integration"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -1137,7 +1137,7 @@ steps:
   # --------------------------------------------------------------------------
   - id: "checkpoint-after-implementation"
     type: "bash"
-    condition: "resume_checkpoint not in ['checkpoint-after-implementation', 'checkpoint-after-review-feedback']"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     command: |
       set -euo pipefail
       WORKTREE_DIR="{{worktree_setup.worktree_path}}"


### PR DESCRIPTION
Replaces Python-style list-membership conditions with equivalent != chains that the Rust recipe runner can parse. Fixes 4 step conditions in default-workflow.yaml (step-07-write-tests, step-08-implement, step-08b-integration, checkpoint-after-implementation).

Closes #4345, #4339, #4330, #4301, #4363