### PR TITLE
fix(ci): make broken-links label creation idempotent in docs-link-checker

### DIFF
--- a/.github/workflows/docs-link-checker.yml
+++ b/.github/workflows/docs-link-checker.yml
@@ -67,13 +67,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Ensure broken-links label exists
-          if ! gh label list --json name --jq '.[].name' | grep -q "^broken-links$"; then
-            gh label create "broken-links" \
-              --description "Issues related to broken links in documentation" \
-              --color "d73a4a"
-            echo "Created broken-links label"
-          fi
+          # Ensure broken-links label exists (idempotent).
+          # `gh label create --force` creates the label or updates it if it
+          # already exists, so this never fails the job. The previous
+          # `gh label list | grep` existence check was unreliable because
+          # `gh label list` defaults to 30 results, missing labels beyond
+          # that page and causing a spurious "label already exists" error.
+          gh label create "broken-links" \
+            --description "Issues related to broken links in documentation" \
+            --color "d73a4a" \
+            --force
 
           # Check if there's already an open issue for broken links
           EXISTING_ISSUE=$(gh issue list --label "broken-links" --state open --json number --jq '.[0].number // empty')


### PR DESCRIPTION
## Summary

The **Docs - Weekly Link Checker** (`.github/workflows/docs-link-checker.yml`) has failed on **every scheduled run** (last 3+: runs `27862934128`, `27459050037`, `27054653722`, all `failure`). The link check itself works — the job fails in the **"Create issue for broken links"** step.

### Root cause

```bash
if ! gh label list --json name --jq '.[].name' | grep -q "^broken-links$"; then
  gh label create "broken-links" ...
fi
```

`gh label list` returns only **30 labels by default**. This repo has **105 labels** and `broken-links` sorts at **position 42**, so the existence check never matches. The script therefore runs `gh label create`, and `gh` exits **1** with:

```
label with name "broken-links" already exists; use `--force` to update its color and description
##[error]Process completed with exit code 1.
```

(Logged verbatim in run `27862934128`.)

### Fix

Replace the unreliable `list + grep` existence check with an idempotent `gh label create --force`, which creates the label or updates it in place and always exits 0. Minimal, single-step change.

## Evidence

**Criterion 6 — Focused diff:** 1 file, +10/−7, no unrelated edits.

**Criterion 1 — Behavioral verification** (run live against `rysweet/amplihack`):

- *Bug reproduced* — old logic with default limit:
  ```
  $ if ! gh label list --json name --jq '.[].name' | grep -q "^broken-links$"; then echo MISSING; fi
  MISSING            # check fails → create attempted → gh exits 1
  ```
  Confirmed `broken-links` is at index 42 of 105 labels (beyond the 30-item page).
- *Fix verified* — new logic:
  ```
  $ gh label create "broken-links" --description "Issues related to broken links in documentation" --color "d73a4a" --force
  $ echo $?
  0                  # idempotent no-op update; label color/description unchanged
  ```

There is no `gadugi-test`/`qa-team` harness for GitHub Actions workflow YAML in this repo; correctness of the shell snippet was validated directly against the live GitHub API as shown above (bug → exit 1, fix → exit 0).

**Criterion 2 — Docs:** Changed surface is an internal CI workflow step; no user-facing documentation references this behavior. Internal-only.

**Criterion 3 — Quality audit cycles:**
1. *Seek* → identified failing step from `--log-failed`; *Validate* → reproduced the 30-item-limit miss; *Fix* → idempotent `--force`.
2. *Seek* → checked YAML validity (`yaml.safe_load` → OK); *Validate* → confirmed current label values match the `--force` payload (true no-op); *Fix* → none needed.
3. *Seek* → reviewed `set -e` semantics of the `run:` step; *Validate* → `--force` exits 0 whether or not the label exists, so no spurious job failure; *Fix* → none needed. Final cycle clean (0 critical/high, 0 medium).

**Criterion 4 — CI:** Will be verified green on this PR before merge.

## Scope

This PR fixes only the workflow job failure. The 708 broken links the checker reports are tracked separately via the issue the workflow itself files; fixing those links is out of scope for this CI-reliability change.

## CI status (final)

**Relevant gate green:** `Validate Code` (CI pre-commit over the full repo) → **pass**. Also passing: Atlas PR Impact Check, Check Version Bump, GitGuardian, Root Directory Hygiene, test-plugin, test-plugin-shell, pre_activation, activation, precompute.

The only red checks are **pre-existing and unrelated** to this one-line workflow change:
- **Check skill/agent drift** (Drift Detection) — chronic repo-wide failure; fails on *every* PR since April 2026 (verified across 10 unrelated branches). It flags drift in `.claude/skills` / `docs/claude/skills` mirror copies that this PR does not touch. Fixing it would require copying dozens of unrelated skill/agent files across mirror dirs — out of scope for this fix.
- **agent** (×2: `repo-guardian`, `dependabot-burner`) — fail at the Claude Code step with `authentication_failed` / `apiKeySource:none` due to an **expired `ANTHROPIC_API_KEY`** repo secret; they fail on any PR regardless of contents (tracked separately).

This PR's diff touches only `.github/workflows/docs-link-checker.yml`, so it cannot cause or fix those checks.
