### PR TITLE
fix(quality-audit-cycle): forbid fix-agent silent degradation to inline edits (#4388)

### DIFF
--- a/amplifier-bundle/recipes/quality-audit-cycle.yaml
+++ b/amplifier-bundle/recipes/quality-audit-cycle.yaml
@@ -445,6 +445,25 @@ steps:
       22-step development workflow (understand → design → implement → test →
       verify) for each confirmed finding, ensuring proper quality gates.
 
+      **HARD CONSTRAINT — DO NOT SILENTLY DEGRADE (issue #4388):** If
+      default-workflow CANNOT be invoked for any reason — including but not
+      limited to recursion-depth limits, missing skill, or recipe-runner
+      failure — you MUST NOT fall back to direct file edits. Instead:
+
+      1. Emit a clear diagnostic on stderr:
+         "ERROR: fix-agent cannot invoke default-workflow (reason: <reason>).
+         Refusing to silently degrade to inline edits."
+      2. Set STATUS: BLOCKED in the JSON output below
+      3. Populate `fixes_skipped` with each confirmed finding and reason
+         "blocked: default-workflow unavailable"
+      4. Exit the step — do NOT modify any files
+
+      Direct file edits on the current branch (without a default-workflow
+      invocation per finding, producing a branch + commit + PR) are a hard
+      quality-gate violation: they convert a 22-step PR-based workflow into
+      an unreviewed direct push, which is exactly the anti-pattern this
+      audit recipe is designed to detect.
+
       **Priority order (but ALL must be fixed):**
       1. Critical findings (security, silent security degradation)
       2. High findings (error swallowing in critical paths, reliability)
@@ -462,7 +481,8 @@ steps:
         is not a valid reason to skip
 
       End with STATUS: COMPLETE if all confirmed findings fixed,
-      STATUS: PARTIAL if some remain (with reasons for each unfixed finding).
+      STATUS: PARTIAL if some remain (with reasons for each unfixed finding),
+      STATUS: BLOCKED if default-workflow could not be invoked (issue #4388).
 
       Output as JSON:
       ```json
@@ -476,7 +496,7 @@ steps:
         ],
         "total_fixed": 0,
         "total_skipped": 0,
-        "status": "COMPLETE|PARTIAL"
+        "status": "COMPLETE|PARTIAL|BLOCKED"
       }
       ```
     output: "fix_results"


### PR DESCRIPTION
Closes #4388.

## Problem

When `quality-audit-cycle` runs deeply nested (e.g. `min_cycles=6`), the recursion guard blocks fix-agent from invoking `default-workflow` per finding. The agent was **silently degrading to direct file edits on the current branch** — a hard quality-gate violation: the audit recipe converts a 22-step PR-based workflow into an unreviewed direct push to main, which is exactly the anti-pattern the audit is designed to detect.

Reported repro: `amplihack recipe run amplifier-bundle/recipes/quality-audit-cycle.yaml -c min_cycles=6 -c max_cycles=6 -c fix_all_per_cycle=true` produced 26 modified files on `main` with no branch / commit / PR. `✓ fix: completed` reported success.

## Fix (prompt-level guard)

Strengthen the `fix` step prompt to:
1. **Explicitly forbid silent degradation** — direct edits are a hard quality-gate violation.
2. **Require an ERROR diagnostic on stderr** if default-workflow cannot be invoked.
3. **Add STATUS: BLOCKED** as a permitted terminal status alongside COMPLETE / PARTIAL.
4. **Require `fixes_skipped`** to enumerate every confirmed finding when blocked.

## Out of scope (tracked in #4388 follow-ups)

- A deeper structural fix (separate non-recursive PR-creation driver, or recursion-limit lifting for this specific path) is left for a follow-up. This PR addresses the most urgent issue: the **silent** degradation.
- Lifting `AMPLIHACK_MAX_DEPTH` for the audit path requires changes in the recipe-runner and is tracked separately.

## Validation

`python3 -c 'import yaml; yaml.safe_load(open(...))'` passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>