### PR TITLE
docs: make Code Style section actionable (closes #4421)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,12 +148,15 @@ test: add coverage for recipe validation
 
 ## Code Style
 
-- **Python**: Follow existing code conventions. Pre-commit hooks enforce
-  formatting.
+- **Python**: We use [`ruff`](https://docs.astral.sh/ruff/) for formatting and
+  linting. Run `uv run ruff check .` to check your code and `uv run ruff format .`
+  to auto-fix formatting issues before committing. Pre-commit hooks enforce
+  these checks.
 - **Markdown**: Follow
   [markdownlint](https://github.com/DavidAnson/markdownlint) rules (see
-  `.markdownlint.json`).
-- Keep functions focused and well-documented.
+  `.markdownlint.json`). Run `uv run markdownlint docs/` to check.
+- Keep functions focused and well-documented — aim for functions under 50 lines
+  with a docstring explaining purpose, args, and return value.
 
 ## Pull Request Guidelines
 


### PR DESCRIPTION
## Summary
This PR makes the 'Code Style' section in CONTRIBUTING.md actionable by replacing vague guidance with concrete, runnable commands.

## Before
- **Python**: Follow existing code conventions. Pre-commit hooks enforce formatting.
- **Markdown**: Follow markdownlint rules (see .markdownlint.json).
- Keep functions focused and well-documented.

## After
- **Python**: We use ruff for formatting and linting. Run `uv run ruff check .` to check your code and `uv run ruff format .` to auto-fix formatting issues before committing. Pre-commit hooks enforce these checks.
- **Markdown**: Follow markdownlint rules (see .markdownlint.json). Run `uv run markdownlint docs/` to check.
- Keep functions focused and well-documented — aim for functions under 50 lines with a docstring explaining purpose, args, and return value.

## Why
The original guidance was vague and not actionable for new contributors. By specifying the exact tools (ruff, markdownlint) and the exact commands to run, new contributors can immediately validate their code style before opening a PR.

Closes #4421