### PR TITLE
fix(investigation-workflow): seed investigation_question from task_description

### DIFF
--- a/amplifier-bundle/recipes/investigation-workflow.yaml
+++ b/amplifier-bundle/recipes/investigation-workflow.yaml
@@ -102,6 +102,26 @@ steps:
     output: "preflight_status"
 
   # ==========================================================================
+  # NORMALIZE QUESTION
+  # When this recipe is launched from smart-orchestrator's multitask path or
+  # any other caller that forwards `task_description` but not
+  # `investigation_question`, promote `task_description` so downstream prompts
+  # have a non-empty question. Without this, every deep-dive agent receives the
+  # literal empty default and reports "no investigation question was provided",
+  # producing hollow success (recipe exits 0 but no real investigation occurs).
+  # An explicitly-supplied `investigation_question` is preserved unchanged.
+  # ==========================================================================
+  - id: "normalize-question"
+    type: "bash"
+    command: |
+      if [ -z "${RECIPE_VAR_investigation_question:-}" ] && [ -n "${RECIPE_VAR_task_description:-}" ]; then
+        printf '%s' "${RECIPE_VAR_task_description}"
+      else
+        printf '%s' "${RECIPE_VAR_investigation_question:-}"
+      fi
+    output: "investigation_question"
+
+  # ==========================================================================
   # INITIALIZATION: Track start time for efficiency metrics
   # ==========================================================================
   - id: "init-tracking"


### PR DESCRIPTION
## Problem

`investigation-workflow` exits with `Status: ✓ Success` while every deep-dive agent reports
"no investigation question was provided" — a hollow-success failure mode.

**Reproduction**: invoke `smart-orchestrator` with any investigation task. The multitask
orchestrator's `_resume_context()` (`.claude/skills/multitask/orchestrator.py:588-612`) builds
a context dict containing `task_description`, `repo_path`, `issue_number`, etc., but does
**not** set `investigation_question`. The investigation recipe declares
`investigation_question: ""` as its sole question variable and uses `{{investigation_question}}`
in 30+ template substitutions, so every spawned agent receives the empty literal.

**Symptoms** (observed in [Simard #1152](https://github.com/rysweet/Simard/issues/1152), Simard #1151, amplihack #896):
- Recipe exits 0
- All agent outputs: "no investigation question was provided" / "all four required scope inputs are empty"
- No findings produced
- Reflection step marks `ACHIEVED` because no work means no failure to detect

## Fix

Add a `normalize-question` bash step immediately after `preflight-validation`:

```yaml
- id: "normalize-question"
  type: "bash"
  command: |
    if [ -z "${RECIPE_VAR_investigation_question:-}" ] && [ -n "${RECIPE_VAR_task_description:-}" ]; then
      printf '%s' "${RECIPE_VAR_task_description}"
    else
      printf '%s' "${RECIPE_VAR_investigation_question:-}"
    fi
  output: "investigation_question"
```

`output: "investigation_question"` overwrites the empty default in place (verified empirically —
recipe-runner-rs supports this). An explicitly-supplied `investigation_question` is preserved.

## Why recipe-local instead of orchestrator-side?

A recipe-local fix handles **all** callers in one place — single workstream, parallel multitask,
direct `amplihack recipe run` invocation — without coupling the orchestrator to recipe-specific
input variable names.

## Verification

Three smoke cases passed locally:

| Case | task_description | investigation_question | Result |
|---|---|---|---|
| Bug case | "audit the auth module" | (empty) | ✓ promoted: "audit the auth module" |
| Explicit wins | "ignored" | "explicit question wins" | ✓ preserved: "explicit question wins" |
| Both empty | (empty) | (empty) | preflight rejects before normalize runs |

## Related

- Hollow-success bug for builder agents in default-workflow (separate root cause:
  `amplihack copilot` spawned without `--allow-all-tools`/`--allow-all-paths` so writes to the
  recipe-output dir and worktree are denied) is being filed as a separate issue.
