### PR TITLE
chore(recipes): bump MIN_RUNNER_VERSION to 0.3.5

### DIFF
--- a/src/amplihack/recipes/rust_runner_binary.py
+++ b/src/amplihack/recipes/rust_runner_binary.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-MIN_RUNNER_VERSION = "0.3.4"
+MIN_RUNNER_VERSION = "0.3.5"
 _REPO_URL = "https://github.com/rysweet/amplihack-recipe-runner"
 
 


### PR DESCRIPTION
## Summary

Bumps the minimum required `recipe-runner-rs` from **0.3.4 → 0.3.5** so `ensure_rust_recipe_runner()` auto-updates existing installs to the fixed binary.

## Why

[recipe-runner-rs v0.3.5](https://github.com/rysweet/amplihack-recipe-runner/releases/tag/v0.3.5) (rysweet/amplihack-recipe-runner#92) fixes the condition parser so postfix access (`.field`, `['k']`, `[i]`, `.method()`) works inside method/function call arguments.

This resolves the `Parse error: unexpected token: LBracket` symptom reported in #4398 (and rysweet/amplihack-rs#313) for users running pre-#71/#81 binaries — e.g. when `default-workflow` step-07-write-tests or `quality-audit-cycle.yaml` evaluated conditions like `validated_findings and validated_findings['confirmed_count'] > 0`.

v0.3.5 also includes a transitive bump of rustls-webpki to 0.103.13 (RUSTSEC-2026-0104).

## Verification

- `MIN_RUNNER_VERSION` is the only literal pin in this repo (`rust_runner.py` re-exports the constant; recipe YAMLs do not pin a version).
- Existing tests in `tests/recipes/test_rust_runner_binary.py` use the constant via import, so they continue to enforce the new minimum.

## Closes

Will close #4398 (with cross-reference to recipe-runner-rs#92) once this lands.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>