### PR TITLE
fix(eval): await async grade_metacognition in progressive suite

### DIFF
--- a/src/amplihack/eval/progressive_test_suite.py
+++ b/src/amplihack/eval/progressive_test_suite.py
@@ -18,6 +18,7 @@ Philosophy: Comprehensive evaluation from simple to complex,
 measuring learning capability across multiple dimensions.
 """
 
+import asyncio
 import json
 import statistics
 import subprocess
@@ -488,14 +489,23 @@ def run_single_level(level: TestLevel, config: ProgressiveConfig, level_dir: Pat
                 num_votes=config.grader_votes,
             )
 
-            # Grade metacognition if trace available
+            # Grade metacognition if trace available.
+            # NOTE: grade_metacognition is async; run_single_level is sync,
+            # so we must drive it with asyncio.run. Without the run() wrap
+            # the function returned a coroutine that was never awaited and
+            # the next line raised
+            #   AttributeError: 'coroutine' object has no attribute 'effort_calibration'
+            # while triggering RuntimeWarning: coroutine 'grade_metacognition'
+            # was never awaited (observed in Simard daemon journal).
             metacog = None
             trace = answer_data.get("reasoning_trace")
             if trace:
-                metacog_grade = grade_metacognition(
-                    trace=trace,
-                    answer_score=grade.score,
-                    level=question.level,
+                metacog_grade = asyncio.run(
+                    grade_metacognition(
+                        trace=trace,
+                        answer_score=grade.score,
+                        level=question.level,
+                    )
                 )
                 metacog = {
                     "effort_calibration": metacog_grade.effort_calibration,


### PR DESCRIPTION
## Symptom (observed in Simard daemon journal across L1-L12)
```
RuntimeWarning: coroutine 'grade_metacognition' was never awaited
✗ L1 failed: 'coroutine' object has no attribute 'effort_calibration'
✗ L2 failed: 'coroutine' object has no attribute 'effort_calibration'
... (repeats L1 through L12)
```

## Root cause
`grade_metacognition` is **async** (`metacognition_grader.py:280`) but `progressive_test_suite.run_single_level` (which is **sync**) called it without `asyncio.run`. The returned coroutine was never awaited, and the subsequent `.effort_calibration` access raised AttributeError.

## Fix
Wrap the call with `asyncio.run(...)`. Add the `asyncio` import.

## Discovery context
This was the next bug surfaced after #4471 (the asyncio.run-on-sync-method fix). With #4471 the underlying answer flow now produces the trace correctly, exposing this previously-shadowed downstream issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>