### PR TITLE
docs: fix broken path-based links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ ls .github/agents/*.md
 **Note**: Copilot shows "No custom agents configured" until you select one with
 `--agent <name>`.
 
-Full guide: [COPILOT_CLI.md](COPILOT_CLI.md)
+Full guide: [COPILOT_CLI.md](https://rysweet.github.io/amplihack/COPILOT_CLI/)
 
 ### Microsoft Amplifier
 


### PR DESCRIPTION
## Summary

Fix broken path-based link in README.md:

- `[COPILOT_CLI.md](COPILOT_CLI.md)` → `[COPILOT_CLI.md](https://rysweet.github.io/amplihack/COPILOT_CLI/)`

The link to COPILOT_CLI.md was using a relative path that doesn't resolve correctly on GitHub Pages. Updated to use the absolute GitHub Pages URL for proper rendering.

Closes #4408