### PR TITLE
fix(eval): don't wrap sync answer_question with asyncio.run

### DIFF
--- a/src/amplihack/eval/agent_subprocess.py
+++ b/src/amplihack/eval/agent_subprocess.py
@@ -163,9 +163,13 @@ def testing_phase(quiz_questions: list[dict], agent_name: str, sdk: str = "mini"
             question = question_data["question"]
             level = question_data.get("level", "L1")
 
-            # Use agent's answer_question with LLM synthesis and trace
-            result = asyncio.run(
-                agent.answer_question(question, question_level=level, return_trace=True)
+            # Use agent's answer_question with LLM synthesis and trace.
+            # NOTE: answer_question is sync (it returns the value directly via
+            # _run_async_or_return); wrapping with asyncio.run() raised
+            # `ValueError: a coroutine was expected` because asyncio.run was
+            # being handed the already-resolved tuple.
+            result = agent.answer_question(
+                question, question_level=level, return_trace=True
             )
             if isinstance(result, tuple):
                 answer, trace = result


### PR DESCRIPTION
## Symptom
Observed in Simard daemon journal during gym benchmark runs (every L1-L12 testing phase failing):

```
File '/home/.../eval/agent_subprocess.py', line 167, in testing_phase
  result = asyncio.run(
      agent.answer_question(question, question_level=level, return_trace=True)
  )
File '/usr/lib/python3.13/asyncio/runners.py', line 89, in run
  raise ValueError('a coroutine was expected, got {!r}'.format(coro))
ValueError: a coroutine was expected, got ('', ReasoningTrace(...))
```

The bench logs surfaced this as `Testing phase failed: WARNING: amplihack_memory.graph not available`, which obscured the real cause.

## Root cause
`agent.answer_question` is a **sync** method (`AnswerSynthesizerMixin.answer_question` in `src/amplihack/agents/goal_seeking/answer_synthesizer.py:52`) that internally uses `_run_async_or_return` to dispatch to the async implementation and **return the value directly**. Wrapping it with `asyncio.run()` then handed asyncio the already-resolved tuple `('', ReasoningTrace)` instead of a coroutine.

## Fix
Call `agent.answer_question(...)` directly. `learn_from_content` (line 120) is genuinely async and remains wrapped.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>