### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #4597)

### DIFF
--- a/.claude/commands/ddd/1-plan.md
+++ b/.claude/commands/ddd/1-plan.md
@@ -2,7 +2,7 @@
 name: ddd:1-plan
 version: 1.0.0
 description: DDD Phase 1 - Planning and design
-argument-hint: [feature description or leave empty to use existing plan]
+argument-hint: "[feature description or leave empty to use existing plan]"
 allowed-tools: TodoWrite, Read, Grep, Glob, Task
 triggers:
   - "Start DDD workflow"

--- a/.claude/commands/ddd/2-docs.md
+++ b/.claude/commands/ddd/2-docs.md
@@ -2,7 +2,7 @@
 name: ddd:2-docs
 version: 1.0.0
 description: DDD Phase 2 - Update all non-code files
-argument-hint: [optional override instructions]
+argument-hint: "[optional override instructions]"
 allowed-tools: TodoWrite, Read, Write, Edit, MultiEdit, Grep, Glob, Task, Bash(git diff:*), Bash(git status:*), Bash(git add:*)
 triggers:
   - "Update DDD documentation"

--- a/.claude/commands/ddd/3-code-plan.md
+++ b/.claude/commands/ddd/3-code-plan.md
@@ -2,7 +2,7 @@
 name: ddd:3-code-plan
 version: 1.0.0
 description: DDD Phase 3 - Plan code implementation
-argument-hint: [optional override instructions]
+argument-hint: "[optional override instructions]"
 allowed-tools: TodoWrite, Read, Grep, Glob, Task, Bash(git diff:*), Bash(make check:*)
 triggers:
   - "Plan code implementation for DDD"

--- a/.claude/commands/ddd/4-code.md
+++ b/.claude/commands/ddd/4-code.md
@@ -2,7 +2,7 @@
 name: ddd:4-code
 version: 1.0.0
 description: DDD Phase 4 - Implement and verify code
-argument-hint: [optional feedback or instructions]
+argument-hint: "[optional feedback or instructions]"
 allowed-tools: TodoWrite, Read, Write, Edit, MultiEdit, Grep, Glob, Task, Bash(*)
 triggers:
   - "Implement DDD code"

--- a/.claude/commands/ddd/5-finish.md
+++ b/.claude/commands/ddd/5-finish.md
@@ -2,7 +2,7 @@
 name: ddd:5-finish
 version: 1.0.0
 description: DDD Phase 5 - Cleanup and finalize
-argument-hint: [optional instructions]
+argument-hint: "[optional instructions]"
 allowed-tools: TodoWrite, Read, Write, Bash(git:*), Bash(make check:*), Bash(rm:*), Glob, Task
 triggers:
   - "Finish DDD workflow"

--- a/.claude/skills/merge-ready/SKILL.md
+++ b/.claude/skills/merge-ready/SKILL.md
@@ -2,7 +2,7 @@
 name: merge-ready
 description: Checks whether a pull request satisfies the project's merge criteria and records the required evidence in the PR description. Use with `/merge-ready` before review or merge when QA-team scenarios, docs links, quality-audit convergence, CI status, and diff scope must be verified.
 disable-model-invocation: true
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 # Merge Ready

--- a/.claude/skills/skill-builder/examples.md
+++ b/.claude/skills/skill-builder/examples.md
@@ -87,7 +87,7 @@ Skill: _activates automatically_
 ```markdown
 ---
 description: Analyzes test coverage gaps and suggests improvements
-argument-hint: [target-path]
+argument-hint: "[target-path]"
 ---
 
 # Test Coverage Analyzer

--- a/amplifier-bundle/skills/skill-builder/examples.md
+++ b/amplifier-bundle/skills/skill-builder/examples.md
@@ -87,7 +87,7 @@ Skill: _activates automatically_
 ```markdown
 ---
 description: Analyzes test coverage gaps and suggests improvements
-argument-hint: [target-path]
+argument-hint: "[target-path]"
 ---
 
 # Test Coverage Analyzer

--- a/docs/claude/commands/ddd/1-plan.md
+++ b/docs/claude/commands/ddd/1-plan.md
@@ -2,7 +2,7 @@
 name: ddd:1-plan
 version: 1.0.0
 description: DDD Phase 1 - Planning and design
-argument-hint: [feature description or leave empty to use existing plan]
+argument-hint: "[feature description or leave empty to use existing plan]"
 allowed-tools: TodoWrite, Read, Grep, Glob, Task
 triggers:
   - "Start DDD workflow"

--- a/docs/claude/commands/ddd/2-docs.md
+++ b/docs/claude/commands/ddd/2-docs.md
@@ -2,7 +2,7 @@
 name: ddd:2-docs
 version: 1.0.0
 description: DDD Phase 2 - Update all non-code files
-argument-hint: [optional override instructions]
+argument-hint: "[optional override instructions]"
 allowed-tools: TodoWrite, Read, Write, Edit, MultiEdit, Grep, Glob, Task, Bash(git diff:*), Bash(git status:*), Bash(git add:*)
 triggers:
   - "Update DDD documentation"

--- a/docs/claude/commands/ddd/3-code-plan.md
+++ b/docs/claude/commands/ddd/3-code-plan.md
@@ -2,7 +2,7 @@
 name: ddd:3-code-plan
 version: 1.0.0
 description: DDD Phase 3 - Plan code implementation
-argument-hint: [optional override instructions]
+argument-hint: "[optional override instructions]"
 allowed-tools: TodoWrite, Read, Grep, Glob, Task, Bash(git diff:*), Bash(make check:*)
 triggers:
   - "Plan code implementation for DDD"

--- a/docs/claude/commands/ddd/4-code.md
+++ b/docs/claude/commands/ddd/4-code.md
@@ -2,7 +2,7 @@
 name: ddd:4-code
 version: 1.0.0
 description: DDD Phase 4 - Implement and verify code
-argument-hint: [optional feedback or instructions]
+argument-hint: "[optional feedback or instructions]"
 allowed-tools: TodoWrite, Read, Write, Edit, MultiEdit, Grep, Glob, Task, Bash(*)
 triggers:
   - "Implement DDD code"

--- a/docs/claude/commands/ddd/5-finish.md
+++ b/docs/claude/commands/ddd/5-finish.md
@@ -2,7 +2,7 @@
 name: ddd:5-finish
 version: 1.0.0
 description: DDD Phase 5 - Cleanup and finalize
-argument-hint: [optional instructions]
+argument-hint: "[optional instructions]"
 allowed-tools: TodoWrite, Read, Write, Bash(git:*), Bash(make check:*), Bash(rm:*), Glob, Task
 triggers:
   - "Finish DDD workflow"

--- a/docs/claude/skills/skill-builder/examples.md
+++ b/docs/claude/skills/skill-builder/examples.md
@@ -87,7 +87,7 @@ Skill: _activates automatically_
 ```markdown
 ---
 description: Analyzes test coverage gaps and suggests improvements
-argument-hint: [target-path]
+argument-hint: "[target-path]"
 ---
 
 # Test Coverage Analyzer


### PR DESCRIPTION
Closes #4597.

## Summary

Purely mechanical single-character transform to 14 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (14)

- `.claude/commands/ddd/1-plan.md`
- `docs/claude/commands/ddd/1-plan.md`
- `.claude/commands/ddd/2-docs.md`
- `.claude/commands/ddd/4-code.md`
- `.claude/skills/merge-ready/SKILL.md`
- `.claude/commands/ddd/5-finish.md`
- `docs/claude/commands/ddd/2-docs.md`
- `docs/claude/commands/ddd/4-code.md`
- `.claude/commands/ddd/3-code-plan.md`
- `docs/claude/commands/ddd/5-finish.md`
- `docs/claude/commands/ddd/3-code-plan.md`
- `.claude/skills/skill-builder/examples.md`
- `docs/claude/skills/skill-builder/examples.md`
- `amplifier-bundle/skills/skill-builder/examples.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
