### PR TITLE
fix: stage amplifier-bundle to ~/.amplihack on install (issue #243)

### DIFF
--- a/src/amplihack/install.py
+++ b/src/amplihack/install.py
@@ -301,6 +301,44 @@ def write_manifest(files: list[str], dirs: list[str]) -> None:
     write_json_atomic(MANIFEST_JSON, {"files": files, "dirs": dirs})
 
 
+def _stage_amplifier_bundle(repo_root) -> None:
+    """Stage the amplifier-bundle directory into ~/.amplihack/amplifier-bundle/.
+
+    Mirrors the Rust copy_amplifier_bundle helper in amplihack-rs
+    (install/directories.rs): recursively copies <repo_root>/amplifier-bundle/
+    into the user's ~/.amplihack/ runtime location so external-repo workflows
+    can locate bundled agents, recipes, and tools.
+
+    Args:
+        repo_root: Path to the repository root containing amplifier-bundle/.
+    """
+    repo_root_path = Path(repo_root)
+    candidates = [
+        repo_root_path / "amplifier-bundle",
+        repo_root_path.parent / "amplifier-bundle",
+    ]
+
+    source_dir = next((c for c in candidates if c.exists()), None)
+    if source_dir is None:
+        print(
+            f"   ⚠️  amplifier-bundle/ not found under {repo_root_path}; "
+            "skipping bundle staging"
+        )
+        return
+
+    target_dir = Path.home() / ".amplihack" / "amplifier-bundle"
+
+    if os.path.realpath(source_dir) == os.path.realpath(target_dir):
+        return
+
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copytree(source_dir, target_dir, dirs_exist_ok=True)
+        print(f"   ✅ Staged amplifier-bundle to {target_dir}")
+    except OSError as exc:
+        print(f"   ⚠️  Failed to stage amplifier-bundle to {target_dir}: {exc}")
+
+
 def _local_install(repo_root, profile_uri=None):
     """Install amplihack files from the given repo_root directory.
 
@@ -418,6 +456,10 @@ def _local_install(repo_root, profile_uri=None):
     print("\n📂 Creating runtime directories:")
     create_runtime_dirs()
 
+    # Step 4.5: Stage amplifier-bundle into ~/.amplihack/amplifier-bundle/
+    print("\n📦 Staging amplifier-bundle:")
+    _stage_amplifier_bundle(repo_root)
+
     # Step 5: Configure settings.json
     print("\n⚙️  Configuring settings.json:")
     from .settings import ensure_settings_json
@@ -504,6 +546,7 @@ __all__ = [
     "copytree_manifest",
     "create_runtime_dirs",
     "_local_install",
+    "_stage_amplifier_bundle",
     "ensure_dirs",
     "get_all_files_and_dirs",
     "write_manifest",

--- a/src/amplihack/uninstall.py
+++ b/src/amplihack/uninstall.py
@@ -14,6 +14,7 @@ Public API (the "studs"):
 import json
 import os
 import shutil
+from pathlib import Path
 
 # Import constants from package root
 from . import CLAUDE_DIR, MANIFEST_JSON
@@ -154,6 +155,16 @@ def uninstall():
                 removed_any = True
             except Exception as e:
                 print(f"  ⚠️  Could not remove {dir_path}: {e}")
+
+    # Remove staged amplifier-bundle from ~/.amplihack/amplifier-bundle/
+    bundle_dir = Path.home() / ".amplihack" / "amplifier-bundle"
+    if bundle_dir.exists():
+        try:
+            shutil.rmtree(bundle_dir)
+            removed_any = True
+            print(f"   • Removed staged amplifier-bundle at {bundle_dir}")
+        except Exception as e:
+            print(f"  ⚠️  Could not remove {bundle_dir}: {e}")
 
     # Remove manifest file
     try:


### PR DESCRIPTION
Mirrors fix from amplihack-rs PR #244.

## Changes
- Add `_stage_amplifier_bundle(repo_root)` helper in `src/amplihack/install.py` that copies `<repo_root>/amplifier-bundle/` to `~/.amplihack/amplifier-bundle/` using `shutil.copytree(..., dirs_exist_ok=True)`.
- Wire the helper into `_local_install` after runtime directory creation.
- Update `src/amplihack/uninstall.py` `uninstall()` to remove `~/.amplihack/amplifier-bundle/`.

Mirrors the Rust `copy_amplifier_bundle` helper in `install/directories.rs` and follows the staging style of `cli.py:_stage_home_runtime_assets`.

Fixes #243