### PR TITLE
fix: update skills to use Rust CLI (amplihack recipe run) over Python paths

### DIFF
--- a/.claude/skills/default-workflow/SKILL.md
+++ b/.claude/skills/default-workflow/SKILL.md
@@ -147,20 +147,23 @@ orchestrator handles the full lifecycle including goal-seeking reflection loops.
 If this skill is activated directly (not via dev-orchestrator), you MUST use the
 recipe runner — **do NOT read the .md file and follow steps manually**:
 
-```python
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    "default-workflow",
-    user_context={
-        "task_description": "TASK_DESCRIPTION_HERE",
-        "repo_path": ".",
-    },
-    progress=True,
-)
+```bash
+amplihack recipe run amplifier-bundle/recipes/default-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="." \
+  --verbose
 ```
 
-Or via shell:
+> **Legacy Python API** (still supported but deprecated):
+>
+> ```python
+> from amplihack.recipes import run_recipe_by_name
+> result = run_recipe_by_name("default-workflow", user_context={
+>     "task_description": "TASK_DESCRIPTION_HERE", "repo_path": ".",
+> }, progress=True)
+> ```
+
+Or via shell (legacy Python wrapper):
 
 ```bash
 cd /path/to/repo && env -u CLAUDECODE \

--- a/.claude/skills/dev-orchestrator/SKILL.md
+++ b/.claude/skills/dev-orchestrator/SKILL.md
@@ -143,9 +143,9 @@ that instructs Claude to invoke `Skill(skill="dev-orchestrator")` for dev/invest
 ## Execution Instructions
 
 **YOUR NEXT ACTION after reading this skill MUST include a Bash tool call that
-executes `run_recipe_by_name("smart-orchestrator")`.** If your runtime requires
-a `report_intent` call (e.g. Copilot CLI), emit it **in parallel** with the
-Bash launch — both tool calls in the same response. The constraint is that no
+executes the recipe runner.** If your runtime requires a `report_intent` call
+(e.g. Copilot CLI), emit it **in parallel** with the Bash launch — both tool
+calls in the same response. The constraint is that no
 _other_ substantive action (reading files, calling TodoWrite, invoking Agent,
 or typing a response) may precede or replace the Bash launch.
 
@@ -169,38 +169,34 @@ When this skill is activated:
 Your next tool call(s) must include the recipe runner launch (alongside
 `report_intent` if your runtime requires it).
 
-#### Default: Direct Execution
+#### Default: Direct Execution (Rust CLI)
 
-The recipe runner is a plain subprocess — it does **not** require tmux.
-Call `run_recipe_by_name()` directly:
+The recipe runner is the Rust `amplihack` binary — invoke it directly:
 
 ```bash
 cd /path/to/repo && env -u CLAUDECODE \
-  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    'smart-orchestrator',
-    user_context={
-        'task_description': '''TASK_DESCRIPTION_HERE''',
-        'repo_path': '.',
-    },
-    progress=True,
-)
-print(f'Recipe result: {result}')
-"
+  AMPLIHACK_HOME=/path/to/amplihack \
+  amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+    -c task_description="TASK_DESCRIPTION_HERE" \
+    -c repo_path="." \
+    --verbose
 ```
 
 **Key points:**
 
-- `PYTHONPATH=${AMPLIHACK_HOME}/src python3` — uses the staged package at `$AMPLIHACK_HOME/src/amplihack/` so `amplihack.recipes` is importable on any project
-- `run_recipe_by_name` — delegates to the Rust binary via `subprocess.Popen`; no tmux involved
-- `progress=True` — streams recipe-runner stderr live so you see nested step activity
+- `amplihack recipe run` — the native Rust binary; no Python wrapper needed
+- `-c key=value` — passes context variables (equivalent to `user_context` dict)
+- `--verbose` — streams recipe-runner stderr live so you see nested step activity
 - The recipe runner manages its own child processes (agent sessions, bash steps) as direct subprocesses
 
 This is the preferred execution mode for most scenarios. It is simpler, has
-no external dependencies beyond Python and the Rust binary, works on all
-platforms, and makes output capture straightforward.
+no external dependencies beyond the Rust binary, works on all platforms,
+and makes output capture straightforward.
+
+> **Legacy Python API** (still supported but deprecated): If the Rust binary is
+> unavailable, you can fall back to the Python wrapper:
+> `PYTHONPATH=${AMPLIHACK_HOME}/src python3 -c "from amplihack.recipes import run_recipe_by_name; ..."`
+> This delegates to the Rust binary via `subprocess.Popen`.
 
 #### Durable Execution (tmux) — optional
 
@@ -213,30 +209,18 @@ Use tmux **only** when:
 
 ```bash
 LOG_FILE=$(mktemp /tmp/recipe-runner-output.XXXXXX.log)
-SCRIPT_FILE=$(mktemp /tmp/recipe-runner-script.XXXXXX.py)
-chmod 600 "$LOG_FILE" "$SCRIPT_FILE"
-cat > "$SCRIPT_FILE" << 'RECIPE_SCRIPT'
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    "smart-orchestrator",
-    user_context={
-        "task_description": """TASK_DESCRIPTION_HERE""",
-        "repo_path": ".",
-    },
-    progress=True,
-)
-print(f"Recipe result: {result}")
-RECIPE_SCRIPT
+chmod 600 "$LOG_FILE"
 tmux new-session -d -s recipe-runner \
   "cd /path/to/repo && env -u CLAUDECODE \
-   AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=\${AMPLIHACK_HOME:-~/.amplihack}/src python3 $SCRIPT_FILE 2>&1 | tee $LOG_FILE"
+   AMPLIHACK_HOME=/path/to/amplihack \
+   amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+     -c task_description='TASK_DESCRIPTION_HERE' \
+     -c repo_path='.' \
+     --verbose 2>&1 | tee $LOG_FILE"
 echo "Recipe runner log: $LOG_FILE"
 ```
 
-- The Python payload is written to a temp script to avoid nested quoting
-  issues that cause silent launch failures (see issue #3215)
-- `chmod 600 "$LOG_FILE" "$SCRIPT_FILE"` — keeps both files private
+- `chmod 600 "$LOG_FILE"` — keeps the log file private
 - `tmux new-session -d` — detached session, no timeout, survives disconnects
 - Monitor with: `tail -f "$LOG_FILE"` or `tmux attach -t recipe-runner`
 
@@ -266,12 +250,9 @@ Investigation tasks.** Always try `smart-orchestrator` first.
 - `AMPLIHACK_HOME` — Auto-detected from the current working directory by
   walking parent directories for an `amplifier-bundle/` folder, with fallback
   to `~/.amplihack`. If auto-detection fails, set manually to the directory
-  containing `amplifier-bundle/`. The recipe runner uses this to find
-  `amplifier-bundle/tools/orch_helper.py` and other orchestrator scripts.
+  containing `amplifier-bundle/`.
 - Preserve `AMPLIHACK_AGENT_BINARY` — nested workflow agents read this env var
   to stay on the caller's active binary (for example, Copilot in Copilot CLI).
-  The Python wrapper no longer forwards the removed `--agent-binary` CLI flag,
-  so keeping this env var set is now the correct behavior.
 - Unset `CLAUDECODE` — required so nested Claude Code sessions can launch.
 
 **Fallback: Direct recipe invocation when smart-orchestrator fails.**
@@ -291,10 +272,10 @@ recipe directly based on your classification:
 
 Example:
 
-```python
-run_recipe_by_name("investigation-workflow", user_context={
-    'task_description': task, 'repo_path': '.',
-}, progress=True)
+```bash
+amplihack recipe run amplifier-bundle/recipes/investigation-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="."
 ```
 
 This is NOT a license to bypass `smart-orchestrator`. Only use direct
@@ -365,11 +346,13 @@ is wrong), you MAY invoke the specific workflow recipe directly. This is an
 
 Example:
 
-```python
+```bash
 # ANNOUNCE the strategy change first — never do this silently
-print("[ADAPTIVE] smart-orchestrator failed at parse-decomposition: <error>")
-print("[ADAPTIVE] Switching to direct investigation-workflow invocation")
-run_recipe_by_name("investigation-workflow", user_context={...}, progress=True)
+echo "[ADAPTIVE] smart-orchestrator failed at parse-decomposition: <error>"
+echo "[ADAPTIVE] Switching to direct investigation-workflow invocation"
+amplihack recipe run amplifier-bundle/recipes/investigation-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="."
 ```
 
 **This is NOT a license to bypass smart-orchestrator.** Always try it first.
@@ -401,7 +384,7 @@ The recipe runner requires these environment variables to function:
 | `AMPLIHACK_NONINTERACTIVE` | Set to `1` to skip interactive prompts            | Unset           |
 
 If `AMPLIHACK_HOME` is not set and auto-detection fails, `parse-decomposition`
-and `activate-workflow` will fail with "orch_helper.py not found". Set it to
+and `activate-workflow` will fail with asset lookup errors. Set it to
 the directory containing `amplifier-bundle/`.
 
 ### After Execution: Reflect and verify
@@ -453,15 +436,11 @@ the mandatory workflow. State is stored in `/tmp/amplihack-workflow-state/`.
 recipe user_context to prevent automatic parallel decomposition regardless of
 task structure. This is a programmatic option (not directly settable from `/dev`):
 
-```python
-run_recipe_by_name(
-    "smart-orchestrator",
-    user_context={
-        "task_description": task,
-        "repo_path": ".",
-        "force_single_workstream": "true",  # disables parallel decomposition
-    }
-)
+```bash
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="." \
+  -c force_single_workstream="true"
 ```
 
 **To force single-workstream execution without modifying recipe context:**

--- a/.claude/skills/investigation-workflow/SKILL.md
+++ b/.claude/skills/investigation-workflow/SKILL.md
@@ -128,20 +128,23 @@ orchestrator handles the full lifecycle including goal-seeking reflection loops.
 If this skill is activated directly (not via dev-orchestrator), you MUST use the
 recipe runner — **do NOT read the .md file and follow phases manually**:
 
-```python
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    "investigation-workflow",
-    user_context={
-        "task_description": "TASK_DESCRIPTION_HERE",
-        "repo_path": ".",
-    },
-    progress=True,
-)
+```bash
+amplihack recipe run amplifier-bundle/recipes/investigation-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="." \
+  --verbose
 ```
 
-Or via shell:
+> **Legacy Python API** (still supported but deprecated):
+>
+> ```python
+> from amplihack.recipes import run_recipe_by_name
+> result = run_recipe_by_name("investigation-workflow", user_context={
+>     "task_description": "TASK_DESCRIPTION_HERE", "repo_path": ".",
+> }, progress=True)
+> ```
+
+Or via shell (legacy Python wrapper):
 
 ```bash
 cd /path/to/repo && env -u CLAUDECODE \
@@ -244,11 +247,10 @@ workstream decomposition, and adaptive error recovery on top of this workflow.
 reflection loop. If running standalone, transition by launching the
 `default-workflow` recipe:
 
-```python
-run_recipe_by_name("default-workflow", user_context={
-    "task_description": "Implement findings from investigation...",
-    "repo_path": ".",
-}, progress=True)
+```bash
+amplihack recipe run amplifier-bundle/recipes/default-workflow.yaml \
+  -c task_description="Implement findings from investigation..." \
+  -c repo_path="."
 ```
 
 ## Integration with Dev Orchestrator

--- a/.claude/skills/multitask/SKILL.md
+++ b/.claude/skills/multitask/SKILL.md
@@ -96,14 +96,21 @@ Report: PR numbers, success/failure, runtime
 
 ### Recipe Mode (Default)
 
-Each workstream runs `run_recipe_by_name()` through a Python launcher:
+Each workstream runs `amplihack recipe run` via a launcher script:
 
-```python
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name("default-workflow",
-    user_context={"task_description": task, "repo_path": "."})
+```bash
+amplihack recipe run amplifier-bundle/recipes/default-workflow.yaml \
+  -c task_description="TASK_DESCRIPTION_HERE" \
+  -c repo_path="."
 ```
+
+> **Legacy Python API** (still supported):
+>
+> ```python
+> from amplihack.recipes import run_recipe_by_name
+> result = run_recipe_by_name("default-workflow",
+>     user_context={"task_description": task, "repo_path": "."})
+> ```
 
 ### Classic Mode
 

--- a/.claude/skills/oxidizer-workflow/SKILL.md
+++ b/.claude/skills/oxidizer-workflow/SKILL.md
@@ -44,14 +44,14 @@ is achieved, with quality audit and silent degradation checks on every iteration
 ### Via Recipe Runner
 
 ```bash
-recipe-runner-rs amplifier-bundle/recipes/oxidizer-workflow.yaml \
-  --set python_package_path=src/mypackage \
-  --set rust_target_path=rust/mypackage \
-  --set rust_repo_name=my-rust-package \
-  --set rust_repo_org=myorg
+amplihack recipe run amplifier-bundle/recipes/oxidizer-workflow.yaml \
+  -c python_package_path=src/mypackage \
+  -c rust_target_path=rust/mypackage \
+  -c rust_repo_name=my-rust-package \
+  -c rust_repo_org=myorg
 ```
 
-### Via Python API
+### Via Python API (deprecated — prefer CLI)
 
 ```python
 from amplihack.recipes import run_recipe_by_name

--- a/.claude/skills/quality-audit/SKILL.md
+++ b/.claude/skills/quality-audit/SKILL.md
@@ -192,19 +192,13 @@ Cycle 3: SEEK (deepest) → VALIDATE → FIX → decision
 
 **Run via recipe:**
 
-```python
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    "quality-audit-cycle",
-    user_context={
-        "target_path": "src/amplihack",
-        "repo_path": ".",
-        "min_cycles": "3",
-        "max_cycles": "6",
-    },
-    progress=True,
-)
+```bash
+amplihack recipe run amplifier-bundle/recipes/quality-audit-cycle.yaml \
+  -c target_path=src/amplihack \
+  -c repo_path="." \
+  -c min_cycles=3 \
+  -c max_cycles=6 \
+  --verbose
 ```
 
 ## Configuration
@@ -232,23 +226,17 @@ Override defaults via recipe context or environment:
 
 **Example invocation**:
 
-```python
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    "quality-audit-cycle",
-    user_context={
-        "target_path": "src/amplihack/fleet",
-        "repo_path": ".",
-        "min_cycles": "3",
-        "max_cycles": "6",
-        "severity_threshold": "medium",
-        "module_loc_limit": "300",
-        "fix_all_per_cycle": "true",
-        "categories": "security,reliability,dead_code,silent_fallbacks,error_swallowing",
-    },
-    progress=True,
-)
+```bash
+amplihack recipe run amplifier-bundle/recipes/quality-audit-cycle.yaml \
+  -c target_path=src/amplihack/fleet \
+  -c repo_path="." \
+  -c min_cycles=3 \
+  -c max_cycles=6 \
+  -c severity_threshold=medium \
+  -c module_loc_limit=300 \
+  -c fix_all_per_cycle=true \
+  -c categories="security,reliability,dead_code,silent_fallbacks,error_swallowing" \
+  --verbose
 ```
 
 **Core Settings (environment)**:


### PR DESCRIPTION
## Summary

Updates 6 skill files to use `amplihack recipe run` (Rust CLI) as the primary invocation path instead of Python-specific patterns (`run_recipe_by_name`, `PYTHONPATH`, `python3 -c`).

## Changes

| File | Change |
|------|--------|
| `dev-orchestrator/SKILL.md` | Primary execution → `amplihack recipe run`; tmux fallback simplified; removed Python temp script pattern |
| `default-workflow/SKILL.md` | Rust CLI as primary, Python API demoted to legacy fallback |
| `investigation-workflow/SKILL.md` | Same pattern; transition-to-development example updated |
| `oxidizer-workflow/SKILL.md` | Fixed `recipe-runner-rs` → `amplihack recipe run`; Python API marked deprecated |
| `quality-audit/SKILL.md` | Both invocation examples converted to CLI |
| `multitask/SKILL.md` | Recipe mode uses CLI; Python API preserved as legacy |

## Medium-priority items (intentionally not changed)

- **`mcp-manager`**: Uses `python3 -m mcp-manager.cli` — this is a standalone Python tool with no Rust equivalent yet
- **`transcript-viewer`**: References `launcher_detector.py` and uses `python3` for JSONL parsing — these are utility one-liners, not recipe invocations
- **`gh-work-report`**: Python heredocs for data processing — no Rust equivalent
- **Recipe YAML files** (`quality-audit-cycle.yaml`, `oxidizer-workflow.yaml`): Use inline `python3` for JSON parsing within recipe steps — these are runtime dependencies, not invocation paths

Fixes #4359