### PR TITLE
fix(smart-orchestrator): no silent fallback to `claude` when AGENT_BINARY unset

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -98,7 +98,38 @@ steps:
   - id: "classify-and-decompose"
     type: "bash"
     command: |
-      AGENT_BIN="${AMPLIHACK_AGENT_BINARY:-claude}"
+      # FIX (#309): No silent fallback to `claude`. If AMPLIHACK_AGENT_BINARY
+      # is not propagated (tmux without -e, nohup, subprocess that clears env,
+      # systemd unit, GitHub Actions job), fail fast with a clear remediation
+      # message instead of silently switching to a different model vendor.
+      if [ -z "${AMPLIHACK_AGENT_BINARY:-}" ]; then
+        # Try to auto-detect a single installed binary as a courtesy fallback.
+        _DETECTED=""
+        for _b in copilot claude codex; do
+          if command -v "$_b" >/dev/null 2>&1; then
+            if [ -z "$_DETECTED" ]; then
+              _DETECTED="$_b"
+            else
+              # Multiple installed; cannot pick one safely.
+              _DETECTED="ambiguous"
+              break
+            fi
+          fi
+        done
+        if [ -z "$_DETECTED" ] || [ "$_DETECTED" = "ambiguous" ]; then
+          echo "ERROR: AMPLIHACK_AGENT_BINARY is not set and a unique agent binary could not be auto-detected." >&2
+          echo "       Set one of:" >&2
+          echo "         - export AMPLIHACK_AGENT_BINARY=copilot   (or claude / codex)" >&2
+          echo "         - tmux new-session -e AMPLIHACK_AGENT_BINARY=copilot ..." >&2
+          echo "         - systemd unit: Environment=AMPLIHACK_AGENT_BINARY=copilot" >&2
+          echo "       Refusing to silently fall back to 'claude' — see issue #309." >&2
+          exit 1
+        fi
+        echo "INFO: AMPLIHACK_AGENT_BINARY unset; auto-detected single installed binary: $_DETECTED" >&2
+        AGENT_BIN="$_DETECTED"
+      else
+        AGENT_BIN="$AMPLIHACK_AGENT_BINARY"
+      fi
       _PROMPT_FILE=$(mktemp)
       trap 'rm -f "$_PROMPT_FILE"' EXIT
       cat > "$_PROMPT_FILE" <<'__AMPLIHACK_CLASSIFY_EOF__'


### PR DESCRIPTION
Closes rysweet/amplihack-rs#309.

## Problem

`amplifier-bundle/recipes/smart-orchestrator.yaml:101` used:

```bash
AGENT_BIN="${AMPLIHACK_AGENT_BINARY:-claude}"
```

If the env var failed to propagate (`tmux` without `-e`, `nohup`, subprocess that clears env, systemd unit, GitHub Actions job), the recipe **silently switched the model vendor**. In Copilot CLI environments where `claude` isn't installed, this surfaced as a misleading error:

```
classify-and-decompose: claude exited 1
stderr: (empty — binary produced no diagnostic output)
hint: verify 'claude' is installed, ANTHROPIC_API_KEY is set, and network is reachable
```

Users then chased a missing-binary red herring instead of the real bug (env var not inherited).

## Fix

1. Detect `AMPLIHACK_AGENT_BINARY` unset.
2. Try to auto-detect a **single** installed binary (`copilot` / `claude` / `codex`).
3. If zero or multiple are installed, **fail fast** with a clear remediation message naming the three propagation paths (env var, tmux `-e`, systemd `Environment=`).
4. Never silently fall back to `claude`.

## Out of scope

- Full TOML config file (`agent.toml`) — leaving for follow-up. The fail-fast + auto-detect already eliminates the silent vendor switch, which is the urgent issue.

## Validation

YAML parse OK.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>