### PR TITLE
fix(default-workflow): honor caller's feature branch as worktree base (#4414)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -698,6 +698,18 @@ steps:
         echo "INFO: No remote configured — using local HEAD as worktree base" >&2
       fi
 
+      # FIX (issue #4414): honor the caller's current feature branch.
+      # If repo_path HEAD is on a non-default branch (i.e. the caller has
+      # already started work on a feature branch and possibly committed to
+      # it), use that branch's HEAD as the worktree base instead of
+      # origin/<default>. Otherwise the recipe would silently branch from
+      # origin/<default> and discard the caller's committed work.
+      CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo '')
+      if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
+        echo "INFO: caller's current branch '$CURRENT_BRANCH' differs from default '$BASE_BRANCH' — using HEAD as worktree base to preserve any committed work." >&2
+        BASE_WORKTREE_REF="HEAD"
+      fi
+
       # NOTE: This slug pipeline is duplicated in consensus-workflow.yaml step3-setup-worktree
       # with a 30-char limit instead of 50. If you update this pipeline (e.g. security patch),
       # update consensus-workflow.yaml in the same commit. See Issue #2952 for context.


### PR DESCRIPTION
Closes #4414.

## Problem

When `default-workflow` is invoked with `-c repo_path=<worktree on existing feature branch>`, the recipe creates a nested `worktrees/feat/issue-N-<slug>/` directory branched from `origin/<default>` rather than honoring the caller's current branch HEAD.

If the caller has committed work on the feature branch, the recipe's implementation phase produces a diff against `origin/<default>` in a separate worktree — the caller must either discard that committed work or manually merge the recipe's output back.

## Fix

In `step-04-setup-worktree`, after computing `BASE_BRANCH` / `BASE_WORKTREE_REF` from `origin/HEAD`, check whether `repo_path`'s current branch differs from the default. If so, switch `BASE_WORKTREE_REF` to `HEAD` so the new worktree branches from the caller's existing tip.

```bash
CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo '')
if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
  BASE_WORKTREE_REF="HEAD"
fi
```

## Behavior preserved

- Default branch (e.g. main): unchanged — worktree branches from `origin/<default>`.
- Detached HEAD: `symbolic-ref --short HEAD` returns empty → no change.
- Already-existing worktree paths handled by the existing #4254 ancestor check.

## Validation

`python3 -c 'import yaml; yaml.safe_load(open(...))'` passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>