### PR TITLE
fix(default-workflow): re-prune worktree registrations after rm -rf orphan dirs

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -815,6 +815,9 @@ steps:
           echo "INFO: Removing orphaned worktree directory '${WORKTREE_PATH}'" >&2
           rm -rf "${WORKTREE_PATH}"
         fi
+        # Re-prune in case the path is still registered in .git/worktrees/
+        # (rm -rf above can leave a stale registration that blocks `worktree add`)
+        git worktree prune >&2
         if [ "$REATTACH_OK" = true ]; then
           git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
         else
@@ -830,6 +833,8 @@ steps:
           echo "INFO: Removing orphaned worktree directory '${WORKTREE_PATH}'" >&2
           rm -rf "${WORKTREE_PATH}"
         fi
+        # Re-prune in case the path is still registered in .git/worktrees/
+        git worktree prune >&2
         git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" "$BASE_WORKTREE_REF" >&2
         CREATED=true
       fi


### PR DESCRIPTION
## Summary

`step-04-setup-worktree` has two branches (existing-branch+missing-worktree, and new-branch+orphan-dir-present) that delete an orphaned worktree directory before calling `git worktree add`. They forget to re-run `git worktree prune` between the `rm -rf` and the `add`, so if a stale `.git/worktrees/<dir>` registration is still around the add fails with:

```
fatal: '<path>' is a missing but already registered worktree;
use 'add -f' to override, or 'prune' or 'remove' to clear
```

This bites whenever a previous run was killed mid-stream, or when an operator did `rm -rf worktrees/foo` out-of-band.

## Fix

Add `git worktree prune` after each orphan-dir cleanup, before the next `worktree add`. Two places, three lines each.

## Test

Reproduced in cloud-ecosystem-security/Powderfinger when running `smart-orchestrator` after a partial cleanup; the recipe now succeeds with this fix applied (also installed locally to /home/azureuser/.amplihack/amplifier-bundle/recipes/).