### PR TITLE
docs: fix inconsistent command in README Local Development section (closes #4420)

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ Contributing guide:
 git clone https://github.com/rysweet/amplihack.git
 cd amplihack
 uv pip install -e .
-amplihack launch
+amplihack claude
 ```
 
 ### Testing


### PR DESCRIPTION
Good day

## Summary

Fixes issue #4420: the README Local Development section uses `amplihack launch` while the rest of the README uses `amplihack claude`.

## Changes

- Changed `amplihack launch` → `amplihack claude` in the Local Development section to match the rest of the README.

This makes it easier for new contributors to follow along without confusion.

Thank you!

Closely #4420