### PR TITLE
fix(default-workflow): make build_publish_validation_scope.py optional (rysweet/amplihack-recipe-runner#87)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -1946,40 +1946,56 @@ steps:
       # recipe launch time may differ.  Fall back to AMPLIHACK_HOME for repos
       # that don't carry the scripts in-tree (fixes #4321, #4341).
       PRECOMMIT_DIR=""
+      SKIP_PUBLISH_VALIDATION=""
       if [ -f "scripts/pre-commit/build_publish_validation_scope.py" ]; then
         PRECOMMIT_DIR="scripts/pre-commit"
       elif [ -n "${AMPLIHACK_HOME:-}" ] && [ -f "${AMPLIHACK_HOME}/scripts/pre-commit/build_publish_validation_scope.py" ]; then
         PRECOMMIT_DIR="${AMPLIHACK_HOME}/scripts/pre-commit"
+      elif [ -n "${AMPLIHACK_PRECOMMIT_OPTIONAL:-}" ]; then
+        echo "build_publish_validation_scope.py not found; AMPLIHACK_PRECOMMIT_OPTIONAL set, skipping publish-import validation (#87)." >&2
+        SKIP_PUBLISH_VALIDATION="env"
+      elif ! find . -path ./.git -prune -o -name '*.py' -print 2>/dev/null | grep -q .; then
+        echo "build_publish_validation_scope.py not found and no Python files in repo; skipping publish-import validation (#87)." >&2
+        SKIP_PUBLISH_VALIDATION="no-python"
       else
         echo "ERROR: Cannot find build_publish_validation_scope.py in ./scripts/pre-commit/ or \$AMPLIHACK_HOME/scripts/pre-commit/" >&2
+        echo "       Set AMPLIHACK_PRECOMMIT_OPTIONAL=1 to skip publish-import validation in non-amplihack repos (#87)." >&2
         exit 1
       fi
-      python3 "${PRECOMMIT_DIR}/build_publish_validation_scope.py" \
-        --manifest "$PUBLISH_MANIFEST" \
-        --output "$VALIDATION_SCOPE" \
-        --repo-root . \
-        --exclude-claude-scenarios > "$SCOPE_COUNTS_JSON"
-      # Parse scope counts with process substitution instead of fragile nested
-      # heredocs (<<EOFCOUNTS wrapping <<PY).  Fixes #4245.
-      read -r seed_count expanded_local_dep_count validated_count \
-        < <(python3 -c "import json,sys,pathlib; d=json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')); print(d['seed_count'],d['expanded_local_dep_count'],d['validated_count'])" "$SCOPE_COUNTS_JSON")
-      echo "validation_scope=$VALIDATION_SCOPE"
-      echo "seed_count=$seed_count"
-      echo "expanded_local_dep_count=$expanded_local_dep_count"
-      echo "validated_count=$validated_count"
-      if [ "$validated_count" -eq 0 ]; then
-        echo "No Python files in publish scope; treating empty Python surface as success."
+      if [ -n "$SKIP_PUBLISH_VALIDATION" ]; then
+        echo "validation_scope=(skipped: $SKIP_PUBLISH_VALIDATION)"
+        echo "seed_count=0"
+        echo "expanded_local_dep_count=0"
+        echo "validated_count=0"
+        echo "No publish-import validation performed."
       else
-        env -i \
-          PATH="${PATH:-}" \
-          HOME="${HOME:-}" \
-          TMPDIR="${TMPDIR:-/tmp}" \
-          TMP="${TMP:-}" \
-          TEMP="${TEMP:-}" \
-          SYSTEMROOT="${SYSTEMROOT:-}" \
-          USERPROFILE="${USERPROFILE:-}" \
-          PYTHONNOUSERSITE=1 \
-          python3 "${PRECOMMIT_DIR}/check_imports.py" --files-from "$VALIDATION_SCOPE"
+        python3 "${PRECOMMIT_DIR}/build_publish_validation_scope.py" \
+          --manifest "$PUBLISH_MANIFEST" \
+          --output "$VALIDATION_SCOPE" \
+          --repo-root . \
+          --exclude-claude-scenarios > "$SCOPE_COUNTS_JSON"
+        # Parse scope counts with process substitution instead of fragile nested
+        # heredocs (<<EOFCOUNTS wrapping <<PY).  Fixes #4245.
+        read -r seed_count expanded_local_dep_count validated_count \
+          < <(python3 -c "import json,sys,pathlib; d=json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')); print(d['seed_count'],d['expanded_local_dep_count'],d['validated_count'])" "$SCOPE_COUNTS_JSON")
+        echo "validation_scope=$VALIDATION_SCOPE"
+        echo "seed_count=$seed_count"
+        echo "expanded_local_dep_count=$expanded_local_dep_count"
+        echo "validated_count=$validated_count"
+        if [ "$validated_count" -eq 0 ]; then
+          echo "No Python files in publish scope; treating empty Python surface as success."
+        else
+          env -i \
+            PATH="${PATH:-}" \
+            HOME="${HOME:-}" \
+            TMPDIR="${TMPDIR:-/tmp}" \
+            TMP="${TMP:-}" \
+            TEMP="${TEMP:-}" \
+            SYSTEMROOT="${SYSTEMROOT:-}" \
+            USERPROFILE="${USERPROFILE:-}" \
+            PYTHONNOUSERSITE=1 \
+            python3 "${PRECOMMIT_DIR}/check_imports.py" --files-from "$VALIDATION_SCOPE"
+        fi
       fi
       echo ""
       echo "--- Creating Commit ---"


### PR DESCRIPTION
Fixes rysweet/amplihack-recipe-runner#87

## Problem
Recipe runs in repos that don't carry amplihack's `scripts/pre-commit/` directory (and don't have `AMPLIHACK_HOME` pointing at one) failed at step-15 with:

```
✗ step-15-commit-push: Cannot find build_publish_validation_scope.py in ./scripts/pre-commit/ or $AMPLIHACK_HOME/scripts/pre-commit/
```

This Python publish-import validation only matters for repos that publish a Python package — most repos using the recipe are not Python at all.

## Fix
Three behaviors when the script can't be found:

1. **`AMPLIHACK_PRECOMMIT_OPTIONAL=1`** → skip publish-import validation gracefully (explicit opt-in).
2. **No `*.py` files anywhere in repo** → auto-skip (no Python to validate).
3. **Otherwise** → keep the original error, but add a hint pointing to the env-var workaround.

The validation block is now wrapped so the python invocations only run when the script is actually present.

## Test
YAML lints clean (`yaml.safe_load` succeeds). The fix is purely shell logic in a recipe step; no unit-testable code path was changed.