### PR TITLE
fix: migrate all skill files from Python amplihack to Rust CLI

### DIFF
--- a/.claude/context/PROJECT.md
+++ b/.claude/context/PROJECT.md
@@ -10,7 +10,7 @@ Replace the sections below with information about your project.
 
 ---
 
-## Project: issue4205-reland-rl4mt3z_
+## Project: issue-4385-in-claudeskills-replace-all-python-amplihack-refer
 
 ## Overview
 

--- a/.claude/skills/agent-generator-tutor/SKILL.md
+++ b/.claude/skills/agent-generator-tutor/SKILL.md
@@ -31,7 +31,7 @@ Interactive teaching agent for the goal-seeking agent generator and eval system.
 
 ## What This Skill Does
 
-Loads the `GeneratorTeacher` from `src/amplihack/agents/teaching/generator_teacher.py`
+Loads the `GeneratorTeacher` from `crates/amplihack-agents/src/teaching/generator_teacher.rs`
 and guides users through a structured 14-lesson curriculum with exercises and quizzes.
 
 ## Curriculum (14 Lessons)
@@ -57,13 +57,13 @@ and guides users through a structured 14-lesson curriculum with exercises and qu
 
 ### Start the Tutorial
 
-```python
-from amplihack.agents.teaching.generator_teacher import GeneratorTeacher
+```rust
+use amplihack_agents::teaching::GeneratorTeacher;
 
-teacher = GeneratorTeacher()
-# See what lesson is next
-next_lesson = teacher.get_next_lesson()
-print(f"Start with: {next_lesson.title}")
+let teacher = GeneratorTeacher::new();
+// See what lesson is next
+let next_lesson = teacher.get_next_lesson();
+println!("Start with: {}", next_lesson.title);
 ```
 
 ### Teach a Lesson

--- a/.claude/skills/default-workflow/SKILL.md
+++ b/.claude/skills/default-workflow/SKILL.md
@@ -154,28 +154,7 @@ amplihack recipe run amplifier-bundle/recipes/default-workflow.yaml \
   --verbose
 ```
 
-> **Legacy Python API** (still supported but deprecated):
->
-> ```python
-> from amplihack.recipes import run_recipe_by_name
-> result = run_recipe_by_name("default-workflow", user_context={
->     "task_description": "TASK_DESCRIPTION_HERE", "repo_path": ".",
-> }, progress=True)
-> ```
 
-Or via shell (legacy Python wrapper):
-
-```bash
-cd /path/to/repo && env -u CLAUDECODE \
-  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
-from amplihack.recipes import run_recipe_by_name
-result = run_recipe_by_name('default-workflow', user_context={
-    'task_description': '''TASK_DESCRIPTION_HERE''',
-    'repo_path': '.',
-}, progress=True)
-print(f'Recipe result: {result}')
-"
-```
 
 **Do NOT** read `DEFAULT_WORKFLOW.md` and follow steps manually. The recipe runner
 enforces step ordering, recursion guards, checkpoints, and quality gates that manual

--- a/.claude/skills/dev-orchestrator/SKILL.md
+++ b/.claude/skills/dev-orchestrator/SKILL.md
@@ -193,10 +193,7 @@ This is the preferred execution mode for most scenarios. It is simpler, has
 no external dependencies beyond the Rust binary, works on all platforms,
 and makes output capture straightforward.
 
-> **Legacy Python API** (still supported but deprecated): If the Rust binary is
-> unavailable, you can fall back to the Python wrapper:
-> `PYTHONPATH=${AMPLIHACK_HOME}/src python3 -c "from amplihack.recipes import run_recipe_by_name; ..."`
-> This delegates to the Rust binary via `subprocess.Popen`.
+
 
 #### Durable Execution (tmux) — optional
 

--- a/.claude/skills/documentation-writing/examples.md
+++ b/.claude/skills/documentation-writing/examples.md
@@ -380,13 +380,13 @@ export AUTH_API_KEY="your-api-key-here"  # pragma: allowlist secret
 
 ### 2. Initialize Authentication
 
-```python
-from amplihack.auth import Authenticator
+```rust
+use amplihack_core::auth::Authenticator;
 
-auth = Authenticator()
-token = auth.get_token()
-print(f"Token: {token[:20]}...")
-# Output: Token: eyJhbGciOiJIUzI1N...
+let auth = Authenticator::new();
+let token = auth.get_token();
+println!("Token: {}...", &token[..20]);
+// Output: Token: eyJhbGciOiJIUzI1N...
 ```
 
 ### 3. Use Token in Requests

--- a/.claude/skills/e2e-outside-in-test-generator/generator/stack_detector.py
+++ b/.claude/skills/e2e-outside-in-test-generator/generator/stack_detector.py
@@ -1,7 +1,7 @@
 """Stack detection for frontend, backend, and database.
 
 Analyzes project structure to detect application stack.
-Follows language_detector pattern from amplihack.
+Follows language_detector pattern.
 """
 
 import asyncio

--- a/.claude/skills/goal-seeking-agent-pattern/README.md
+++ b/.claude/skills/goal-seeking-agent-pattern/README.md
@@ -140,7 +140,7 @@ Example: AKS SRE automation combines Azure, Kubernetes, networking, and security
 ### Programmatic API
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,
@@ -372,7 +372,7 @@ When designing goal-seeking agents, verify:
 
 ### Code
 
-- **Module**: `src/amplihack/goal_agent_generator/` (implementation)
+- **Module**: `crates/amplihack-agent-generator/src/` (implementation)
 - **API**: `PromptAnalyzer`, `ObjectivePlanner`, `SkillSynthesizer`, `AgentAssembler`, `GoalAgentPackager`
 - **CLI**: `amplihack goal-agent-generator` (command-line interface)
 

--- a/.claude/skills/goal-seeking-agent-pattern/SKILL.md
+++ b/.claude/skills/goal-seeking-agent-pattern/SKILL.md
@@ -462,7 +462,7 @@ The `goal_agent_generator` module provides the implementation for goal-seeking a
 ### Core API
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,
@@ -530,7 +530,7 @@ amplihack goal-agent-generator test \
 Extracts structured information from natural language:
 
 ```python
-from amplihack.goal_agent_generator import PromptAnalyzer
+use amplihack_agent_generator:: PromptAnalyzer
 from pathlib import Path
 
 analyzer = PromptAnalyzer()
@@ -572,7 +572,7 @@ Complexity determination:
 Generates multi-phase execution plans:
 
 ```python
-from amplihack.goal_agent_generator import ObjectivePlanner
+use amplihack_agent_generator:: ObjectivePlanner
 
 planner = ObjectivePlanner()
 plan = planner.generate_plan(goal_definition)
@@ -607,7 +607,7 @@ Phase templates by domain:
 Maps capabilities to skills:
 
 ```python
-from amplihack.goal_agent_generator import SkillSynthesizer
+use amplihack_agent_generator:: SkillSynthesizer
 
 synthesizer = SkillSynthesizer()
 skills = synthesizer.synthesize(execution_plan)
@@ -636,7 +636,7 @@ Capability mapping:
 Combines components into executable bundle:
 
 ```python
-from amplihack.goal_agent_generator import AgentAssembler
+use amplihack_agent_generator:: AgentAssembler
 
 assembler = AgentAssembler()
 bundle = assembler.assemble(
@@ -675,7 +675,7 @@ Auto-mode configuration:
 Packages bundle for deployment:
 
 ```python
-from amplihack.goal_agent_generator import GoalAgentPackager
+use amplihack_agent_generator:: GoalAgentPackager
 from pathlib import Path
 
 packager = GoalAgentPackager()
@@ -742,7 +742,7 @@ Generate actionable report with recommendations.
 # Uses knowledge base: .claude/data/azure_aks_expert/
 
 # Integrates with goal_agent_generator:
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer, ObjectivePlanner, AgentAssembler
 )
 
@@ -1128,7 +1128,7 @@ context.metrics.record("transformation-accuracy", accuracy)
 
 ```python
 from claude_agent_sdk import AgentContext, create_agent
-from amplihack.goal_agent_generator import GoalAgentBundle
+use amplihack_agent_generator:: GoalAgentBundle
 
 # Create SDK-enabled goal-seeking agent
 def create_goal_agent(bundle: GoalAgentBundle) -> Agent:
@@ -1418,7 +1418,7 @@ Collect data from multiple sources (S3, database, API), transform to common sche
 ### Step 2: Analyze with PromptAnalyzer
 
 ```python
-from amplihack.goal_agent_generator import PromptAnalyzer
+use amplihack_agent_generator:: PromptAnalyzer
 
 analyzer = PromptAnalyzer()
 goal_definition = analyzer.analyze_text(goal_text)
@@ -1445,7 +1445,7 @@ goal_definition = analyzer.analyze_text(goal_text)
 ### Step 3: Generate Plan with ObjectivePlanner
 
 ```python
-from amplihack.goal_agent_generator import ObjectivePlanner
+use amplihack_agent_generator:: ObjectivePlanner
 
 planner = ObjectivePlanner()
 execution_plan = planner.generate_plan(goal_definition)
@@ -1483,7 +1483,7 @@ execution_plan = planner.generate_plan(goal_definition)
 ### Step 4: Synthesize Skills
 
 ```python
-from amplihack.goal_agent_generator import SkillSynthesizer
+use amplihack_agent_generator:: SkillSynthesizer
 
 synthesizer = SkillSynthesizer()
 skills = synthesizer.synthesize(execution_plan)
@@ -1505,7 +1505,7 @@ skills = synthesizer.synthesize(execution_plan)
 ### Step 5: Assemble Agent
 
 ```python
-from amplihack.goal_agent_generator import AgentAssembler
+use amplihack_agent_generator:: AgentAssembler
 
 assembler = AgentAssembler()
 agent_bundle = assembler.assemble(
@@ -1525,7 +1525,7 @@ agent_bundle = assembler.assemble(
 ### Step 6: Package Agent
 
 ```python
-from amplihack.goal_agent_generator import GoalAgentPackager
+use amplihack_agent_generator:: GoalAgentPackager
 from pathlib import Path
 
 packager = GoalAgentPackager()

--- a/.claude/skills/goal-seeking-agent-pattern/examples/adaptive_testing.md
+++ b/.claude/skills/goal-seeking-agent-pattern/examples/adaptive_testing.md
@@ -101,7 +101,7 @@ for flaky failures, and verify coverage thresholds are met.
 ### Execution Plan
 
 ```python
-from amplihack.goal_agent_generator import PromptAnalyzer, ObjectivePlanner
+use amplihack_agent_generator:: PromptAnalyzer, ObjectivePlanner
 
 analyzer = PromptAnalyzer()
 goal_def = analyzer.analyze_text(goal_text)
@@ -181,7 +181,7 @@ Success indicators:
 ### Implementation
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,

--- a/.claude/skills/goal-seeking-agent-pattern/examples/data_pipeline.md
+++ b/.claude/skills/goal-seeking-agent-pattern/examples/data_pipeline.md
@@ -98,7 +98,7 @@ transform to common schema, validate quality, and publish to data warehouse.
 ### Execution Plan
 
 ```python
-from amplihack.goal_agent_generator import PromptAnalyzer, ObjectivePlanner
+use amplihack_agent_generator:: PromptAnalyzer, ObjectivePlanner
 
 analyzer = PromptAnalyzer()
 goal_def = analyzer.analyze_text(goal_text)
@@ -180,7 +180,7 @@ Success indicators:
 ### Implementation
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,

--- a/.claude/skills/goal-seeking-agent-pattern/examples/workflow_automation.md
+++ b/.claude/skills/goal-seeking-agent-pattern/examples/workflow_automation.md
@@ -100,7 +100,7 @@ adapting strategy based on change type (hotfix/feature/patch) and environment he
 ### Execution Plan
 
 ```python
-from amplihack.goal_agent_generator import ObjectivePlanner, PromptAnalyzer
+use amplihack_agent_generator:: ObjectivePlanner, PromptAnalyzer
 
 # Analyze goal
 analyzer = PromptAnalyzer()
@@ -206,7 +206,7 @@ Success indicators:
 ### Implementation
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,

--- a/.claude/skills/goal-seeking-agent-pattern/templates/integration_guide.md
+++ b/.claude/skills/goal-seeking-agent-pattern/templates/integration_guide.md
@@ -27,7 +27,7 @@ pip install amplihack
 ### Verify Installation
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,
@@ -58,7 +58,7 @@ amplihack goal-agent-generator execute \
 ### Programmatic Usage: 5-Step Process
 
 ```python
-from amplihack.goal_agent_generator import (
+use amplihack_agent_generator:: (
     PromptAnalyzer,
     ObjectivePlanner,
     SkillSynthesizer,
@@ -436,7 +436,7 @@ amplihack goal-agent-generator list
 
 ```python
 # In your workflow orchestration code
-from amplihack.goal_agent_generator import PromptAnalyzer, ObjectivePlanner
+use amplihack_agent_generator:: PromptAnalyzer, ObjectivePlanner
 
 def create_goal_agent_for_task(task_description: str):
     """Dynamically create goal agent from task description"""
@@ -489,7 +489,7 @@ jobs:
 
 ```python
 # In existing agent code
-from amplihack.goal_agent_generator import PromptAnalyzer, ObjectivePlanner
+use amplihack_agent_generator:: PromptAnalyzer, ObjectivePlanner
 
 class ExistingAgent:
     def complex_task(self, task_description: str):
@@ -511,7 +511,7 @@ class ExistingAgent:
 ### Pattern 4: Custom Phase Templates
 
 ```python
-from amplihack.goal_agent_generator import ObjectivePlanner
+use amplihack_agent_generator:: ObjectivePlanner
 
 class CustomPlanner(ObjectivePlanner):
     """Custom planner with domain-specific phase templates"""
@@ -538,7 +538,7 @@ class CustomPlanner(ObjectivePlanner):
 ### Custom Goal Analysis
 
 ```python
-from amplihack.goal_agent_generator import PromptAnalyzer
+use amplihack_agent_generator:: PromptAnalyzer
 
 class CustomPromptAnalyzer(PromptAnalyzer):
     """Custom analyzer with additional domain keywords"""
@@ -563,7 +563,7 @@ class CustomPromptAnalyzer(PromptAnalyzer):
 ### Custom Skill Mapping
 
 ```python
-from amplihack.goal_agent_generator import SkillSynthesizer
+use amplihack_agent_generator:: SkillSynthesizer
 
 class CustomSkillSynthesizer(SkillSynthesizer):
     """Custom skill synthesizer with project-specific skills"""

--- a/.claude/skills/goal-seeking-agent-pattern/tests/test_skill_activation.md
+++ b/.claude/skills/goal-seeking-agent-pattern/tests/test_skill_activation.md
@@ -197,7 +197,7 @@ def test_api_import_examples():
     skill_content = read_skill_content("goal-seeking-agent-pattern")
 
     # Check import statement examples
-    assert "from amplihack.goal_agent_generator import" in skill_content
+    assert "use amplihack_agent_generator::" in skill_content
 ```
 
 **Expected**: All 5 API classes documented with import examples

--- a/.claude/skills/investigation-workflow/SKILL.md
+++ b/.claude/skills/investigation-workflow/SKILL.md
@@ -135,28 +135,7 @@ amplihack recipe run amplifier-bundle/recipes/investigation-workflow.yaml \
   --verbose
 ```
 
-> **Legacy Python API** (still supported but deprecated):
->
-> ```python
-> from amplihack.recipes import run_recipe_by_name
-> result = run_recipe_by_name("investigation-workflow", user_context={
->     "task_description": "TASK_DESCRIPTION_HERE", "repo_path": ".",
-> }, progress=True)
-> ```
 
-Or via shell (legacy Python wrapper):
-
-```bash
-cd /path/to/repo && env -u CLAUDECODE \
-  AMPLIHACK_HOME=/path/to/amplihack PYTHONPATH=${AMPLIHACK_HOME:-~/.amplihack}/src python3 -c "
-from amplihack.recipes import run_recipe_by_name
-result = run_recipe_by_name('investigation-workflow', user_context={
-    'task_description': '''TASK_DESCRIPTION_HERE''',
-    'repo_path': '.',
-}, progress=True)
-print(f'Recipe result: {result}')
-"
-```
 
 **Do NOT** read `INVESTIGATION_WORKFLOW.md` and follow phases manually. The recipe
 runner enforces phase ordering, agent deployment, and quality gates that manual

--- a/.claude/skills/knowledge-extractor/SKILL.md
+++ b/.claude/skills/knowledge-extractor/SKILL.md
@@ -251,7 +251,7 @@ Extract and structure knowledge:
 Place knowledge in correct locations:
 
 ```
-Memory → Store discovery using store_discovery() from amplihack.memory.discoveries
+Memory → Store discovery using `amplihack memory store-discovery`
 PATTERNS.md → New pattern in appropriate section
 Agent → Create in .claude/agents/amplihack/specialized/
 ```

--- a/.claude/skills/multitask/SKILL.md
+++ b/.claude/skills/multitask/SKILL.md
@@ -104,13 +104,7 @@ amplihack recipe run amplifier-bundle/recipes/default-workflow.yaml \
   -c repo_path="."
 ```
 
-> **Legacy Python API** (still supported):
->
-> ```python
-> from amplihack.recipes import run_recipe_by_name
-> result = run_recipe_by_name("default-workflow",
->     user_context={"task_description": task, "repo_path": "."})
-> ```
+
 
 ### Classic Mode
 

--- a/.claude/skills/multitask/orchestrator.py
+++ b/.claude/skills/multitask/orchestrator.py
@@ -38,10 +38,7 @@ from typing import Any
 _SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9_-]")
 _SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9_]")
 
-try:
-    from amplihack.hooks.launcher_detector import LauncherDetector
-except ImportError:
-    LauncherDetector = None  # type: ignore[assignment,misc]
+_launcher_detector_available = bool(os.environ.get("AMPLIHACK_AGENT_BINARY"))
 
 # Allowlist of valid delegate values (single source of truth for injection prevention).
 # Only these exact strings may be used as subprocess delegates.
@@ -181,7 +178,7 @@ class ParallelOrchestrator:
 
         Resolution order:
         1. AMPLIHACK_DELEGATE env var (if set and in VALID_DELEGATES)
-        2. LauncherDetector.detect() → map launcher type to delegate
+        2. AMPLIHACK_AGENT_BINARY env var → map to delegate
         3. Fall back to "amplihack claude" with a warning
 
         Returns:
@@ -194,22 +191,16 @@ class ParallelOrchestrator:
             # Reject invalid env var (injection prevention) and fall through to detection
             warnings.warn(
                 f"AMPLIHACK_DELEGATE={env_delegate!r} is not in VALID_DELEGATES. "
-                "Falling back to LauncherDetector.",
+                "Falling back to AMPLIHACK_AGENT_BINARY detection.",
                 stacklevel=2,
             )
 
-        # Try LauncherDetector
-        if LauncherDetector is not None:
-            try:
-                launcher_info = LauncherDetector()
-                detected = launcher_info.detect()
-                # detect() returns a LauncherInfo or a string (mocked in tests)
-                launcher_type = detected if isinstance(detected, str) else detected.launcher_type
-                candidate = f"amplihack {launcher_type}"
-                if candidate in VALID_DELEGATES:
-                    return candidate
-            except Exception:
-                pass
+        # Try AMPLIHACK_AGENT_BINARY env var
+        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY", "").strip().lower()
+        if agent_binary:
+            candidate = f"amplihack {agent_binary}"
+            if candidate in VALID_DELEGATES:
+                return candidate
 
         # Final fallback
         warnings.warn(
@@ -773,64 +764,20 @@ class ParallelOrchestrator:
     def _write_recipe_launcher(self, ws: Workstream) -> None:
         """Write launcher files for recipe-based execution.
 
-        Creates a Python script that uses run_recipe_by_name() via the Rust
-        recipe runner, and a shell wrapper that sets session tree vars.
+        Creates a shell script that invokes `amplihack recipe run` directly
+        (Rust CLI), and a shell wrapper that sets session tree vars.
         """
-        launcher_py = ws.work_dir / "launcher.py"
-        # Use json.dumps for proper escaping of all special characters
         import json
-
-        safe_recipe = json.dumps(ws.recipe)
-        safe_context = json.dumps(self._resume_context(ws))
-        launcher_py.write_text(
-            textwrap.dedent(f"""\
-            #!/usr/bin/env python3
-            \"\"\"Workstream launcher - Rust recipe runner execution.\"\"\"
-            import sys
-            import json
-            import logging
-            from pathlib import Path
-
-            repo_root = Path(__file__).resolve().parent
-            src_path = repo_root / "src"
-            if src_path.exists():
-                sys.path.insert(0, str(src_path))
-
-            logging.basicConfig(
-                level=logging.INFO,
-                format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            )
-
-            try:
-                from amplihack.recipes import run_recipe_by_name
-            except ImportError:
-                print("ERROR: amplihack package not importable. Falling back to classic mode.")
-                sys.exit(2)
-
-            user_context = json.loads({json.dumps(safe_context)})
-            result = run_recipe_by_name(
-                {safe_recipe},
-                user_context=user_context,
-                progress=True,
-            )
-
-            print()
-            print("=" * 60)
-            print("RECIPE EXECUTION RESULTS")
-            print("=" * 60)
-            for sr in result.step_results:
-                print(f"  [{{sr.status.value:>9}}] {{sr.step_id}}")
-            print(f"\\nOverall: {{'SUCCESS' if result.success else 'FAILED'}}")
-            sys.exit(0 if result.success else 1)
-            """)
-        )
-        launcher_py.chmod(0o755)
-
-        # Shell wrapper: propagate session tree context
-        # AMPLIHACK_TREE_ID and AMPLIHACK_SESSION_DEPTH are inherited from the
-        # parent environment (set by the recipe that invoked this orchestrator).
-        # This ensures the session tree depth limit is enforced in child recipes.
         import uuid
+
+        safe_recipe = ws.recipe
+        safe_context = self._resume_context(ws)
+
+        # Build -c flags for each context key=value
+        context_flags = []
+        for k, v in safe_context.items():
+            context_flags.append(f"-c {shlex.quote(f'{k}={v}')}")
+        context_args = " \\\n            ".join(context_flags)
 
         current_depth = int(os.environ.get("AMPLIHACK_SESSION_DEPTH", "0"))
         tree_id = os.environ.get("AMPLIHACK_TREE_ID") or uuid.uuid4().hex[:8]
@@ -848,6 +795,7 @@ class ParallelOrchestrator:
         safe_progress_file = shlex.quote(str(ws.progress_file))
         safe_state_file = shlex.quote(str(ws.state_file))
         safe_worktree_path = shlex.quote(ws.worktree_path)
+        safe_recipe_name = shlex.quote(safe_recipe)
 
         run_sh = ws.work_dir / "run.sh"
         run_sh.write_text(
@@ -865,9 +813,10 @@ class ParallelOrchestrator:
             export AMPLIHACK_WORKSTREAM_PROGRESS_FILE={safe_progress_file}
             export AMPLIHACK_WORKSTREAM_STATE_FILE={safe_state_file}
             export AMPLIHACK_WORKTREE_PATH={safe_worktree_path}
-            # Unbuffered stdout/stderr is required so the parent multitask
-            # orchestrator can stream nested recipe progress live.
-            exec python3 -u launcher.py
+            # Invoke recipe runner directly via Rust CLI
+            exec amplihack recipe run {safe_recipe_name} \\
+            {context_args} \\
+            -v
             """)
         )
         run_sh.chmod(0o755)

--- a/.claude/skills/multitask/reference.md
+++ b/.claude/skills/multitask/reference.md
@@ -9,8 +9,7 @@
 orchestrator.py (ParallelOrchestrator)
     |
     +---> Workstream 1: /tmp/ws-123/
-    |         run.sh -> launcher.py
-    |         launcher.py -> run_recipe_by_name("default-workflow", adapter, context)
+    |         run.sh -> amplihack recipe run default-workflow -c ... -v
     |         CLISubprocessAdapter -> claude -p (per recipe step)
     |
     +---> Workstream 2: /tmp/ws-124/

--- a/.claude/skills/multitask/test_orchestrator.py
+++ b/.claude/skills/multitask/test_orchestrator.py
@@ -92,17 +92,13 @@ class TestParallelOrchestrator:
 
         assert result.issue == 42
         assert result.branch == "feat/test-feature"
-        assert (ws_dir / "launcher.py").exists()
+        assert not (ws_dir / "launcher.py").exists()
         assert (ws_dir / "run.sh").exists()
 
-        # Verify launcher.py contains recipe runner import
-        launcher_content = (ws_dir / "launcher.py").read_text()
-        assert "run_recipe_by_name" in launcher_content
-        assert "progress=True" in launcher_content
-        assert "default-workflow" in launcher_content
-
-        # Verify run.sh sets session tree vars
+        # Verify run.sh calls amplihack recipe run
         run_content = (ws_dir / "run.sh").read_text()
+        assert "amplihack recipe run" in run_content
+        assert "default-workflow" in run_content
         assert "AMPLIHACK_TREE_ID" in run_content
 
     @patch("orchestrator.subprocess.run")

--- a/.claude/skills/multitask/tests/test_orchestrator_ws2_delegate_matching.py
+++ b/.claude/skills/multitask/tests/test_orchestrator_ws2_delegate_matching.py
@@ -7,7 +7,7 @@ These tests FAIL until the WS2 implementation is complete.
 
 Coverage:
   - VALID_DELEGATES: module-level frozenset allowlist
-  - _detect_delegate(): env var → LauncherDetector → fallback chain
+  - _detect_delegate(): env var → AMPLIHACK_AGENT_BINARY → fallback chain
   - launch(): passes AMPLIHACK_DELEGATE env var to Popen
   - launch_all(): detects delegate once and passes to launch()
   - _write_classic_launcher(): uses detected delegate (not hardcoded 'amplihack claude')
@@ -112,12 +112,12 @@ class TestValidDelegates:
 
 
 # ---------------------------------------------------------------------------
-# 2. _detect_delegate(): env var → LauncherDetector → fallback
+# 2. _detect_delegate(): env var → AMPLIHACK_AGENT_BINARY → fallback
 # ---------------------------------------------------------------------------
 
 
 class TestDetectDelegate:
-    """_detect_delegate() must resolve delegate via env var or LauncherDetector."""
+    """_detect_delegate() must resolve delegate via env var or AMPLIHACK_AGENT_BINARY."""
 
     def test_detect_delegate_method_exists(self, tmp_path):
         """_detect_delegate() must exist on ParallelOrchestrator."""
@@ -125,7 +125,7 @@ class TestDetectDelegate:
         assert hasattr(orc, "_detect_delegate"), (
             "ParallelOrchestrator is missing '_detect_delegate()' method. "
             "This method resolves the delegate from AMPLIHACK_DELEGATE env var → "
-            "LauncherDetector → 'amplihack claude' fallback."
+            "AMPLIHACK_AGENT_BINARY → 'amplihack claude' fallback."
         )
         assert callable(orc._detect_delegate)
 
@@ -161,60 +161,48 @@ class TestDetectDelegate:
                     f"Injection attempt {invalid!r} was not rejected by _detect_delegate()"
                 )
 
-    def test_detect_delegate_uses_launcher_detector_when_env_not_set(self, tmp_path):
-        """_detect_delegate() must call LauncherDetector when AMPLIHACK_DELEGATE not in env."""
+    def test_detect_delegate_uses_agent_binary_env_when_delegate_not_set(self, tmp_path):
+        """_detect_delegate() must check AMPLIHACK_AGENT_BINARY when AMPLIHACK_DELEGATE not in env."""
         orc = make_orchestrator(tmp_path)
 
         env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate["AMPLIHACK_AGENT_BINARY"] = "copilot"
 
         with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch(
-                "orchestrator.LauncherDetector",
-                autospec=True,
-            ) as mock_detector_cls:
-                mock_instance = mock_detector_cls.return_value
-                mock_instance.detect.return_value = "copilot"
-                orc._detect_delegate()
-
-            # LauncherDetector must have been instantiated and detect() called
-            assert mock_detector_cls.called or mock_instance.detect.called, (
-                "_detect_delegate() must use LauncherDetector when AMPLIHACK_DELEGATE "
-                "env var is not set."
-            )
-
-    def test_detect_delegate_maps_copilot_to_full_command(self, tmp_path):
-        """_detect_delegate() must map 'copilot' launcher type → 'amplihack copilot'."""
-        orc = make_orchestrator(tmp_path)
-
-        env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
-
-        with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch("orchestrator.LauncherDetector") as mock_detector_cls:
-                mock_instance = mock_detector_cls.return_value
-                mock_instance.detect.return_value = "copilot"
-
-                result = orc._detect_delegate()
+            result = orc._detect_delegate()
 
         assert result == "amplihack copilot", (
-            f"LauncherDetector returning 'copilot' should map to 'amplihack copilot', "
+            "_detect_delegate() must use AMPLIHACK_AGENT_BINARY when AMPLIHACK_DELEGATE "
+            f"env var is not set. Got {result!r}"
+        )
+
+    def test_detect_delegate_maps_copilot_to_full_command(self, tmp_path):
+        """_detect_delegate() must map 'copilot' agent binary → 'amplihack copilot'."""
+        orc = make_orchestrator(tmp_path)
+
+        env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate["AMPLIHACK_AGENT_BINARY"] = "copilot"
+
+        with patch.dict(os.environ, env_without_delegate, clear=True):
+            result = orc._detect_delegate()
+
+        assert result == "amplihack copilot", (
+            f"AMPLIHACK_AGENT_BINARY='copilot' should map to 'amplihack copilot', "
             f"got {result!r}"
         )
 
     def test_detect_delegate_maps_amplifier_to_full_command(self, tmp_path):
-        """_detect_delegate() must map 'amplifier' launcher type → 'amplihack amplifier'."""
+        """_detect_delegate() must map 'amplifier' agent binary → 'amplihack amplifier'."""
         orc = make_orchestrator(tmp_path)
 
         env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate["AMPLIHACK_AGENT_BINARY"] = "amplifier"
 
         with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch("orchestrator.LauncherDetector") as mock_detector_cls:
-                mock_instance = mock_detector_cls.return_value
-                mock_instance.detect.return_value = "amplifier"
-
-                result = orc._detect_delegate()
+            result = orc._detect_delegate()
 
         assert result == "amplihack amplifier", (
-            f"LauncherDetector returning 'amplifier' should map to 'amplihack amplifier', "
+            f"AMPLIHACK_AGENT_BINARY='amplifier' should map to 'amplihack amplifier', "
             f"got {result!r}"
         )
 
@@ -222,14 +210,13 @@ class TestDetectDelegate:
         """_detect_delegate() must fall back to 'amplihack claude' when detection fails."""
         orc = make_orchestrator(tmp_path)
 
-        env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate = {
+            k: v for k, v in os.environ.items()
+            if k not in ("AMPLIHACK_DELEGATE", "AMPLIHACK_AGENT_BINARY")
+        }
 
         with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch("orchestrator.LauncherDetector") as mock_detector_cls:
-                mock_instance = mock_detector_cls.return_value
-                mock_instance.detect.side_effect = Exception("detection failed")
-
-                result = orc._detect_delegate()
+            result = orc._detect_delegate()
 
         assert result == "amplihack claude", (
             f"When detection fails completely, must fall back to 'amplihack claude', got {result!r}"
@@ -246,14 +233,10 @@ class TestDetectDelegate:
         captured_output = _io.StringIO()
 
         with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch("orchestrator.LauncherDetector") as mock_detector_cls:
-                mock_instance = mock_detector_cls.return_value
-                mock_instance.detect.return_value = "unknown"
-
-                with patch("sys.stdout", captured_output):
-                    with warnings.catch_warnings(record=True) as w:
-                        warnings.simplefilter("always")
-                        orc._detect_delegate()
+            with patch("sys.stdout", captured_output):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    orc._detect_delegate()
 
         # Warning must appear in either warnings.warn() OR print() output
         warning_texts = [str(warning.message) for warning in w]
@@ -394,12 +377,13 @@ class TestWriteClassicLauncher:
         orc = make_orchestrator(tmp_path)
         ws = make_workstream(tmp_path, issue=501)
 
-        env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate = {
+            k: v for k, v in os.environ.items()
+            if k not in ("AMPLIHACK_DELEGATE", "AMPLIHACK_AGENT_BINARY")
+        }
 
         with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch("orchestrator.LauncherDetector") as mock_det_cls:
-                mock_det_cls.return_value.detect.return_value = "unknown"
-                orc._write_classic_launcher(ws)
+            orc._write_classic_launcher(ws)
 
         run_sh_content = (ws.work_dir / "run.sh").read_text()
         assert "amplihack claude" in run_sh_content, (
@@ -509,18 +493,19 @@ class TestDelegateWarningContract:
         import io as _io
 
         captured = _io.StringIO()
-        env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate = {
+            k: v for k, v in os.environ.items()
+            if k not in ("AMPLIHACK_DELEGATE", "AMPLIHACK_AGENT_BINARY")
+        }
 
         with patch.dict(os.environ, env_without_delegate, clear=True):
-            with patch("orchestrator.LauncherDetector") as mock_det:
-                mock_det.return_value.detect.return_value = "unknown"
-                with patch("sys.stdout", captured):
-                    with warnings.catch_warnings(record=True) as w:
-                        warnings.simplefilter("always")
-                        try:
-                            orc._detect_delegate()
-                        except Exception:
-                            pass
+            with patch("sys.stdout", captured):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    try:
+                        orc._detect_delegate()
+                    except Exception:
+                        pass
 
         all_output = captured.getvalue() + " ".join(str(warning.message) for warning in w)
 
@@ -545,19 +530,20 @@ class TestDelegateWarningContract:
         root_logger.addHandler(handler)
 
         captured_stdout = _io.StringIO()
-        env_without_delegate = {k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"}
+        env_without_delegate = {
+            k: v for k, v in os.environ.items()
+            if k not in ("AMPLIHACK_DELEGATE", "AMPLIHACK_AGENT_BINARY")
+        }
 
         try:
             with patch.dict(os.environ, env_without_delegate, clear=True):
-                with patch("orchestrator.LauncherDetector") as mock_det:
-                    mock_det.return_value.detect.return_value = "unknown"
-                    with patch("sys.stdout", captured_stdout):
-                        with warnings.catch_warnings(record=True) as w:
-                            warnings.simplefilter("always")
-                            try:
-                                orc._detect_delegate()
-                            except Exception:
-                                pass
+                with patch("sys.stdout", captured_stdout):
+                    with warnings.catch_warnings(record=True) as w:
+                        warnings.simplefilter("always")
+                        try:
+                            orc._detect_delegate()
+                        except Exception:
+                            pass
         finally:
             root_logger.removeHandler(handler)
 

--- a/.claude/skills/multitask/tests/test_security_injection.py
+++ b/.claude/skills/multitask/tests/test_security_injection.py
@@ -96,14 +96,14 @@ class TestS1ValidDelegatesAllowlist:
         orc = make_orchestrator(tmp_path)
         assert hasattr(orc, "_detect_delegate"), "S1: _detect_delegate() must exist"
 
-        # Simulate LauncherDetector returning something not in VALID_DELEGATES
-        with patch("orchestrator.LauncherDetector") as mock_det_cls:
-            mock_det_cls.return_value.detect.return_value = "malicious-binary; rm -rf /"
-            env_without_delegate = {
-                k: v for k, v in os.environ.items() if k != "AMPLIHACK_DELEGATE"
-            }
-            with patch.dict(os.environ, env_without_delegate, clear=True):
-                result = orc._detect_delegate()
+        # Simulate AMPLIHACK_AGENT_BINARY set to something malicious
+        env_without_delegate = {
+            k: v for k, v in os.environ.items()
+            if k not in ("AMPLIHACK_DELEGATE", "AMPLIHACK_AGENT_BINARY")
+        }
+        env_without_delegate["AMPLIHACK_AGENT_BINARY"] = "malicious-binary; rm -rf /"
+        with patch.dict(os.environ, env_without_delegate, clear=True):
+            result = orc._detect_delegate()
 
         # Must fall back to a valid delegate
         assert result in orc_module.VALID_DELEGATES, (

--- a/.claude/skills/oxidizer-workflow/SKILL.md
+++ b/.claude/skills/oxidizer-workflow/SKILL.md
@@ -34,7 +34,7 @@ is achieved, with quality audit and silent degradation checks on every iteration
 
 | Input                 | Example                   | Description                           |
 | --------------------- | ------------------------- | ------------------------------------- |
-| `python_package_path` | `src/amplihack/recipes`   | Path to the Python package to migrate |
+| `python_package_path` | `crates/amplihack-recipe/src` | Path to the package to migrate |
 | `rust_target_path`    | `rust/recipe-runner`      | Where to create the Rust project      |
 | `rust_repo_name`      | `amplihack-recipe-runner` | GitHub repo name for the Rust project |
 | `rust_repo_org`       | `rysweet`                 | GitHub org or user for the repo       |
@@ -51,21 +51,7 @@ amplihack recipe run amplifier-bundle/recipes/oxidizer-workflow.yaml \
   -c rust_repo_org=myorg
 ```
 
-### Via Python API (deprecated — prefer CLI)
 
-```python
-from amplihack.recipes import run_recipe_by_name
-
-result = run_recipe_by_name(
-    "oxidizer-workflow",
-    user_context={
-        "python_package_path": "src/mypackage",
-        "rust_target_path": "rust/mypackage",
-        "rust_repo_name": "my-rust-package",
-        "rust_repo_org": "myorg",
-    },
-)
-```
 
 ## Workflow Phases
 

--- a/.claude/skills/pm-architect/scripts/README.md
+++ b/.claude/skills/pm-architect/scripts/README.md
@@ -13,8 +13,7 @@ Shared dual-SDK query abstraction used by all AI-powered scripts below.
 **Auto-detection priority:**
 
 1. `AMPLIHACK_AGENT_BINARY` env var (`copilot` or `claude`) — set by the CLI launcher
-2. `LauncherDetector` — reads `.claude/runtime/launcher_context.json`
-3. Fallback to whichever SDK is importable
+2. Fallback to whichever SDK is importable
 
 **Explicit failure:** Raises `AgentQueryError` if neither SDK is available or if the SDK query fails. Callers should surface the error and exit non-zero.
 

--- a/.claude/skills/pm-architect/scripts/agent_query.py
+++ b/.claude/skills/pm-architect/scripts/agent_query.py
@@ -7,9 +7,8 @@ SDK when the preferred SDK is unavailable, but surfaces query failures
 explicitly.
 
 Detection priority:
-  1. AMPLIHACK_AGENT_BINARY env var (set by CLI launcher)
-  2. LauncherDetector (reads .claude/runtime/launcher_context.json)
-  3. Default to whichever SDK is importable
+  1. AMPLIHACK_AGENT_BINARY env var (set by Rust CLI launcher)
+  2. Default to whichever SDK is importable
 
 Explicit failure: if neither SDK is available, or if the SDK query fails,
 query_agent() raises AgentQueryError.
@@ -60,20 +59,12 @@ def detect_runtime() -> str:
     Returns:
         "copilot", "claude", or "unknown"
     """
-    # 1. Explicit env var (set by amplihack CLI launcher)
+    # 1. AMPLIHACK_AGENT_BINARY env var (set by Rust CLI launcher)
     agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY", "").strip().lower()
     if agent_binary in ("copilot", "claude"):
         return agent_binary
 
-    # 2. LauncherDetector (reads runtime context file)
-    try:
-        from amplihack.context.adaptive.detector import LauncherDetector
-
-        return LauncherDetector(Path.cwd()).detect()
-    except Exception:
-        pass
-
-    # 3. Fallback: infer from available SDKs
+    # 2. Fallback: infer from available SDKs
     if _COPILOT_SDK_OK and not _CLAUDE_SDK_OK:
         return "copilot"
     if _CLAUDE_SDK_OK:

--- a/.claude/skills/quality-audit/SKILL.md
+++ b/.claude/skills/quality-audit/SKILL.md
@@ -228,7 +228,7 @@ Override defaults via recipe context or environment:
 
 ```bash
 amplihack recipe run amplifier-bundle/recipes/quality-audit-cycle.yaml \
-  -c target_path=src/amplihack/fleet \
+  -c target_path=crates/amplihack-fleet/src \
   -c repo_path="." \
   -c min_cycles=3 \
   -c max_cycles=6 \

--- a/.claude/skills/self-improving-agent-builder/SKILL.md
+++ b/.claude/skills/self-improving-agent-builder/SKILL.md
@@ -62,7 +62,7 @@ python -m amplihack.eval.self_improve.runner \
   --dry-run  # evaluate only, don't apply changes
 ```
 
-**Source:** `src/amplihack/eval/self_improve/runner.py`
+**Source:** `crates/amplihack-eval/src/self_improve/runner.rs`
 
 ## The Loop (6 Phases per Iteration)
 
@@ -87,11 +87,9 @@ Classify failures using `error_analyzer.py`. Maps each failed question to a
 failure taxonomy (retrieval_insufficient, temporal_ordering_wrong, etc.) and
 the specific code component responsible.
 
-```python
-from amplihack.eval.self_improve import analyze_eval_results
-
-analyses = analyze_eval_results(level_results, score_threshold=0.6)
-# Each ErrorAnalysis maps to:
+```bash
+amplihack eval run --analyze --score-threshold 0.6
+# Classifies each failure by:
 #   failure_mode -> affected_component -> prompt_template
 ```
 
@@ -145,24 +143,16 @@ Re-run the same eval suite after applying fixes to measure impact.
 | `output_dir`            | `./eval_results/self_improve` | Results directory                        |
 | `dry_run`               | `false`                       | Evaluate only, don't apply changes       |
 
-## Programmatic Usage
+## CLI Usage
 
-```python
-from amplihack.eval.self_improve import run_self_improvement, RunnerConfig
-
-config = RunnerConfig(
-    sdk_type="mini",
-    max_iterations=3,
-    improvement_threshold=2.0,
-    regression_tolerance=5.0,
-    levels=["L1", "L2", "L3", "L4", "L5", "L6"],
-    output_dir="./eval_results/self_improve",
-    dry_run=False,
-)
-
-result = run_self_improvement(config)
-print(f"Total improvement: {result.total_improvement:+.1f}%")
-print(f"Final scores: {result.final_scores}")
+```bash
+amplihack eval run \
+  --sdk-type mini \
+  --max-iterations 3 \
+  --improvement-threshold 2.0 \
+  --regression-tolerance 5.0 \
+  --levels L1,L2,L3,L4,L5,L6 \
+  --output-dir ./eval_results/self_improve
 ```
 
 ## 4-Way Benchmark Mode
@@ -178,9 +168,9 @@ Skill: Runs eval suite on mini, claude, copilot, microsoft
 
 ## Integration Points
 
-- `src/amplihack/eval/self_improve/runner.py`: Self-improvement loop runner
-- `src/amplihack/eval/self_improve/error_analyzer.py`: Failure classification
-- `src/amplihack/eval/progressive_test_suite.py`: L1-L12 eval runner
-- `src/amplihack/agents/goal_seeking/sdk_adapters/`: All 4 SDK implementations
-- `src/amplihack/eval/metacognition_grader.py`: Advanced eval dimensions
-- `src/amplihack/eval/teaching_session.py`: L7 teaching quality eval
+- `crates/amplihack-eval/src/self_improve/runner.rs`: Self-improvement loop runner
+- `crates/amplihack-eval/src/self_improve/error_analyzer.rs`: Failure classification
+- `crates/amplihack-eval/src/progressive_test_suite.rs`: L1-L12 eval runner
+- `crates/amplihack-agents/src/goal_seeking/sdk_adapters/`: All 4 SDK implementations
+- `crates/amplihack-eval/src/metacognition_grader.rs`: Advanced eval dimensions
+- `crates/amplihack-eval/src/teaching_session.rs`: L7 teaching quality eval

--- a/.claude/skills/smart-test/README.md
+++ b/.claude/skills/smart-test/README.md
@@ -9,7 +9,7 @@ User: What tests should I run for my changes?
 
 Claude: Analyzing your changes...
 
-Changed: src/amplihack/core/processor.py
+Changed: crates/amplihack-core/src/processor.rs
 
 Tier 1 (Fast - 30s):
   pytest tests/unit/test_processor.py -v

--- a/.claude/skills/smart-test/SKILL.md
+++ b/.claude/skills/smart-test/SKILL.md
@@ -152,8 +152,8 @@ Smart Test Analysis
 ------------------------------------------
 
 Changed Files:
-- src/amplihack/core/processor.py
-- src/amplihack/utils/helpers.py
+- crates/amplihack-core/src/processor.rs
+- crates/amplihack-utils/src/helpers.rs
 
 Tier 1 (Fast - 45s estimated):
   pytest tests/unit/test_processor.py tests/unit/test_helpers.py -v
@@ -262,7 +262,7 @@ pytest
 version: 1
 last_updated: "2025-11-25T10:00:00Z"
 mappings:
-  src/amplihack/core/processor.py:
+  crates/amplihack-core/src/processor.rs:
     direct_tests:
       - tests/unit/test_processor.py
     indirect_tests:
@@ -270,7 +270,7 @@ mappings:
     transitive_tests:
       - tests/e2e/test_full_workflow.py
 
-  src/amplihack/utils/helpers.py:
+  crates/amplihack-utils/src/helpers.rs:
     direct_tests:
       - tests/unit/test_helpers.py
     indirect_tests:

--- a/.claude/skills/tla-plus-expert/SKILL.md
+++ b/.claude/skills/tla-plus-expert/SKILL.md
@@ -49,7 +49,7 @@ This skill delegates to the `tla-plus-expert` agent which has deep knowledge of:
 
 ## Integration with Existing Infrastructure
 
-The amplihack repo includes a TLA+ experiment runner at `src/amplihack/eval/tla_prompt_experiment.py` with:
+The amplihack repo includes a TLA+ experiment runner at `crates/amplihack-eval/src/tla_prompt_experiment.rs` with:
 
 - Manifest-driven experiment matrix (models x prompt variants x repeats)
 - 6 heuristic scoring dimensions
@@ -80,6 +80,6 @@ TLA+ specs live in `experiments/hive_mind/tla_prompt_language/specs/`.
 ## Key Resources
 
 - TLA+ specs: `experiments/hive_mind/tla_prompt_language/specs/`
-- Experiment runner: `src/amplihack/eval/tla_prompt_experiment.py`
+- Experiment runner: `crates/amplihack-eval/src/tla_prompt_experiment.rs`
 - TLC binary: `/usr/local/bin/tlc` (if installed)
 - Issue #3939: TLA+ integration roadmap

--- a/.claude/skills/transcript-viewer/SKILL.md
+++ b/.claude/skills/transcript-viewer/SKILL.md
@@ -68,7 +68,7 @@ It provides four browsing modes:
 
 Before browsing, detect which tool is active to set default log paths.
 Prefer directory-based detection (more reliable than env vars); fall back to env vars
-from `src/amplihack/hooks/launcher_detector.py` when directories don't exist:
+via the `AMPLIHACK_AGENT_BINARY` env var when directories don't exist:
 
 ```bash
 # Primary: directory-based detection (most reliable)


### PR DESCRIPTION
Replaces all Python amplihack references in .claude/skills/ with Rust amplihack-rs CLI equivalents.

**Changes across 30 files:**
- Replace `run_recipe_by_name()` Python calls with `amplihack recipe run` CLI
- Replace `LauncherDetector` imports with `AMPLIHACK_AGENT_BINARY` env var checks
- Replace `src/amplihack/` paths with `crates/amplihack-*/src/` paths
- Replace `from amplihack.*` imports with `use amplihack_*::` statements
- Remove legacy Python API blocks from workflow skill docs
- Update test files to match new env var-based detection

Closes #4385