### PR TITLE
fix(launcher): add --allow-all-paths to copilot launch_copilot()

### DIFF
--- a/src/amplihack/launcher/copilot.py
+++ b/src/amplihack/launcher/copilot.py
@@ -1520,6 +1520,7 @@ def launch_copilot(args: list[str] | None = None, interactive: bool = True) -> i
     cmd = [
         "copilot",
         "--allow-all-tools",
+        "--allow-all-paths",
     ]
     if not args:
         cmd.extend(


### PR DESCRIPTION
Single-line fix that resolves #4445.

`launch_copilot()` in `launcher/copilot.py` only adds `--allow-all-tools`. When invoked non-interactively as `amplihack copilot -- -p '...'` (recipe-runner builder agents), copilot denies all writes because it can neither prompt the user nor see explicit path approval. Symptom: 'Permission denied and could not request permission from user' for every write, hollow-success runs, no actual commits.

`_normalize_copilot_cli_args()` already prefixes both flags for the wrapper compat path; this PR brings the direct launcher in line.

Verified end-to-end: smart-orchestrator → default-workflow → builder now produces real commits + file modifications. See linked issue for full diagnosis.