### PR TITLE
docs: clarify uvx vs uv tool install in CLAUDE_CODE_SETUP.md

### DIFF
--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -64,12 +64,19 @@ export AMPLIHACK_TRACE_LOGGING=true
 Then install amplihack:
 
 ```bash
-# Try without installing (temporary)
+# Option 1: Run via uvx (no permanent entry in PATH, but still installs amplihack's
+# agents/skills into your project — suitable for trying it out)
 uvx amplihack install
 
-# Or install permanently
+# Option 2: Install permanently (adds `amplihack` to your PATH via uv)
 uv tool install amplihack
 ```
+
+> **Note:** `uvx amplihack install` does run amplihack's `install` command (which
+> sets up agents and skills in the current directory). The difference from Option 2
+> is that the `amplihack` binary itself is **not added to your PATH** permanently —
+> you'd need to prefix every invocation with `uvx`. If you plan to use amplihack
+> regularly, Option 2 is recommended.
 
 ## Verify Everything Works
 


### PR DESCRIPTION
Fixes #4499

## What changed

The `# Try without installing (temporary)` comment on `uvx amplihack install` was misleading — it implies nothing is installed, but `uvx amplihack install` still runs amplihack's `install` command and sets up agents/skills in the current project directory.

## Changes

- Rewrote the two code comments in the **Permanent Setup** section to clearly label each as **Option 1** / **Option 2** with a description of what each does
- Added a `> Note` block below the code block explaining the real difference: `uvx` runs it without permanently adding `amplihack` to PATH, while `uv tool install` does

## Before / After

**Before:**
```bash
# Try without installing (temporary)
uvx amplihack install

# Or install permanently
uv tool install amplihack
```

**After:**
```bash
# Option 1: Run via uvx (no permanent entry in PATH, but still installs amplihack's
# agents/skills into your project — suitable for trying it out)
uvx amplihack install

# Option 2: Install permanently (adds `amplihack` to your PATH via uv)
uv tool install amplihack
```

> **Note:** `uvx amplihack install` does run amplihack's `install` command... The difference from Option 2 is that the `amplihack` binary itself is **not added to your PATH** permanently...